### PR TITLE
colored tables extra description

### DIFF
--- a/templates/print/marei/credit_note.tex
+++ b/templates/print/marei/credit_note.tex
@@ -21,7 +21,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
   \gutschrift~
   \nr ~<%invnumber%>%
 }

--- a/templates/print/marei/inheaders.tex
+++ b/templates/print/marei/inheaders.tex
@@ -1,6 +1,0 @@
-%Dokumentenklasse für DIN-Briefe auf A4
-\documentclass[paper=a4,fontsize=10pt]{scrartcl}
-\usepackage{kiviletter}
-
-%TODO babel setup
-\endinput

--- a/templates/print/marei/invoice.tex
+++ b/templates/print/marei/invoice.tex
@@ -38,7 +38,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
   \rechnung~ \nr ~<%invnumber%>%
 }
 <%if ordnumber%>%

--- a/templates/print/marei/kiviletter.sty
+++ b/templates/print/marei/kiviletter.sty
@@ -291,20 +291,17 @@
 }
 \long\def\kivi@color@b@x#1#2#3%
 {\leavevmode
-  \setbox\z@\hbox{{\set@color#3}}%
+  \setbox\z@\hbox to \linewidth{{\set@color\parbox{\linewidth}{\raggedright#3}}}%
   \dimen@\ht\z@\advance\dimen@\l__kivi_fboxsep_dim\ht\z@\dimen@
   \dimen@\dp\z@\advance\dimen@\l__kivi_fboxsep_dim\dp\z@\dimen@
   {#1{#2\color@block{\wd\z@}{\ht\z@}{\dp\z@}\box\z@}}}
-
 \long\def\kivi@nocolor@b@x#1#2#3%
 {\leavevmode
-  \setbox\z@\hbox{#3}%
+  \setbox\z@\hbox to \linewidth{\parbox{\linewidth}{\raggedright#3}}%
   \dimen@\ht\z@\advance\dimen@\l__kivi_fboxsep_dim\ht\z@\dimen@
   \dimen@\dp\z@\advance\dimen@\l__kivi_fboxsep_dim\dp\z@\dimen@
   {\box\z@}}
-
 %%%
-
 \newcommand{\FakeTable}[1]{
   \par
   \seq_set_split:Nnn \l_kivi_PricingTable_seq {\tabularnewline} {#1}
@@ -321,7 +318,8 @@
       {\nointerlineskip\kivi@tabcolorbox{\g__kivi_Tabular_rowcolor_odd_tl}}
       {\nointerlineskip\kivi@tabcolorbox{\g__kivi_Tabular_rowcolor_even_tl}}
     }
-    {\parbox{\linewidth}{
+    {
+     \parbox{\linewidth}{
         \seq_set_split:Nnn  \l_kivi_columns_seq {&} {##1}
         \seq_gclear:N \g_kivi_extraDescription_seq
         \exp_args:Nnx \use:n {\tabular[t]}\g_kivi_Pricing_colspec_tl
@@ -331,11 +329,18 @@
           &\seq_item:Nn \l_kivi_columns_seq {####1}
         }
         \endtabular
+       }
       }
+
         \seq_if_empty:NTF \g_kivi_extraDescription_seq
         {\par}
         {\par\nopagebreak
-          \begingroup
+            \bool_if:NT \g__kivi_Tabular_rowcolor_bool {
+              \int_if_odd:nTF {\g__kivi_PricingTable_rowcolor_int}
+              {\nointerlineskip\kivi@tabcolorbox{\g__kivi_Tabular_rowcolor_odd_tl}}
+              {\nointerlineskip\kivi@tabcolorbox{\g__kivi_Tabular_rowcolor_even_tl}}
+            }
+          {
           \setlength{\leftskip}{\dim_eval:n {\bool_if:NT \g__kivi_Tabular_rowcolor_bool {-\tabcolsep} +\l_kivi_tab_desc_leftskip_dim}}
           \setlength{\hsize}{\dim_eval:n {\l_kivi_tab_desc_dim+\leftskip}}
           \setlength{\linewidth}{\hsize}
@@ -343,17 +348,14 @@
           \usekomafont{extraDescription}
           \seq_use:Nn \g_kivi_extraDescription_seq {\ifhmode\\\fi}
           \par
-          \endgroup
+          }
         }
-    }
     \par
     \tl_if_empty:NF \l__kivi_Tabular_rowsep_tl {\nointerlineskip\l__kivi_Tabular_rowsep_tl}
   }
   \endgroup
   \par
 }
-
-
 \seq_new:N  \__l_FakeTable_columns_seq
 \cs_new:Nn \__kivi_setup_FakeTable: {
   \seq_clear:N \__l_FakeTable_columns_seq
@@ -552,6 +554,7 @@
   \__kivi_setup_LT_boxes:
   \__kivi_setup_FakeTable:
   \dim_set:Nn \parskip {\c_zero_dim}
+  \dim_set:Nn \parindent {\c_zero_dim}
   \PricingTabularBox\ignorespaces
 }{\endPricingTabularBox
   %compensate footer spacing

--- a/templates/print/marei/kiviletter.sty
+++ b/templates/print/marei/kiviletter.sty
@@ -478,9 +478,9 @@
       \prop_item:cn {l_kivi_col_##1_prop} {header}
     }
   }
-  \cs_gset_eq:NN \__kivi_tab_column_currency: \__kivi_tab_column_body_currency:
   \\
   \bool_if:NF \g__kivi_Tabular_rowcolor_bool \midrule
+  \cs_gset_eq:NN \__kivi_tab_column_currency: \__kivi_tab_column_body_currency:
 }
 
 \newkomafont{tablehead}{\bfseries}

--- a/templates/print/marei/kiviletter.sty
+++ b/templates/print/marei/kiviletter.sty
@@ -638,25 +638,14 @@
 \cs_if_exist:NF \Ifkomavarempty {\let\Ifkomavarempty\ifkomavarempty}
 
 %Definitionen für die insettings.tex
-
-\newcommand*{\setupIdentpath}[1]{
-  \int_set:Nn \l_kivi_tmp_int {1}
-  \bool_set_true:N \l_kivi_tmp_bool
-  \bool_while_do:Nn \l_kivi_tmp_bool {
-    \file_if_exist:nTF {firma\int_use:N \l_kivi_tmp_int/ident.tex}
-    {
-      \exp_args:Nf \str_if_in:nnTF {#1} {Firma\int_use:N \l_kivi_tmp_int}
-      {
-        \newcommand*{\identpath}{firma\int_use:N \l_kivi_tmpa_int}
-        \bool_set_false:N \l_kivi_tmp_bool
-      }
-      {\int_incr:N \l_kivi_tmp_int}
-    }
-    {
-      \bool_set_false:N \l_kivi_tmp_bool
-      \newcommand*{\identpath}{firma}
-    }
-  }
+\NewDocumentCommand{\setupIdentpath}{sm}{
+		\file_if_exist:nTF {#2/ident.tex}
+		{
+			\newcommand*{\identpath}{#2}
+		} {
+			\newcommand*{\identpath}{firma}
+		}
+	}
 }
 
 \newcommand*{\setupCurrencyConfig}[3][euro]{

--- a/templates/print/marei/kiviletter.sty
+++ b/templates/print/marei/kiviletter.sty
@@ -14,6 +14,7 @@
 \ExplSyntaxOn
 \newif\if@kivi@infobox
 \newif\if@kivi@footer
+\newcommand*{\SetupKiviletter}[1]{\keys_set:nn {kiviletter} {#1}}
 \keys_define:nn {kiviletter} {
   infobox .choices:nn = {true,false} {\use:c {@kivi@infobox\l_keys_choice_tl}},
   infobox .default:n = true,

--- a/templates/print/marei/proforma.tex
+++ b/templates/print/marei/proforma.tex
@@ -18,7 +18,7 @@
 
 \begin{document}
 
-\setkomavar{title}{
+\setkomavar{title}{%
   \proformarechnung~
   \nr ~<%ordnumber%>%
 }

--- a/templates/print/marei/purchase_delivery_order.tex
+++ b/templates/print/marei/purchase_delivery_order.tex
@@ -21,7 +21,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
 	\beistelllieferschein~\nr ~<%donumber%>%
 }
 <%if ordnumber%>

--- a/templates/print/marei/purchase_order.tex
+++ b/templates/print/marei/purchase_order.tex
@@ -22,7 +22,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
   \bestellung~
   \nr~<%ordnumber%>%
 }

--- a/templates/print/marei/purchase_reclamation.tex
+++ b/templates/print/marei/purchase_reclamation.tex
@@ -26,7 +26,7 @@ $( USE LxERP )$
 \setkomavar{fromname}{$( KiviLatex.filter(reclamation.employee.name) )$}
 %\setkomavar{fromphone}{$( KiviLatex.filter(reclamation.employee.deleted_tel) )$}
 %\setkomavar{fromemail}{$( KiviLatex.filter(reclamation.employee.deleted_email) )$}
-\setkomavar{title}{
+\setkomavar{title}{%
   \ekreklamation~
   \nr~$( KiviLatex.filter(reclamation.record_number) )$%
 }

--- a/templates/print/marei/request_quotation.tex
+++ b/templates/print/marei/request_quotation.tex
@@ -22,7 +22,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
   \anfrage~
   \nr ~<%quonumber%>%
 }

--- a/templates/print/marei/sales_delivery_order.tex
+++ b/templates/print/marei/sales_delivery_order.tex
@@ -20,7 +20,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
   \lieferschein~
   \nr~<%donumber%>%
 }

--- a/templates/print/marei/sales_order.tex
+++ b/templates/print/marei/sales_order.tex
@@ -23,7 +23,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
   \auftragsbestaetigung~
   \nr~<%ordnumber%>%
 }

--- a/templates/print/marei/sales_quotation.tex
+++ b/templates/print/marei/sales_quotation.tex
@@ -31,7 +31,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
   \angebot~
   <%quonumber%>%
 }

--- a/templates/print/marei/sales_reclamation.tex
+++ b/templates/print/marei/sales_reclamation.tex
@@ -26,7 +26,7 @@ $( KiviLatex.required_packages_for_html )$
 \setkomavar{fromname}{$( KiviLatex.filter(reclamation.employee.name) )$}
 %\setkomavar{fromphone}{$( KiviLatex.filter(reclamation.employee.deleted_tel) )$}
 %\setkomavar{fromemail}{$( KiviLatex.filter(reclamation.employee.deleted_email) )$}
-\setkomavar{title}{
+\setkomavar{title}{%
   \vkreklamation~
   \nr~$( KiviLatex.filter(reclamation.record_number) )$%
 }

--- a/templates/print/marei/statement.tex
+++ b/templates/print/marei/statement.tex
@@ -16,7 +16,7 @@
 \ourhead{}{}{\sammelrechnung}{}{}
 
 
-\setkomavar{title}{
+\setkomavar{title}{%
   \sammelrechnung~
   \nr~<%quonumber%>%
 }

--- a/templates/print/marei/supplier_delivery_order.tex
+++ b/templates/print/marei/supplier_delivery_order.tex
@@ -25,7 +25,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
 	\beistelllieferschein~\nr ~<%donumber%>%
 }
 <%if ordnumber%>

--- a/templates/print/marei/zahlungserinnerung.tex
+++ b/templates/print/marei/zahlungserinnerung.tex
@@ -21,7 +21,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
   \mahnung
   <%if dunning_id%>~\nr~<%dunning_id%><%end if%>%
 }

--- a/templates/print/marei/zahlungserinnerung_invoice.tex
+++ b/templates/print/marei/zahlungserinnerung_invoice.tex
@@ -21,7 +21,7 @@
 \setkomavar{fromname}{<%employee_name%>}
 \setkomavar{fromphone}{<%employee_tel%>}
 \setkomavar{fromemail}{<%employee_email%>}
-\setkomavar{title}{
+\setkomavar{title}{%
   \rechnung~
   \nr ~<%invnumber%>%
 }


### PR DESCRIPTION
Es gibt aktuell einen Bug, der verhindert, dass bei farbigen Tabellen der Umbruch zwischen der description und der longdescription richtig gesetzt wird. Der PR soll daran etwas ändern. Bräuchte aber ein paar kivitendo Nutzer*innen die das testen um sicherzustellen, dass es alle Anwedungsfälle abdeckt. 