### PR TITLE
Xmlbill master

### DIFF
--- a/SL/Controller/ZUGFeRD.pm
+++ b/SL/Controller/ZUGFeRD.pm
@@ -1,10 +1,12 @@
 package SL::Controller::ZUGFeRD;
 use strict;
+use warnings;
 use parent qw(SL::Controller::Base);
 
 use SL::DB::RecordTemplate;
 use SL::Locale::String qw(t8);
 use SL::Helper::DateTime;
+use SL::XMLInvoice;
 use SL::VATIDNr;
 use SL::ZUGFeRD;
 
@@ -20,31 +22,49 @@ sub action_upload_zugferd {
   $self->render('zugferd/form', title => $::locale->text('Factur-X/ZUGFeRD import'));
 }
 
-sub action_import_zugferd {
-  my ($self, %params) = @_;
+sub find_vendor_by_taxnumber {
+  my $taxnumber = shift @_;
 
-  die t8("missing file for action import") unless $::form->{file};
-  die t8("can only parse a pdf file")      unless $::form->{file} =~ m/^%PDF/;
+  # 1.1 check if we a have a vendor with this tax number (vendor.taxnumber)
+  my $vendor = SL::DB::Manager::Vendor->find_by(
+    taxnumber => $taxnumber,
+    or    => [
+      obsolete => undef,
+      obsolete => 0,
+    ]);
 
-  my $info = SL::ZUGFeRD->extract_from_pdf($::form->{file});
+  if (!$vendor) {
+    # 1.2 If no vendor with the exact VAT ID number is found, the
+    # number might be stored slightly different in the database
+    # (e.g. with spaces breaking up groups of numbers). Iterate over
+    # all existing vendors with VAT ID numbers, normalize their
+    # representation and compare those.
 
-  if ($info->{result} != SL::ZUGFeRD::RES_OK()) {
-    # An error occurred; log message from parser:
-    $::lxdebug->message(LXDebug::DEBUG1(), "Could not extract ZUGFeRD data, error message: " . $info->{message});
-    die t8("Could not extract Factur-X/ZUGFeRD data, data and error message:") . $info->{message};
+    my $vendors = SL::DB::Manager::Vendor->get_all(
+      where => [
+        '!taxnumber' => undef,
+        '!taxnumber' => '',
+        or       => [
+          obsolete => undef,
+          obsolete => 0,
+        ],
+      ]);
+
+    foreach my $other_vendor (@{ $vendors }) {
+      next unless $other_vendor->taxnumber eq $taxnumber;
+
+      $vendor = $other_vendor;
+      last;
+    }
   }
-  # valid ZUGFeRD metadata
-  my $dom   = XML::LibXML->load_xml(string => $info->{invoice_xml});
+}
 
-  # 1. check if ZUGFeRD SellerTradeParty has a VAT-ID
-  my $ustid = $dom->findnodes('//ram:SellerTradeParty/ram:SpecifiedTaxRegistration')->string_value;
-  die t8("No VAT Info for this Factur-X/ZUGFeRD invoice," .
-         " please ask your vendor to add this for his Factur-X/ZUGFeRD data.") unless $ustid;
+sub find_vendor_by_ustid {
+  my $ustid = shift @_;
 
   $ustid = SL::VATIDNr->normalize($ustid);
 
   # 1.1 check if we a have a vendor with this VAT-ID (vendor.ustid)
-  my $vc     = $dom->findnodes('//ram:SellerTradeParty/ram:Name')->string_value;
   my $vendor = SL::DB::Manager::Vendor->find_by(
     ustid => $ustid,
     or    => [
@@ -77,72 +97,174 @@ sub action_import_zugferd {
     }
   }
 
-  die t8("Please add a valid VAT-ID for this vendor: #1", $vc) unless (ref $vendor eq 'SL::DB::Vendor');
+  return $vendor;
+}
 
-  # 2. check if we have a ap record template for this vendor (TODO only the oldest template is choosen)
-  my $template_ap = SL::DB::Manager::RecordTemplate->get_first(where => [vendor_id => $vendor->id]);
-  die t8("No AP Record Template for this vendor found, please add one") unless (ref $template_ap eq 'SL::DB::RecordTemplate');
+sub find_vendor {
+  my ($ustid, $taxnumber) = @_;
+  my $vendor;
+
+  if ( $ustid ) {
+    $vendor = find_vendor_by_ustid($ustid);
+  }
+
+  if (ref $vendor eq 'SL::DB::Vendor') { return $vendor; }
+
+  if ( $taxnumber ) {
+    $vendor = find_vendor_by_taxnumber($taxnumber);
+  }
+
+  if (ref $vendor eq 'SL::DB::Vendor') { return $vendor; }
+
+  return undef;
+}
+
+sub action_import_zugferd {
+  my ($self, %params) = @_;
+
+  my %res;          # result data structure returned by SL::ZUGFeRD->extract_from_{pdf,xml}()
+  my $parser;       # SL::XMLInvoice object created by SL::ZUGFeRD->extract_from_{pdf,xml}()
+  my $dom;          # DOM object for parsed XML data
+  my $template_ap;  # SL::DB::RecordTemplate object
+  my $vendor;       # SL::DB::Vendor object
+
+  my $ibanmessage;  # Message to display if vendor's database and invoice IBANs don't match up
+
+  die t8("missing file for action import") unless $::form->{file};
+  die t8("can only parse a pdf or xml file")      unless $::form->{file} =~ m/^%PDF|<\?xml/;
+
+  if ( $::form->{file} =~ m/^%PDF/ ) {
+    %res = %{SL::ZUGFeRD->extract_from_pdf($::form->{file})}
+  } else {
+    %res = %{SL::ZUGFeRD->extract_from_xml($::form->{file})};
+  }
+
+  if ($res{'result'} != SL::ZUGFeRD::RES_OK()) {
+    # An error occurred; log message from parser:
+    $::lxdebug->message(LXDebug::DEBUG1(), "Could not extract ZUGFeRD data, error message: " . $res{'message'});
+    die(t8("Could not extract Factur-X/ZUGFeRD data, data and error message:") . " $res{'message'}");
+  }
+
+  $parser = $res{'invoice_xml'};
+
+  # Shouldn't be neccessary with SL::XMLInvoice doing the heavy lifting, but
+  # let's grab it, just in case.
+  $dom  = $parser->{dom};
+
+  my %metadata = %{$parser->metadata};
+  my @items = @{$parser->items};
+
+  my $iban = $metadata{'iban'};
+  my $invnumber = $metadata{'invnumber'};
+
+  if ( ! ($metadata{'ustid'} or $metadata{'taxnumber'}) ) {
+    die t8("Cannot process this invoice: neither VAT ID nor tax ID present.");
+    }
+
+  $vendor = find_vendor($metadata{'ustid'}, $metadata{'taxnumber'});
+
+  die t8("Please add a valid VAT ID or tax number for this vendor: #1", $metadata{'vendor_name'}) unless $vendor;
 
 
-  # 3. parse the zugferd data and fill the ap record template
-  # -> no need to check sign (credit notes will be negative) just record thei ZUGFeRD type in ap.notes
-  # -> check direct debit (defaults to no)
-  # -> set amount (net amount) and unset taxincluded
-  #    (template and user cares for tax and if there is more than one booking accno)
-  # -> date (can be empty)
-  # -> duedate (may be empty)
-  # -> compare record iban and generate a warning if this differs from vendor's master data iban
-  my $total     = $dom->findnodes('//ram:SpecifiedTradeSettlementHeaderMonetarySummation' .
-                                  '/ram:TaxBasisTotalAmount')->string_value;
+  # Create a record template for this imported invoice
+  $template_ap = SL::DB::RecordTemplate->new(
+      vendor_id=>$vendor->id,
+  );
 
-  my $invnumber = $dom->findnodes('//rsm:ExchangedDocument/ram:ID')->string_value;
+  # Check IBAN specified on bill matches the one we've got in
+  # the database for this vendor.
+  $ibanmessage = $iban ne $vendor->iban ? "Record IBAN $iban doesn't match vendor IBAN " . $vendor->iban : $iban if $iban;
+
+  # Use invoice creation date as due date if there's no due date
+  $metadata{'duedate'} = $metadata{'transdate'} unless defined $metadata{'duedate'};
 
   # parse dates to kivi if set/valid
-  my ($transdate, $duedate, $dt_to_kivi, $due_dt_to_kivi);
-  $transdate = $dom->findnodes('//ram:IssueDateTime')->string_value;
-  $duedate   = $dom->findnodes('//ram:DueDateDateTime')->string_value;
-  $transdate =~ s/^\s+|\s+$//g;
-  $duedate   =~ s/^\s+|\s+$//g;
+  foreach my $key ( qw(transdate duedate) ) {
+    next unless defined $metadata{$key};
+    $metadata{$key} =~ s/^\s+|\s+$//g;
 
-  if ($transdate =~ /^[0-9]{8}$/) {
-    $dt_to_kivi = DateTime->new(year  => substr($transdate,0,4),
-                                month => substr ($transdate,4,2),
-                                day   => substr($transdate,6,2))->to_kivitendo;
-  }
-  if ($duedate =~ /^[0-9]{8}$/) {
-    $due_dt_to_kivi = DateTime->new(year  => substr($duedate,0,4),
-                                    month => substr ($duedate,4,2),
-                                    day   => substr($duedate,6,2))->to_kivitendo;
+    if ($metadata{$key} =~ /^([0-9]{4})-?([0-9]{2})-?([0-9]{2})$/) {
+    $metadata{$key} = DateTime->new(year  => $1,
+                                    month => $2,
+                                    day   => $3)->to_kivitendo;
+    }
   }
 
-  my $type = $dom->findnodes('//rsm:ExchangedDocument/ram:TypeCode')->string_value;
+  # Try to fill in AP account to book against
+  my $ap_chart_id = $::instance_conf->get_ap_chart_id;
 
-  my $dd   = $dom->findnodes('//ram:ApplicableHeaderTradeSettlement' .
-                             '/ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode')->string_value;
-  my $direct_debit = $dd == 59 ? 1 : 0;
+  unless ( defined $ap_chart_id ) {
+    # If no default account is configured, just use the first AP account found.
+    my $ap_chart = SL::DB::Manager::Chart->get_all(
+      where   => [ link => 'AP' ],
+      sort_by => [ 'accno' ],
+    );
+    $ap_chart_id = ${$ap_chart}[0]->id;
+  }
 
-  my $iban = $dom->findnodes('//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans' .
-                             '/ram:PayeePartyCreditorFinancialAccount/ram:IBANID')->string_value;
-  my $ibanmessage;
-  $ibanmessage = $iban ne $vendor->iban ? "Record IBAN $iban doesn't match vendor IBAN " . $vendor->iban : $iban if $iban;
+  my $currency = SL::DB::Manager::Currency->find_by(
+    name => $metadata{'currency'},
+    );
+
+  $template_ap->assign_attributes(
+    template_name       => "Faktur-X/ZUGFeRD/XRechnung Import $vendor->name, $invnumber",
+    template_type       => 'ap_transaction',
+    direct_debit        => $metadata{'direct_debit'},
+    notes               => "Faktur-X/ZUGFeRD/XRechnung Import. Type: $metadata{'type'}\nIBAN: " . $ibanmessage,
+    taxincluded         => 0,
+    currency_id         => $currency->id,
+    ar_ap_chart_id      => $ap_chart_id,
+    );
+
+  $template_ap->save;
+
+  my $default_ap_amount_chart = SL::DB::Manager::Chart->find_by(charttype => 'A');
+
+  foreach my $i ( @items )
+    {
+    my %item = %{$i};
+
+    my $net_total = $item{'subtotal'};
+    my $desc = $item{'description'};
+    my $tax_rate = $item{'tax_rate'} / 100; # XML data is usually in percent
+
+    my $taxes = SL::DB::Manager::Tax->get_all(
+      where   => [ chart_categories => { like => '%' . $default_ap_amount_chart->category . '%' },
+                   rate => $tax_rate,
+                 ],
+    );
+
+    # If we really can't find any tax definition (a simple rounding error may
+    # be sufficient for that to happen), grab the first tax fitting the default
+    # category, just like the AP form would do it for manual entry.
+    if ( scalar @{$taxes} == 0 ) {
+      $taxes = SL::D::ManagerTax->get_all(
+        where   => [ chart_categories => { like => '%' . $default_ap_amount_chart->category . '%' } ],
+      );
+    }
+
+    my $tax = ${$taxes}[0];
+
+    my $item_obj = SL::DB::RecordTemplateItem
+      ->new(amount1 => $net_total,
+            record_template_id => $template_ap->id,
+            chart_id      => $default_ap_amount_chart->id,
+            tax_id      => $tax->id,
+        );
+    $item_obj->save;
+    }
 
   my $url = $self->url_for(
     controller                           => 'ap.pl',
     action                               => 'load_record_template',
     id                                   => $template_ap->id,
-    'form_defaults.amount_1'             => $::form->format_amount(\%::myconfig, $total, 2),
-    'form_defaults.transdate'            => $dt_to_kivi,
-    'form_defaults.invnumber'            => $invnumber,
-    'form_defaults.duedate'              => $due_dt_to_kivi,
     'form_defaults.no_payment_bookings'  => 0,
-    'form_defaults.paid_1_suggestion'    => $::form->format_amount(\%::myconfig, $total, 2),
-    'form_defaults.notes'                => "ZUGFeRD Import. Type: $type\nIBAN: " . $ibanmessage,
-    'form_defaults.taxincluded'          => 0,
-    'form_defaults.direct_debit'          => $direct_debit,
+    'form_defaults.invnumber'            => $invnumber,
+    'form_defaults.duedate'              => $metadata{'duedate'},
+    'form_defaults.transdate'            => $metadata{'transdate'},
   );
 
   $self->redirect_to($url);
-
 }
 
 sub check_auth {
@@ -172,8 +294,7 @@ __END__
 
 =head1 NAME
 
-SL::Controller::ZUGFeRD
-Controller for importing ZUGFeRD pdf files to kivitendo
+SL::Controller::ZUGFeRD - Controller for importing ZUGFeRD PDF files or XML invoices to kivitendo
 
 =head1 FUNCTIONS
 
@@ -183,43 +304,81 @@ Controller for importing ZUGFeRD pdf files to kivitendo
 
 Creates a web from with a single upload dialog.
 
-=item C<action_import_zugferd $pdf>
+=item C<action_import_zugferd $file>
 
-Expects a single pdf with ZUGFeRD 2.0 metadata.
-Checks if the param <C$pdf> is set and a valid pdf file.
-Calls helper functions to validate and extract the ZUGFeRD data.
-Needs a valid VAT ID (EU) for this vendor and
-expects one ap template for this vendor in kivitendo.
+Expects a single PDF with ZUGFeRD, Factur-X or XRechnung
+metadata. Alternatively, it can also process said data as a
+standalone XML file.
 
-Parses some basic ZUGFeRD data (invnumber, total net amount,
-transdate, duedate, vendor VAT ID, IBAN) and uses the first
-found ap template for this vendor to fill this template with
-ZUGFeRD data.
-If the vendor's master data contain a IBAN and the
-ZUGFeRD record has a IBAN also these values will be compared.
-If they  don't match a warning will be writte in ap.notes.
-Furthermore the ZUGFeRD type code will be written to ap.notes.
-No callback implemented.
+Checks if the param <C$pdf> is set and a valid PDF or XML
+file. Calls helper functions to validate and extract the
+ZUGFeRD/Factur-X/XRechnung data. The invoice needs to have a
+valid VAT ID (EU) or tax number (Germany) and a vendor with
+the same VAT ID or tax number enrolled in Kivitendo.
+
+It parses some basic ZUGFeRD data (invnumber, total net amount,
+transdate, duedate, vendor VAT ID, IBAN, etc.) and also
+extracts the invoice's items.
+
+If the invoice has a IBAN also, it will be be compared to the
+IBAN saved for the vendor (if any). If they  don't match a
+warning will be writte in ap.notes. Furthermore the ZUGFeRD
+type code will be written to ap.notes. No callback
+implemented.
 
 =back
 
-=head1 TODO and CAVEAT
+=head1 CAVEAT
 
-This is just a very basic Parser for ZUGFeRD data.
-We assume that the ZUGFeRD generator is a company with a
-valid European VAT ID. Furthermore this vendor needs only
-one and just noe ap template (the first match will be used).
+This is just a very basic Parser for ZUGFeRD/Factur-X/XRechnung invoices.
+We assume that the invoice's creator is a company with a valid
+European VAT ID or German tax number and enrolled in
+Kivitendo. Currently, implementation is a bit hacky because
+invoice import uses AP record templates as a vessel for
+generating the AP record form with the imported data filled
+in.
 
-The ZUGFeRD data should also be extracted in the helper package
-and maybe a model should be used for this.
-The user should set one ap template as a default for ZUGFeRD.
-The ZUGFeRD pdf should be written to WebDAV or DMS.
+=head1 TODO
+
+This implementation could be improved as follows:
+
+=over 4
+
+=item Direct creation of the filled in AP record form
+
+Creating an AP record template in the database is not
+very elegant, since it will spam the database with record
+templates that become redundant once the invoice has been
+booked. It would be preferable to fill in the form directly.
+
+=item Automatic upload of invoice
+
+Right now, one has to use the "Book and upload" button to
+upload the raw invoice document to WebDAV or DMS and attach it
+to the invoice. This should be a simple matter of setting a
+check box when uploading.
+
+=item Handling of vendor invoices
+
+There is no reason this functionality could not be used to
+import vendor invoices as well. Since these tend to be very
+lengthy, the ability to import them would be very beneficial.
+
+=item Automatic handling of payment purpose
+
 If the ZUGFeRD data has a payment purpose set, this should
 be the default for the SEPA-XML export.
 
+=back
 
-=head1 AUTHOR
+=head1 AUTHORS
 
-Jan Büren E<lt>jan@kivitendo-premium.deE<gt>,
+=over 4
+
+=item Jan Büren E<lt>jan@kivitendo-premium.deE<gt>,
+
+=item Johannes Graßler E<lt>info@computer-grassler.deE<gt>,
+
+=back
 
 =cut

--- a/SL/XMLInvoice.pm
+++ b/SL/XMLInvoice.pm
@@ -1,0 +1,326 @@
+package SL::XMLInvoice;
+
+=head1 NAME
+
+SL::XMLInvoice - Top level factory class for XML Invoice parsers.
+
+=head1 DESCRIPTION
+
+C<SL::XMLInvoice> is an abstraction layer allowing the application to pass any
+supported XML invoice document for parsing, with C<SL::XMLInvoice> handling all
+details from there: depending on its document type declaration, this class will
+pick and instatiate the appropriate child class for parsing the document and
+return an object exposing its data with the standardized structure outlined
+below.
+
+=head1 SYNOPSIS
+
+  # $xml_data contains an XML document as flat scalar
+  my $invoice_parser = SL::XMLInvoice->new($xml_data);
+
+  # %metadata is a hash of document level metadata items
+  my %metadata = %{$invoice_parser->metadata};
+
+  # @items is an array of hashes, each representing a line
+  # item on the bill
+  my @items = @{$invoice_parser->items};
+                                                        
+=cut
+
+use strict;
+use warnings;
+
+use XML::LibXML;
+
+=head1 ATTRIBUTES
+
+=over 4
+
+=item dom
+
+A XML::LibXML document object model (DOM) object created from the XML data supplied.
+
+=item message
+
+Will contain a detailed error message if the C<result> attribute is anything
+other than C<SL::XMLInvoice::RES_OK>.
+
+=item result
+
+A status field indicating whether the supplied XML data could be parsed. It
+can take the following values:
+
+=item SL::XMLInvoice::RES_OK
+
+File has been parsed successfully.
+
+=item SL::XMLInvoice::RES_XML_PARSING FAILED
+
+Parsing the file failed.
+
+=item SL::XMLInvoice::RES_UNKNOWN_ROOT_NODE_TYPE
+
+The root node is of an unknown type. Currently, C<rsm:CrossIndustryInvoice> and
+C<ubl:Invoice> are supported.
+
+=back
+
+=cut
+
+use constant RES_OK                                  => 0;
+use constant RES_XML_PARSING_FAILED                  => 1;
+use constant RES_UNKNOWN_ROOT_NODE_TYPE              => 2;
+
+=head1 METHODS
+
+=head2 Data structure definition methods (only in C<SL::XMLInvoice>)
+
+These methods are only implemented in C<SL::XMLInvoice> itself and define the
+data structures to be exposed by any child classes.
+
+=over 4 
+
+=item data_keys()
+
+Returns all keys the hash returned by any child's C<metadata()> method must
+contain. If you add keys to this list, you need to add them to all classes
+inheriting from C<SL::XMLInvoice> as well. An application may use this method
+to discover the metadata keys guaranteed to be present.
+
+=cut
+
+sub data_keys  {
+  my @keys = (
+    'currency',      # The bill's currency, such as "EUR"
+    'direct_debit',  # Boolean: whether the bill will get paid by direct debit (1) or not (0)
+    'duedate',       # The bill's due date in YYYY-MM-DD format.
+    'gross_total',   # The invoice's sum total with tax included
+    'iban',          # The creditor's IBAN
+    'invnumber',     # The invoice's number
+    'net_total',     # The invoice's sum total without tax
+    'taxnumber',     # The creditor's tax number (Steuernummer in Germany). May be present if
+                     # there is no VAT ID (USTiD in Germany).
+    'transdate',     # The date the invoice was issued in YYYY-MM-DD format.
+    'type',          # Numeric invoice type code, e.g. 380
+    'ustid',         # The creditor's UStID.
+    'vendor_name',   # The vendor's company name
+  );
+  return \@keys;
+}
+
+=item item_keys()
+
+Returns all keys the item hashes returned by any child's C<items()> method must
+contain. If you add keys to this list, you need to add them to all classes
+inheriting from C<SL::XMLInvoice> as well. An application may use this method
+to discover the metadata keys guaranteed to be present.
+
+=back
+
+=cut
+
+sub item_keys  {
+  my @keys = (
+    'currency',
+    'description',
+    'price',
+    'quantity',
+    'subtotal',
+    'tax_rate',
+    'tax_scheme',
+    'vendor_partno',
+  );
+  return \@keys;
+}
+
+=head2 User/application facing methods
+
+Any class inheriting from C<SL::XMLInvoice> must implement the following
+methods. To ensure this happens, C<SL::XMLInvoice> contains stub functions that
+raise an exception if a child class does not override them.
+
+=over 4
+
+=item new($xml_data)
+
+Constructor for C<SL::XMLInvoice>. This method takes a scalar containing the
+entire XML document to be parsed as a flat string as its sole argument. It will
+instantiate the appropriate child class to parse the XML document in question,
+call its C<parse_xml> method and return the C<SL::XMLInvoice> child object it
+instantiated. From that point on, the structured data retrieved from the XML
+document will be available through the object's C<metadata> and C<items()>
+methods.
+
+=item metadata()
+
+This method returns a hash of document level metadata, such as the invoice
+number, the total, or the the issuance date. Its keys are the keys returned by
+the C<(data_keys()> method. Its values are plain scalars containing strings or
+C<undef> for any data items not present or empty in the XML document.
+
+=cut
+
+sub metadata {
+  my $self = shift;
+  die "Children of $self must implement a metadata() method returning the bill's metadata as a hash.";
+  }
+
+=item items()
+
+This method returns an array of hashes containing line item metadata, such as
+the quantity, price for one unit, or subtotal. These hashes' keys are the keys
+returned by the C<(item_keys()> method. Its values are plain scalars containing
+strings or C<undef> for any data items not present or empty in the XML
+document.
+
+=cut
+
+sub items {
+  my $self = shift;
+  die "Children of $self must implement a item() method returning the bill's items as a hash.";
+  }
+
+=item parse_xml()
+
+This method is only implemented in child classes of C<SL::XMLInvoice> and is
+called by the C<SL::XMLInvoice> constructor once the appropriate child class has been
+determined and instantiated. It uses C<$self->{dom}>, an C<XML::LibXML>
+instance to iterate through the XML document to parse. That XML document is
+created by the C<SL::XMLInvoice> constructor.
+
+=back
+
+=cut
+
+sub parse_xml {
+  my $self = shift;
+  die "Children of $self must implement a parse_xml() method.";
+  }
+
+=head2 Internal methods
+
+These methods' purpose is child classs selection and making sure child classes
+implent the interface promised by C<SL::XMLInvoice>. You can safely ignore them
+if you don't plan on implementing any child classes.
+
+
+=item _document_nodenames()
+
+This method is implemented in C<SL::XMLInvoice> only and returns a hash mapping
+XML document root node name to a child class implementing a parser for it. If
+you add any child classes for new XML document types you need to add them to
+this hash and add a use statement to make it available from C<SL::XMLInvoice>.
+
+=cut
+
+use SL::XMLInvoice::UBL;
+use SL::XMLInvoice::CrossIndustryInvoice;
+
+sub _document_nodenames {
+  return { 
+    'rsm:CrossIndustryInvoice' => 'SL::XMLInvoice::CrossIndustryInvoice',
+    'ubl:Invoice' => 'SL::XMLInvoice::UBL',
+  };
+}
+
+=item _data_keys()
+
+Returns a list of all keys present in the hash returned by the class'
+C<metadata()> method. Must be implemented in all classes inheriting from
+C<SL::XMLInvoice> This list must contain the same keys as the list returned by
+C<data_keys>. Omitting this method from a child class will cause an exception.
+
+=cut
+
+sub _data_keys {
+  my $self = shift;
+  die "Children of $self must implement a _data_keys() method returning the keys an invoice item hash will contain.";
+  }
+
+=item _item_keys()
+
+Returns a list of all keys present in the hashes returned by the class'
+C<items()> method. Must be implemented in all classes inheriting from
+C<SL::XMLInvoice> This list must contain the same keys as the list returned by
+C<item_keys>. Omitting this method from a child class will cause an exception.
+
+=head1 AUTHOR
+
+  Johannes Grassler <info@computer-grassler.de>
+
+=cut
+
+sub _item_keys {
+  my $self = shift;
+  die "Children of $self must implement a _item_keys() method returning the keys an invoice item hash will contain.";
+  }
+
+
+sub new
+  {
+  my ($self, $xml_data) = @_;
+  my $type = undef;
+  $self = {};
+
+  bless $self;
+
+  $self->{message} = '';
+  $self->{dom} = eval { XML::LibXML->load_xml(string => $xml_data) };
+
+  if ( ! $self->{dom} ) {
+    $self->{message} = $::locale->text("Parsing the XML data failed: $xml_data");
+    $self->{result} = RES_XML_PARSING_FAILED;
+    return $self;
+    }
+
+  # Determine parser class to use
+  my $document_nodename = $self->{dom}->documentElement->nodeName;
+  if ( ${$self->_document_nodenames}{$document_nodename} ) {
+    $type = ${$self->_document_nodenames}{$document_nodename}
+    }
+
+  unless ( $type ) {
+    $self->{result} = RES_UNKNOWN_ROOT_NODE_TYPE;
+    my $node_types = keys %{ $self->_document_nodenames };
+    $self->{message} =  t8("Could not parse XML Invoice: unknown root node name (#1) (supported: (#2))",
+                           $node_types,
+                           $document_nodename);
+    return $self;
+    }
+
+  bless $self, $type;
+
+  # Implementation sanity check for child classes: make sure they are aware of
+  # the keys the hash returned by their metadata() method must contain.
+  my @missing_data_keys = ();
+  foreach my $data_key ( @{$self->data_keys} )
+    {
+    unless ( ${$self->_data_keys}{$data_key}) { push @missing_data_keys, $data_key; }
+    }
+  if ( scalar(@missing_data_keys) > 0 ) {
+    die "Incomplete implementation: the following metadata keys appear to be missing from $type: " . join(", ", @missing_data_keys);
+  }
+
+  # Implementation sanity check for child classes: make sure they are aware of
+  # the keys the hashes returned by their items() method must contain.
+  my @missing_item_keys = ();
+  foreach my $item_key ( @{$self->item_keys} )
+    {
+    unless ( ${$self->_item_keys}{$item_key}) { push @missing_item_keys, $item_key; }
+    }
+  if ( scalar(@missing_item_keys) > 0 ) {
+    die "Incomplete implementation: the following item keys appear to be missing from $type: " . join(", ", @missing_item_keys);
+  }
+
+  $self->parse_xml;
+
+  # Ensure these methods are implemented in the child class
+  $self->metadata;
+  $self->items;
+
+  $self->{result} = RES_OK;
+  return $self;
+  }
+
+1;
+

--- a/SL/XMLInvoice/CrossIndustryInvoice.pm
+++ b/SL/XMLInvoice/CrossIndustryInvoice.pm
@@ -1,0 +1,178 @@
+package SL::XMLInvoice::CrossIndustryInvoice;
+use parent qw(SL::XMLInvoice);
+
+=head1 NAME
+
+SL::XMLInvoice::FakturX - XML parser for UN/CEFACT Cross Industry Invoice
+
+=head1 DESCRIPTION
+
+C<SL::XMLInvoice::CrossIndustryInvoice> parses XML invoices in UN/CEFACT Cross
+Industry Invoice format and makes their data available through the interface
+defined by C<SL::XMLInvoice>. Refer to L<SL::XMLInvoice> for a detailed
+description of that interface.
+
+See L<https://unece.org/trade/uncefact/xml-schemas> for that format's
+specification.
+
+=head1 OPERATION
+
+This module is fairly simple. It keeps two hashes of XPath statements exposed
+by methods:
+
+=over 4
+
+=item scalar_xpaths()
+
+This hash is keyed by the keywords C<data_keys> mandates. Values are XPath
+statements specifying the location of this field in the invoice XML document.
+
+=item item_xpaths()
+
+This hash is keyed by the keywords C<item_keys> mandates. Values are XPath
+statements specifying the location of this field inside a line item.
+
+=back
+
+When invoked by the C<SL::XMLInvoice> constructor, C<parse_xml()> will first
+use the XPath statements from the C<scalar_xpaths()> hash to populate the hash
+returned by the C<metadata()> method.
+
+After that, it will use the XPath statements from the C<scalar_xpaths()> hash
+to iterate over the invoice's line items and populate the array of hashes
+returned by the C<items()> method.
+
+=head1 AUTHOR
+
+  Johannes Grassler <info@computer-grassler.de>
+
+=cut
+
+use strict;
+use constant ITEMS_XPATH => '//ram:IncludedSupplyChainTradeLineItem';
+
+# XML XPath expressions for global metadata
+sub scalar_xpaths {
+  return {
+    currency => '//ram:InvoiceCurrencyCode',
+    direct_debit => '//ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode',
+    duedate => '//ram:DueDateDateTime/udt:DateTimeString',
+    gross_total => '//ram:DuePayableAmount',
+    iban => '//ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount/ram:IBANID',
+    invnumber => '//rsm:ExchangedDocument/ram:ID',
+    net_total => '//ram:SpecifiedTradeSettlementHeaderMonetarySummation' . '//ram:TaxBasisTotalAmount',
+    transdate => '//ram:IssueDateTime/udt:DateTimeString',
+    taxnumber => '//ram:SellerTradeParty/ram:SpecifiedTaxRegistration/ram:ID[@schemeID="FC"]',
+    type => '//rsm:ExchangedDocument/ram:TypeCode',
+    ustid => '//ram:SellerTradeParty/ram:SpecifiedTaxRegistration/ram:ID[@schemeID="VA"]',
+    vendor_name => '//ram:SellerTradeParty/ram:Name',
+  };
+}
+
+sub item_xpaths {
+  return {
+    'currency' => undef, # Only global currency in CrossIndustryInvoice
+    'price' => './ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice',
+    'description' => './ram:SpecifiedTradeProduct/ram:Name',
+    'quantity' => './ram:SpecifiedLineTradeDelivery/ram:BilledQuantity',
+    'subtotal' => './ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount',
+    'tax_rate' => './ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent',
+    'tax_scheme' => './ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:TypeCode',
+    'vendor_partno' => './ram:SpecifiedTradeProduct/ram:SellerAssignedID',
+  };
+}
+
+
+# Metadata accessor method
+sub metadata {
+  my $self = shift;
+  return $self->{_metadata};
+}
+
+# Item list accessor method
+sub items {
+  my $self = shift;
+  return $self->{_items};
+}
+
+# Data keys we return
+sub _data_keys {
+  my $self = shift;
+  my %keys;
+
+  map { $keys{$_} = 1; } keys %{$self->scalar_xpaths};
+
+  return \%keys;
+}
+
+# Item keys we return
+sub _item_keys {
+  my $self = shift;
+  my %keys;
+
+  map { $keys{$_} = 1; } keys %{$self->item_xpaths};
+
+  return \%keys;
+}
+
+# Main parser subroutine for retrieving XML data
+sub parse_xml {
+  my $self = shift;
+  $self->{_metadata} = {};
+  $self->{_items} = ();
+
+  # Retrieve scalar metadata from DOM
+  foreach my $key ( keys %{$self->scalar_xpaths} ) {
+    my $xpath = ${$self->scalar_xpaths}{$key};
+    unless ( $xpath ) {
+      # Skip keys without xpath expression
+      ${$self->{_metadata}}{$key} = undef;
+      next;
+    }
+    my $value = $self->{dom}->findnodes($xpath);
+    if ( $value ) {
+      # Get rid of extraneous white space
+      $value = $value->string_value;
+      $value =~ s/\n|\r//g;
+      $value =~ s/\s{2,}/ /g;
+      ${$self->{_metadata}}{$key} = $value;
+    } else {
+      ${$self->{_metadata}}{$key} = undef;
+    }
+  }
+
+
+  # Convert payment code metadata field to Boolean
+  # See https://service.unece.org/trade/untdid/d16b/tred/tred4461.htm for other valid codes.
+  ${$self->{_metadata}}{'direct_debit'} = ${$self->{_metadata}}{'direct_debit'} == 59 ? 1 : 0;
+
+  my @items;
+  $self->{_items} = \@items;
+
+  foreach my $item ( $self->{dom}->findnodes(ITEMS_XPATH) ) {
+    my %line_item;
+    foreach my $key ( keys %{$self->item_xpaths} ) {
+      my $xpath = ${$self->item_xpaths}{$key};
+      unless ( $xpath ) {
+        # Skip keys without xpath expression
+        $line_item{$key} = undef;
+        next;
+      }
+      my $value = $item->findnodes($xpath);
+      if ( $value ) {
+        # Get rid of extraneous white space
+        $value = $value->string_value;
+        $value =~ s/\n|\r//g;
+        $value =~ s/\s{2,}/ /g;
+        $line_item{$key} = $value;
+      } else {
+        $line_item{$key} = undef;
+      }
+    }
+    push @items, \%line_item;
+  }
+
+
+}
+
+1;

--- a/SL/XMLInvoice/UBL.pm
+++ b/SL/XMLInvoice/UBL.pm
@@ -1,0 +1,183 @@
+package SL::XMLInvoice::UBL;
+
+=head1 NAME
+
+SL::XMLInvoice::UBL - XML parser for Universal Business Language invoices
+
+=head1 DESCRIPTION
+
+C<SL::XMLInvoice::UBL> parses XML invoices in Oasis Universal Business
+Language format and makes their data available through the interface defined
+by C<SL::XMLInvoice>. Refer to L<SL::XMLInvoice> for a detailed description of
+that interface.
+
+See L<http://docs.oasis-open.org/ubl/os-UBL-2.1/UBL-2.1.html#T-INVOICE> for
+that format's specification.
+
+=head1 OPERATION
+
+This module is fairly simple. It keeps two hashes of XPath statements exposed
+by methods:
+
+=over 4
+
+=item scalar_xpaths()
+
+This hash is keyed by the keywords C<data_keys> mandates. Values are XPath
+statements specifying the location of this field in the invoice XML document.
+
+=item item_xpaths()
+
+This hash is keyed by the keywords C<item_keys> mandates. Values are XPath
+statements specifying the location of this field inside a line item.
+
+=back
+
+When invoked by the C<SL::XMLInvoice> constructor, C<parse_xml()> will first
+use the XPath statements from the C<scalar_xpaths()> hash to populate the hash
+returned by the C<metadata()> method.
+
+After that, it will use the XPath statements from the C<scalar_xpaths()> hash
+to iterate over the invoice's line items and populate the array of hashes
+returned by the C<items()> method.
+
+=head1 AUTHOR
+
+  Johannes Grassler <info@computer-grassler.de>
+
+=cut
+
+use strict;
+use parent qw(SL::XMLInvoice);
+
+use constant ITEMS_XPATH => '//cac:InvoiceLine';
+
+# XML XPath expression for
+sub scalar_xpaths {
+  return {
+    currency => '//cbc:DocumentCurrencyCode',
+    direct_debit => '//cbc:PaymentMeansCode[@listID="UN/ECE 4461"]',
+    duedate => '//cbc:DueDate',
+    gross_total => '//cac:LegalMonetaryTotal/cbc:TaxInclusiveAmount',
+    iban => '//cac:PayeeFinancialAccount/cbc:ID',
+    invnumber => '//cbc:ID',
+    net_total => '//cac:LegalMonetaryTotal/cbc:TaxExclusiveAmount',
+    transdate => '//cbc:IssueDate',
+    type => '//cbc:InvoiceTypeCode',
+    taxnumber => '//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID',
+    ustid => '//cac:AccountingSupplierParty/cac:Party/cac:PartyTaxScheme/cbc:CompanyID',
+    vendor_name => '//cac:AccountingSupplierParty/cac:Party/cac:PartyName/cbc:Name',
+  };
+}
+
+sub item_xpaths {
+  return {
+    'currency' => './cbc:LineExtensionAmount[attribute::currencyID]',
+    'price' => './cac:Price/cbc:PriceAmount',
+    'description' => './cac:Item/cbc:Description',
+    'quantity' => './cbc:InvoicedQuantity',
+    'subtotal' => './cbc:LineExtensionAmount',
+    'tax_rate' => './/cac:ClassifiedTaxCategory/cbc:Percent',
+    'tax_scheme' => './cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cbc:ID',
+    'vendor_partno' => './cac:Item/cac:SellersItemIdentification/cbc:ID',
+  };
+}
+
+
+# Metadata accessor method
+sub metadata {
+  my $self = shift;
+  return $self->{_metadata};
+}
+
+# Item list accessor method
+sub items {
+  my $self = shift;
+  return $self->{_items};
+}
+
+# Data keys we return
+sub _data_keys {
+  my $self = shift;
+  my %keys;
+
+  map { $keys{$_} = 1; } keys %{$self->scalar_xpaths};
+
+  return \%keys;
+}
+
+# Item keys we return
+sub _item_keys {
+  my $self = shift;
+  my %keys;
+
+  map { $keys{$_} = 1; } keys %{$self->item_xpaths};
+
+  return \%keys;
+}
+
+# Main parser subroutine for retrieving XML data
+sub parse_xml {
+  my $self = shift;
+  $self->{_metadata} = {};
+  $self->{_items} = ();
+
+  # Retrieve scalar metadata from DOM
+  foreach my $key ( keys %{$self->scalar_xpaths} ) {
+    my $xpath = ${$self->scalar_xpaths}{$key};
+    my $value = $self->{dom}->findnodes($xpath);
+    if ( $value ) {
+      # Get rid of extraneous white space
+      $value = $value->string_value;
+      $value =~ s/\n|\r//g;
+      $value =~ s/\s{2,}/ /g;
+      ${$self->{_metadata}}{$key} = $value;
+    } else {
+      ${$self->{_metadata}}{$key} = undef;
+    }
+  }
+
+  # Convert payment code metadata field to Boolean
+  # See https://service.unece.org/trade/untdid/d16b/tred/tred4461.htm for other valid codes.
+  ${$self->{_metadata}}{'direct_debit'} = ${$self->{_metadata}}{'direct_debit'} == 59 ? 1 : 0;
+
+  # UBL does not have a specified way of designating the tax scheme, so we'll
+  # have to guess whether it's a tax ID or VAT ID (not using
+  # SL::VATIDNr->validate here to keep this code portable):
+
+  if ( ${$self->{_metadata}}{'ustid'} =~ qr"/" )
+    {
+      # Unset this since the 'taxid' key has been retrieved with the same xpath
+      # expression.
+      ${$self->{_metadata}}{'ustid'} = undef;
+    } else {
+      # Unset this since the 'ustid' key has been retrieved with the same xpath
+      # expression.
+      ${$self->{_metadata}}{'taxnumber'} = undef;
+    }
+
+  my @items;
+  $self->{_items} = \@items;
+
+  foreach my $item ( $self->{dom}->findnodes(ITEMS_XPATH) ) {
+    my %line_item;
+    foreach my $key ( keys %{$self->item_xpaths} ) {
+      my $xpath = ${$self->item_xpaths}{$key};
+      my $value = $item->findnodes($xpath);
+      if ( $value ) {
+        # Get rid of extraneous white space
+        $value = $value->string_value;
+        $value =~ s/\n|\r//g;
+        $value =~ s/\s{2,}/ /g;
+        $line_item{$key} = $value;
+      } else {
+        $line_item{$key} = undef;
+      }
+    }
+    push @items, \%line_item;
+  }
+
+
+}
+
+1;

--- a/templates/webpages/zugferd/form.html
+++ b/templates/webpages/zugferd/form.html
@@ -10,5 +10,5 @@
  </p>
 
  <form method="post" action="controller.pl" enctype="multipart/form-data" id="form">
-    [% L.input_tag('file', '', type => 'file', accept => '.pdf') %]
+    [% L.input_tag('file', '', type => 'file', accept => '.pdf,.xml') %]
  </form>


### PR DESCRIPTION
Ich saß kürzlich vor einem unangenehm hohen Stapel Lieferantenrechnungen und hab die von meinem Lieferanten netterweise auch als XRechnung bekommen. Da der ZUGFeRD-Import in Kivitendo etwas dürr war, hab ich ihn etwas erweitert: es ist nun möglich sowohl XRechnung als auch ZUGFeRD zu importieren und beim Import werden nun auch die einzelnen Posten der Rechnung ins Formular für die Kreditorenbuchung mit eingetragen.

Der Code funktioniert soweit ich ihn mit den Beispielrechnungen von https://www.ferd-net.de und den XRechnung-Rechnungen meines Lieferanten testen konnte. Sowohl mit Kivitendo 3.6.1 als auch mit dem aktuellen `master`-Branch.

Ein bisschen feilen werde ich noch muessen: Die HTML-Dokumentation hab ich noch nicht aktualisiert, nur die POD-Dokumentation in den Perl-Modulen. Bevor ich das angehe stelle ich den Code aber erst mal als Pull-Request zur Diskussion. Insbesondere ein eleganterer Weg das Formular zu erzeugen als der Umweg ueber ein RecordTemplate waere interessant: im aktuellen Zustand spamme ich mit jeder importierten Rechnung eine nach der Buchung ueberfluessige Belegvorlage in die Datenbank.