### PR TITLE
Design40 Korrektur bei der Darstellung des Umrechnungskurses

### DIFF
--- a/templates/design40_webpages/is/form_header.html
+++ b/templates/design40_webpages/is/form_header.html
@@ -149,20 +149,33 @@
         <input type="hidden" name="selectAR" value="[% selectAR | html %]">
       </td>
     </tr>
-  [% IF currencies %]
-    <tr>
-      <th>[% 'Currency' | $T8 %]</th>
-      <td>
-       [%- IF readonly  %]
-         [% HTML.escape(currency) %]
-         [% L.hidden_tag("currency", currency) %]
-       [%- ELSE %]
-         [% currencies %]
-       [%- END %]
-      </td>
-    </tr>
-  [% END %]
-  <!--PENDENT: Hardcoded! Ist das korrekt? hps-->
+    [% IF currencies %]
+      <tr>
+        <th>[% 'Currency' | $T8 %]</th>
+        <td>
+         [%- IF readonly  %]
+           [% HTML.escape(currency) %]
+           [% L.hidden_tag("currency", currency) %]
+         [%- ELSE %]
+           [% currencies %]
+         [%- END %]
+        </td>
+      </tr>
+    [% END %]
+    [% IF show_exchangerate %]
+      <tr>
+        <th>[% 'Exchangerate' | $T8 %]</th>
+        <td>
+          [%- IF readonly  %]
+            [% LxERP.format_amount(exchangerate, 5) %]
+            [% L.hidden_tag("exchangerate", LxERP.format_amount(exchangerate, 5)) %]
+          [% ELSE %]
+            <input type="text" name="exchangerate" size="10" value="[% HTML.escape(LxERP.format_amount(exchangerate)) %]">
+          [% END %]
+          [% IF record_forex %][% 'record exchange rate' | $T8 %][%- ELSE %][% 'default exchange rate' | $T8 %][%- END %]
+        </td>
+      </tr>
+    [% END %]
     <tr>
       <th>[% 'Steuersatz' | $T8 %]</th>
       <td>
@@ -203,20 +216,6 @@
         <input type="hidden" name="rndloss_accno" value="[% rndloss_accno %]">
       </td>
     </tr>
-    [% IF show_exchangerate %]
-      <tr>
-        <th>[% 'Exchangerate' | $T8 %]</th>
-        <td>
-          [%- IF readonly  %]
-            [% LxERP.format_amount(exchangerate, 5) %]
-            [% L.hidden_tag("exchangerate", LxERP.format_amount(exchangerate, 5)) %]
-          [% ELSE %]
-            <input type="text" name="exchangerate" size="10" value="[% HTML.escape(LxERP.format_amount(exchangerate)) %]">
-          [% END %]
-          [% IF record_forex %][% 'record exchange rate' | $T8 %][%- ELSE %][% 'default exchange rate' | $T8 %][%- END %]
-        </td>
-      </tr>
-    [% END %]
     <tr>
       <th>[% 'Shipping Point' | $T8 %]</th>
       <td><input type="text" class="wi-wide" name="shippingpoint" value="[% HTML.escape(shippingpoint) %]"></td>

--- a/templates/design40_webpages/order/tabs/basic_data.html
+++ b/templates/design40_webpages/order/tabs/basic_data.html
@@ -90,7 +90,7 @@
       <tr id="exchangerate_settings" [%- IF SELF.order.currency_id==INSTANCE_CONF.get_currency_id %]style='display:none'[%- END %]>
         <th>[% 'Exchangerate' | $T8 %]</th>
         <td> 1 <span id="currency_name">[% SELF.order.currency.name %]</span> =
-          [% L.input_tag('order.exchangerate_as_null_number', SELF.order.exchangerate_as_null_number, class="reformat_number_as_null_number numeric wi-lightwide") %]
+          [% L.input_tag('order.exchangerate_as_null_number', SELF.order.exchangerate_as_null_number, class="reformat_number_as_null_number numeric wi-small") %]
           [% INSTANCE_CONF.default_currency %]
           [% L.hidden_tag('old_currency_id', currency_id) %]
           [% L.hidden_tag('old_exchangerate', SELF.order.exchangerate_as_null_number) %]


### PR DESCRIPTION
- Angebot und Auftrag: Input Feld verkleinert, damit alles auf einer Zeile Platz findet
- Rechnung: Umrechnungskurs direkt unter der Waehrung plaziert