### PR TITLE
fehlendes Escaping im check-Skript ergänzt

### DIFF
--- a/scripts/installation_check.pl
+++ b/scripts/installation_check.pl
@@ -164,7 +164,7 @@ sub check_latex {
   Your pdfx version is too old. You cannot use ZuGFeRD or modern (2018+)
   templates. Please consider using a more recent LaTeX environment.
   Verify with:
-  pdflatex --interaction=batchmode "\RequirePackage{pdfx}[2018/12/22]"
+  pdflatex --interaction=batchmode "\\RequirePackage{pdfx}[2018/12/22]"
 +------------------------------------------------------------------------------+
 EOL
 }


### PR DESCRIPTION
Behebt folgende Warnmeldung:

```
Unrecognized escape \R passed through at scripts/installation_check.pl line 163.
```