### PR TITLE
proof of concept: Formular-Gültigkeit beim Buchen von Verkaufsrechnungen

### DIFF
--- a/SL/BackgroundJob/ValidityTokenCleanup.pm
+++ b/SL/BackgroundJob/ValidityTokenCleanup.pm
@@ -1,0 +1,30 @@
+package SL::BackgroundJob::ValidityTokenCleanup;
+
+use strict;
+
+use parent qw(SL::BackgroundJob::Base);
+
+use SL::DB::ValidityToken;
+
+sub create_job {
+  $_[0]->create_standard_job('0 3 * * *'); # daily
+}
+
+sub run {
+  SL::DB::Manager::ValidityToken->cleanup;
+
+  return 1;
+}
+
+1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+SL::BackgroundJob::ValidityTokenCleanup - Background job for
+deleting all expired validity tokens
+
+=cut

--- a/SL/DB/Helper/ALL.pm
+++ b/SL/DB/Helper/ALL.pm
@@ -148,6 +148,7 @@ use SL::DB::Unit;
 use SL::DB::UnitsLanguage;
 use SL::DB::UserPreference;
 use SL::DB::VC;
+use SL::DB::ValidityToken;
 use SL::DB::Vendor;
 use SL::DB::Warehouse;
 

--- a/SL/DB/Helper/Mappings.pm
+++ b/SL/DB/Helper/Mappings.pm
@@ -226,6 +226,7 @@ my %kivitendo_package_names = (
   units                          => 'unit',
   units_language                 => 'units_language',
   user_preferences               => 'user_preference',
+  validity_tokens                => 'ValidityToken',
   vendor                         => 'vendor',
   warehouse                      => 'warehouse',
 );

--- a/SL/DB/Manager/ValidityToken.pm
+++ b/SL/DB/Manager/ValidityToken.pm
@@ -1,0 +1,35 @@
+package SL::DB::Manager::ValidityToken;
+
+use strict;
+
+use parent qw(SL::DB::Helper::Manager);
+
+sub object_class { 'SL::DB::ValidityToken' }
+
+use Carp;
+
+__PACKAGE__->make_manager_methods;
+
+sub cleanup {
+  my ($class) = @_;
+  $class->delete_all(where => [ valid_until => { lt => DateTime->now_local }]);
+}
+
+sub fetch_valid_token {
+  my ($class, %params) = @_;
+
+  croak "missing required parameter 'scope'" if !$params{scope};
+
+  return undef if !$params{token};
+
+  my $token_obj = $class->get_first(
+    where => [
+      scope       => $params{scope},
+      token       => $params{token},
+      valid_until => { ge => DateTime->now_local },
+    ]);
+
+  return $token_obj;
+}
+
+1;

--- a/SL/DB/MetaSetup/ValidityToken.pm
+++ b/SL/DB/MetaSetup/ValidityToken.pm
@@ -1,0 +1,26 @@
+# This file has been auto-generated. Do not modify it; it will be overwritten
+# by rose_auto_create_model.pl automatically.
+package SL::DB::ValidityToken;
+
+use strict;
+
+use parent qw(SL::DB::Object);
+
+__PACKAGE__->meta->table('validity_tokens');
+
+__PACKAGE__->meta->columns(
+  id          => { type => 'serial', not_null => 1 },
+  itime       => { type => 'timestamp', default => 'now()', not_null => 1 },
+  scope       => { type => 'text', not_null => 1 },
+  token       => { type => 'text', not_null => 1 },
+  valid_until => { type => 'timestamp', not_null => 1 },
+);
+
+__PACKAGE__->meta->primary_key_columns([ 'id' ]);
+
+__PACKAGE__->meta->unique_keys([ 'scope', 'token' ]);
+
+__PACKAGE__->meta->allow_inline_column_values(1);
+
+1;
+;

--- a/SL/DB/ValidityToken.pm
+++ b/SL/DB/ValidityToken.pm
@@ -1,0 +1,41 @@
+package SL::DB::ValidityToken;
+
+use strict;
+
+use Carp;
+use Digest::SHA qw(sha256_hex);
+use Time::HiRes qw(gettimeofday);
+
+use SL::DB::MetaSetup::ValidityToken;
+use SL::DB::Manager::ValidityToken;
+
+__PACKAGE__->meta->initialize;
+
+use constant SCOPE_SALES_INVOICE_POST => 'SalesInvoice::Post';
+
+sub create {
+  my ($class, %params) = @_;
+
+  croak "missing required parameter 'scope'" if !$params{scope};
+
+  my $token_obj = $class->new(
+    scope       => $params{scope},
+    valid_until => $params{valid_until} // DateTime->now_local->add(hours => 24),
+  );
+
+  while (1) {
+    my $token_value = join('-', gettimeofday(), $$, int(rand(1 << 63)));
+
+    $token_obj->token(sha256_hex($token_value));
+
+    last if eval {
+      $token_obj->save;
+      1;
+    };
+  }
+
+  return $token_obj;
+}
+
+
+1;

--- a/bin/mozilla/is.pl
+++ b/bin/mozilla/is.pl
@@ -52,6 +52,7 @@ use SL::DB::Customer;
 use SL::DB::Department;
 use SL::DB::Invoice;
 use SL::DB::PaymentTerm;
+use SL::DB::ValidityToken;
 
 require "bin/mozilla/common.pl";
 require "bin/mozilla/io.pl";
@@ -105,6 +106,9 @@ sub add {
 
   }
 
+  if (!$form->{form_validity_token}) {
+    $form->{form_validity_token} = SL::DB::ValidityToken->create(scope => SL::DB::ValidityToken::SCOPE_SALES_INVOICE_POST())->token;
+  }
 
   $form->{callback} = "$form->{script}?action=add&type=$form->{type}" unless $form->{callback};
 
@@ -1008,6 +1012,16 @@ sub post {
   $main::auth->assert('invoice_edit');
   $form->mtime_ischanged('ar');
 
+  my $validity_token;
+  if (!$form->{id}) {
+    $validity_token = SL::DB::Manager::ValidityToken->fetch_valid_token(
+      scope => SL::DB::ValidityToken::SCOPE_SALES_INVOICE_POST(),
+      token => $form->{form_validity_token},
+    );
+
+    $form->error($::locale->text('The form is not valid anymore.')) if !$validity_token;
+  }
+
   $form->{defaultcurrency} = $form->get_default_currency(\%myconfig);
   $form->isblank("invdate",  $locale->text('Invoice Date missing!'));
   $form->isblank("customer_id", $locale->text('Customer missing!'));
@@ -1135,6 +1149,9 @@ sub post {
       $form->error($locale->text('Cannot post invoice!'));
     }
   }
+
+  $validity_token->delete if $validity_token;
+  delete $form->{form_validity_token};
 
   if(!exists $form->{addition}) {
     $form->{snumbers}  =  'invnumber' .'_'. $form->{invnumber}; # ($form->{type} eq 'credit_note' ? 'cnnumber' : 'invnumber') .'_'. $form->{invnumber};

--- a/locale/de/all
+++ b/locale/de/all
@@ -3641,6 +3641,7 @@ $self->{texts} = {
   'The following transactions are concerned:' => 'Die folgenden Buchungen sind betroffen:',
   'The following users are a member of this group' => 'Die folgenden Benutzer sind Mitglieder dieser Gruppe',
   'The following users will have access to this client' => 'Die folgenden Benutzer werden auf diesen Mandanten Zugriff haben',
+  'The form is not valid anymore.' => 'Das Formular ist nicht mehr gültig.',
   'The formula needs the following syntax:<br>For regular article:<br>Variablename= Variable Unit;<br>Variablename2= Variable2 Unit2;<br>...<br>###<br>Variable + ( Variable2 / Variable )<br><b>Please be beware of the spaces in the formula</b><br>' => 'Die Formeln müssen in der folgenden Syntax eingegeben werden:<br>Bei normalen Artikeln:<br>Variablenname = Variable Einheit;<br>Variablenname2 = Variable2 Einheit2;<br>...<br>###<br>Variable + Variable2 * ( Variable - Variable2 )<br>Variablennamen und Einheiten dürfen nur aus alphanumerischen Zeichen bestehen.<br>Es muss jeweils die Gesamte Zeile eingegeben werden',
   'The greetings have been saved.' => 'Die Anreden wurden gespeichert',
   'The installation is currently locked.' => 'Die Installation ist momentan gesperrt.',

--- a/sql/Pg-upgrade2/validity_tokens.sql
+++ b/sql/Pg-upgrade2/validity_tokens.sql
@@ -1,0 +1,16 @@
+-- @tag: validity_tokens
+-- @description: Gültigkeits-Tokens z.B. für HTML-Formulare
+-- @depends: release_3_6_1
+CREATE TABLE validity_tokens (
+  id          SERIAL,
+  scope       TEXT      NOT NULL,
+  token       TEXT      NOT NULL,
+  itime       TIMESTAMP NOT NULL DEFAULT now(),
+  valid_until TIMESTAMP NOT NULL,
+
+  PRIMARY KEY (id),
+  UNIQUE (scope, token)
+);
+
+INSERT INTO background_jobs (type, package_name, cron_spec, next_run_at, active)
+VALUES ('interval', 'ValidityTokenCleanup', '0 3 * * *', now(), true);

--- a/templates/webpages/is/form_header.html
+++ b/templates/webpages/is/form_header.html
@@ -19,6 +19,9 @@
 <input type="hidden" name="follow_up_rowcount" id="follow_up_rowcount" value="1">
 <input type="hidden" name="lastmtime" id="lastmtime" value="[% HTML.escape(lastmtime) %]">
 <input type="hidden" name="already_printed_flag" id="already_printed_flag" value="0">
+[% IF !id %]
+[%   L.hidden_tag('form_validity_token', form_validity_token) %]
+[% END %]
 
 <h1>[% title %]</h1>
 


### PR DESCRIPTION
Ziel: verhindern, dass eine noch nicht gebuchte Rechnung durch
Verwendung des »Zurück«-Buttons im Browser mehrfach gebucht werden
kann.

Implementation: Beim Neuanlegen einer Rechnung wird ein einmaliges
Gültigkeitstoken mit einem Scope (»Verkaufsrechnung buchen«)
erzeugt. Dieses hat eine Laufzeit von 24h. Es wird als Hidden-Variable
im Formular mitgeschleift, sofern noch keine Datenbank-ID existiert,
die Rechnung also noch nicht gebucht wurde.

Wird die Rechnung gebucht, so wird zuerst überprüft, ob das vom
Browser mitgeschickte Token noch gültig ist:

1. ob es das Token mit demselben Scope in der Datenbank noch gibt
2. ob das Ablaufdatum des Tokens noch nicht erreicht ist

Falls ja, wird die Rechnung gebucht und das Token aus der Datenbank
und dem Formular entfernt. Es ist somit entwertet und kann nicht
erneut zum Buchen verwendet werden, da es bei der Prüfung oben Punkt 1
verletzt.

Falls nein, wird hingegen eine Fehlermeldung angezeigt, dass das
Formular nicht mehr gültig ist. Das kann man auch durch Verwenden von
Funktionen wie »Erneuern« nicht umgehen: das Fomular mit der
ungebuchten Rechnung ist jetzt »tot«.