### PR TITLE
fehlendes BCC(global_bcc) in CreatePeriodicInvoices.pm(_email_invoice) hinzugefügt

### DIFF
--- a/SL/BackgroundJob/CreatePeriodicInvoices.pm
+++ b/SL/BackgroundJob/CreatePeriodicInvoices.pm
@@ -400,10 +400,13 @@ sub _email_invoice {
       );
     }
 
+    my $global_bcc = SL::DB::Default->get->global_bcc;
+
     for my $recipient (@recipients) {
       my $mail             = Mailer->new;
       $mail->{from}        = $data->{config}->email_sender || $::lx_office_conf{periodic_invoices}->{email_from};
       $mail->{to}          = $recipient;
+      $mail->{bcc}         = $global_bcc;
       $mail->{subject}     = $data->{config}->email_subject;
       $mail->{message}     = $data->{config}->email_body;
       $mail->{attachments} = [{


### PR DESCRIPTION
Auch mit `definierter global_bcc` werden `wiederkehrende Rechnungen` nicht an die `global_bcc` versendet. Dies funktioniert nur mit `normal manuell` generierten Rechnungen, Aufträgen ... etc.

Da `wiederkehrende Rechnungen` auch an den `global_bcc` versendet werden sollen, habe ich versucht diesen Mißstand zu beheben.

Ich hätte auch gerne das `Formular` für `wiederkehrende Rechnungen` angepasst, damit man dort _explizit_ einen `BCC-Empfänger` definieren kann. Aber dafür reichen meine kivitendo Kenntnisse derzeit noch nicht ganz aus. Auch sind meine perl Kenntnisse eher dürftig ...
Wäre schön, wenn Ihr mir Tips geben könntet, welche Dateien ich dafür anfassen müßte. Dann würde ich versuchen die `wiederkehrenden Rechnungen` dahingehend zu verbessern.

Danke und Gruß
 Chris