### PR TITLE
quoten von Argumentlist in shellscript

### DIFF
--- a/doc/dokumentation.xml
+++ b/doc/dokumentation.xml
@@ -7376,7 +7376,7 @@ document_path = /var/local/kivi_documents
         export PATH=/usr/local/texlive/2020/bin/x86_64-linux:$PATH
         hash -r
 
-        exec pdflatex $@
+        exec pdflatex &quot;$@&quot;
         ------------------------------------------------------------
 
         4. In config/kivitendo.conf den Parameter »latex« auf den Pfad zu »run_pdflatex.sh« setzen

--- a/doc/html/ch03s10.html
+++ b/doc/html/ch03s10.html
@@ -17,7 +17,7 @@
         export PATH=/usr/local/texlive/2020/bin/x86_64-linux:$PATH
         hash -r
 
-        exec pdflatex $@
+        exec pdflatex &quot;$@&quot;
         ------------------------------------------------------------
 
         4. In config/kivitendo.conf den Parameter »latex« auf den Pfad zu »run_pdflatex.sh« setzen


### PR DESCRIPTION
Ansonsten werden Pfade mit Leerzeichen zu einzelnen Argumenten.