### PR TITLE
marei: eigene spaltentypen auch bei der Verarbeitung in PricingTabular verarbeiten

### DIFF
--- a/templates/print/marei/kiviletter.sty
+++ b/templates/print/marei/kiviletter.sty
@@ -345,7 +345,7 @@
         }
       }}
     \par
-    \l__kivi_Tabular_rowsep_tl
+    \tl_if_empty:NF \l__kivi_Tabular_rowsep_tl {\nointerlineskip\l__kivi_Tabular_rowsep_tl}
   }
   \endgroup
   \par

--- a/templates/print/marei/kiviletter.sty
+++ b/templates/print/marei/kiviletter.sty
@@ -305,7 +305,6 @@
 
 %%%
 
-
 \newcommand{\FakeTable}[1]{
   \par
   \seq_set_split:Nnn \l_kivi_PricingTable_seq {\tabularnewline} {#1}
@@ -332,18 +331,21 @@
           &\seq_item:Nn \l_kivi_columns_seq {####1}
         }
         \endtabular
+      }
         \seq_if_empty:NTF \g_kivi_extraDescription_seq
         {\par}
         {\par\nopagebreak
           \begingroup
           \setlength{\leftskip}{\dim_eval:n {\bool_if:NT \g__kivi_Tabular_rowcolor_bool {-\tabcolsep} +\l_kivi_tab_desc_leftskip_dim}}
           \setlength{\hsize}{\dim_eval:n {\l_kivi_tab_desc_dim+\leftskip}}
+          \setlength{\linewidth}{\hsize}
+          \addtolength{\leftmargini}{\l_kivi_tab_desc_leftskip_dim}
           \usekomafont{extraDescription}
           \seq_use:Nn \g_kivi_extraDescription_seq {\\}
           \par
           \endgroup
         }
-      }}
+    }
     \par
     \tl_if_empty:NF \l__kivi_Tabular_rowsep_tl {\nointerlineskip\l__kivi_Tabular_rowsep_tl}
   }

--- a/templates/print/marei/kiviletter.sty
+++ b/templates/print/marei/kiviletter.sty
@@ -171,7 +171,7 @@
 \dim_gset:Nn \g_kivi_tabcolsep_dim {.5\tabcolsep}
 \setlength\tabcolsep{.5\tabcolsep}
 
-\prg_new_conditional:Nnn \kivi_if_Price_col:n {T} {
+\prg_new_conditional:Nnn \kivi_if_Price_col:n {T, TF} {
   \prop_get:cnN {l_kivi_col_#1_prop} {colspec} \l_tmpa_tl
   \exp_args:NV \tl_if_eq:nnTF \l_tmpa_tl {Price}
   {\prg_return_true:}
@@ -204,7 +204,16 @@
             \dim_use:c {l_kivi_tab_##1_dim}+2\g_kivi_tabcolsep_dim
           }
         }
-        \tl_gput_right:Nn \g_kivi_Pricing_colspec_tl {K{\dim_use:c {l_kivi_tab_##1_dim}}}
+        \prop_if_in:cnTF {l_kivi_col_##1_prop} {colspec} {
+          \kivi_if_Price_col:nTF {##1} {
+             \tl_gput_right:Nn \g_kivi_Pricing_colspec_tl {K}
+          }{
+             \tl_gput_right:Nx \g_kivi_Pricing_colspec_tl {\prop_item:cn {l_kivi_col_##1_prop} {colspec}}
+          }
+          \tl_gput_right:Nn \g_kivi_Pricing_colspec_tl {{\dim_use:c {l_kivi_tab_##1_dim}}}
+         } {
+          \tl_gput_right:Nn \g_kivi_Pricing_colspec_tl {K{\dim_use:c {l_kivi_tab_##1_dim}}}
+         }
         \kivi_if_Price_col:nT {##1} {\tl_gput_right:Nn \g_kivi_Pricing_colspec_tl {<{\__kivi_tab_column_currency:}}}
       }
     }

--- a/templates/print/marei/kiviletter.sty
+++ b/templates/print/marei/kiviletter.sty
@@ -344,9 +344,11 @@
           \endgroup
         }
       }}
+    \par
+    \l__kivi_Tabular_rowsep_tl
   }
-  \endgroup\par
-  \l__kivi_Tabular_rowsep_tl
+  \endgroup
+  \par
 }
 
 


### PR DESCRIPTION
löst außerdem den Bug mit falschen einzügen auf der Linken seite von Listen innerhalb der `\ExtraDescription`.