### PR TITLE
add missing List::UtilsBy to list of new perl modules in UPGRADE/3.2.0

### DIFF
--- a/doc/UPGRADE
+++ b/doc/UPGRADE
@@ -118,6 +118,7 @@ Upgrade auf v3.2.0
   * GD
   * HTML::Restrict
   * Image::Info
+  * List::UtilsBy
 
   Wie immer bitte vor dem ersten Aufrufen einmal die Pakete überprüfen:
 


### PR DESCRIPTION
List::UtilsBy was introduced in 3.2.0, but UPGRADE didn't mention it and 'scripts/installation_check.pl' checks for it ...