### PR TITLE
migrate a latex list with a lot of margins to a list with regular margins

### DIFF
--- a/SL/Template/LaTeX.pm
+++ b/SL/Template/LaTeX.pm
@@ -40,8 +40,8 @@ sub _format_text {
 
 my %html_replace = (
   '</p>'      => "\n\n",
-  '<ul>'      => "\\begin{itemize} ",
-  '</ul>'     => "\\end{itemize} ",
+  '<ul>'      => "\\begin{compactitem} ",
+  '</ul>'     => "\\end{compactitem} ",
   '<ol>'      => "\\begin{enumerate} ",
   '</ol>'     => "\\end{enumerate} ",
   '<li>'      => "\\item ",

--- a/SL/Template/Plugin/KiviLatex.pm
+++ b/SL/Template/Plugin/KiviLatex.pm
@@ -26,8 +26,8 @@ sub filter {
 
 my %html_replace = (
   '</p>'      => "\n\n",
-  '<ul>'      => "\\begin{itemize} ",
-  '</ul>'     => "\\end{itemize} ",
+  '<ul>'      => "\\begin{compactitem} ",
+  '</ul>'     => "\\end{compactitem} ",
   '<ol>'      => "\\begin{enumerate} ",
   '</ol>'     => "\\end{enumerate} ",
   '<li>'      => "\\item ",

--- a/templates/print/RB/inheaders.tex
+++ b/templates/print/RB/inheaders.tex
@@ -15,3 +15,4 @@
 \usepackage{xcolor,colortbl}
 \usepackage{lastpage}
 \usepackage{geometry}
+\usepackage{paralist}


### PR DESCRIPTION
Die normalen Listen in kivitendo haben sehr große Zeilenabstände. Schön sieht das nicht aus.

Die Migration von itemize zu compactitem löst das Problem. Allerdings muss dann in der Datei inheaders.tex das Paket `paralist` mit inkludiert werden.

Dabei sehe ich auch eine Schwierigkeit für bestehende Systeme, da diese alle das Paket `paralist` mit inkludieren müssten.