### PR TITLE
Behebt Einbettung der falschen Schriften bei älteren Debian/Ubuntu Installationen.

### DIFF
--- a/templates/print/marei/kiviletter.sty
+++ b/templates/print/marei/kiviletter.sty
@@ -1,5 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{kiviletter}[2019/10/10 Letter Layouts for Kivitendo]
+\ProvidesPackage{kiviletter}[2020/04/24 Letter Layouts for Kivitendo]
 
 \newif\if@kivi@infobox
 \DeclareOption{reffields}{\@kivi@infoboxfalse}
@@ -16,6 +16,7 @@
 \ifPDFTeX
 \RequirePackage[utf8]{inputenc}% Nur notwendig, wenn Basis älter als TL2018
 \RequirePackage[T1]{fontenc}
+\RequirePackage{lmodern}
 \else
 \RequirePackage{fontspec}
 \fi


### PR DESCRIPTION
Im Forum tauchte das Problem auf, dass bei Verwendung von pdflatex auf älteren Debian Instalationen Schwierigkeiten bei der Schrifteinbettung entstehen (https://forum.kivitendo.de/4919/beim-vorlagensatz-marei-sieht-das-schriftbild-unsch%C3%B6n-aus)

Das betrifft Installationen, die älter sind als TeX Live 2019 unter Verwendung von pdflatex, für neuerer Installationen bedeutet die Änderung keinerlei Nachteil.