### PR TITLE
record_links.t: batch-Test als TODO markieren

### DIFF
--- a/t/db_helper/record_links.t
+++ b/t/db_helper/record_links.t
@@ -338,7 +338,9 @@ $o1->link_to_record($i1);
 $o2->link_to_record($i2);
 
 $links = $o1->linked_records(direction => 'to', to => 'Invoice', batch => [ $o1->id, $o2->id ]);
-is_deeply [ map { $_->id } @$links ], [ $i1->id , $i2->id ], "batch works";
+{ local $TODO = 'Check, if the helper should return links in the order of ids given to batch';
+  is_deeply [ map { $_->id } @$links ], [ $i1->id , $i2->id ], "batch works";
+}
 
 $links = $o1->linked_records(direction => 'to', recursive => 1, batch => [ $o1->id, $o2->id ]);
 cmp_bag [ map { $_->id } @$links ], [ $i1->id , $i2->id ], "batch works recursive";


### PR DESCRIPTION
Dieser Test schlägt manchmal fehl, da die Reihenfolge der zurückgelieferten Links nicht stabil ist.
Die Frage ist hier, ob der Helper die Links in der Reihenfolge der angegebenen Ids zurückgeben soll (also der Helper kaputt ist), oder ob die Reihenfolge unbestimmt ist (also der Test falsch ist).
Deshalb: TODO.

Refs #571 (redmine)