### PR TITLE
Admin-Login ohne HTTPS nicht möglich

### DIFF
--- a/SL/Form.pm
+++ b/SL/Form.pm
@@ -426,7 +426,7 @@ sub create_http_response {
       $session_cookie = $cgi->cookie('-name'   => $main::auth->get_session_cookie_name(),
                                      '-value'  => $session_cookie_value,
                                      '-path'   => $uri->path,
-                                     '-secure' => $ENV{HTTPS});
+                                     '-secure' => ($ENV{HTTPS} and $ENV{HTTPS} !~ /off/i) );
     }
   }
 


### PR DESCRIPTION
**Problem:**
`$ENV{HTTPS}` kann auch den Wert "off" haben, dann wird trotzdem ein HTTPS-Cookie gesetzt. In SL/Form.pm->_get_request_uri wird bereits nicht nur geprüft, ob `$ENV{HTTPS}` gesetzt ist, sondern auch ob dort "on" steht, in ->create_http_response wird beim setzen des Session-Cookie nur auf `$ENV{HTTPS}` geprüft. So wird das Session-Cookie auch auf "secure" (nur HTTPS) gesetzt, wenn `$ENV{HTTPS} = "off"` ist.

**Hintergrund:**
Kivitendo installiert, aber beim Login kam immer nur "Ungültiges Passwort". Nach längerer Suche stieß ich auf das Cookie-Problem.