### PR TITLE
DMS: Webdav-Backend: Modell zu Nummer-Zuordnung repariert.

### DIFF
--- a/SL/File/Backend/Webdav.pm
+++ b/SL/File/Backend/Webdav.pm
@@ -170,8 +170,8 @@ my %type_to_model = (
 );
 
 my %model_to_number = (
-  Order           => 'ordnumber',
-  DeliveryOrder   => 'ordnumber',
+  Order           => 'record_number',
+  DeliveryOrder   => 'record_number',
   Reclamation     => 'record_number',
   Invoice         => 'invnumber',
   PurchaseInvoice => 'invnumber',


### PR DESCRIPTION
Nummer für Order-Objkekte kann quonumber oder ordnumber sein. Nummer für DeliveryOrders ist donumber.
Jetzt wird die generische Methode record_number verwendet.

Ob das an der Oberfläche tatsächlich Auswirkungen hatte, weiß ich nicht. Die Nummer wurde so nicht im Backend-Data gespeichert, aber wenn die dort nicht ist, wird irgendwie versucht, die aus dem Dateinamen herauszubekommen.