### PR TITLE
LaTeX switch from `\n\n` to `\par` in replacements of user input

### DIFF
--- a/SL/Template/LaTeX.pm
+++ b/SL/Template/LaTeX.pm
@@ -41,7 +41,7 @@ sub _format_text {
 }
 
 my %html_replace = (
-  '</p>'      => "\n\n",
+  '</p>'      => "\\par\n",
   '<ul>'      => "\\begin{itemize} ",
   '</ul>'     => "\\end{itemize} ",
   '<ol>'      => "\\begin{enumerate} ",


### PR DESCRIPTION
wie mit @mbunkus besprochen hier die mini Anpassung bezüglich der Ersetzung. 