### PR TITLE
Neu angelegte Artikel in Shopware aktivieren.

### DIFF
--- a/SL/ShopConnector/Shopware.pm
+++ b/SL/ShopConnector/Shopware.pm
@@ -276,6 +276,7 @@ sub update_part {
                                                             customerGroupKey  => 'EK',
                                                             },
                                                           ],
+                                             active   => $shop_part->active,
                                              #attribute => { attr1  => $cvars->{CVARNAME}->{value}, } , #HowTo handle attributes
                                        },
                       supplier          => 'AR', # Is needed by shopware,


### PR DESCRIPTION
Scheint seit Shopware 5.2 notwendig zu sein, damit der Artikel im Frontend erscheint.
s. https://forum.shopware.com/discussion/39006/artikel-nach-import-ueber-rest-api-im-frontend-nicht-sichtbar