### PR TITLE
reverse Charge Steuerschlüssel 94, keine Steuerbuchung in acc_trans

### DIFF
--- a/SL/AP.pm
+++ b/SL/AP.pm
@@ -224,7 +224,7 @@ sub _post_transaction {
                    $form->{"AP_amount_chart_id_$i"});
         do_query($form, $dbh, $query, @values);
 
-        if ($form->{"tax_$i"} != 0) {
+        if ($form->{"tax_$i"} != 0 && !$form->{"reverse_charge_$i"}) {
           # insert detail records in acc_trans
           $query =
             qq|INSERT INTO acc_trans (trans_id, chart_id, amount, transdate, | .

--- a/SL/Form.pm
+++ b/SL/Form.pm
@@ -3313,7 +3313,7 @@ sub calculate_arap {
 
     my $selected_tax = SL::DB::Manager::Tax->find_by(id => "$tax_id");
 
-    if ( $selected_tax ) {
+    if ( $selected_tax && $selected_tax->taxkey ne '94') {
 
       if ( $buysell eq 'sell' ) {
         $self->{AR_amounts}{"tax_$i"} = $selected_tax->chart->accno if defined $selected_tax->chart;
@@ -3324,6 +3324,8 @@ sub calculate_arap {
       $self->{"taxkey_$i"} = $selected_tax->taxkey;
       $self->{"taxrate_$i"} = $selected_tax->rate;
     };
+
+    $self->{"taxkey_$i"} = $selected_tax->taxkey if $selected_tax->taxkey eq '94';
 
     ($self->{"amount_$i"}, $self->{"tax_$i"}) = $self->calculate_tax($self->{"amount_$i"},$self->{"taxrate_$i"},$taxincluded,$roundplaces);
 

--- a/bin/mozilla/ap.pl
+++ b/bin/mozilla/ap.pl
@@ -846,8 +846,10 @@ sub post {
     # no taxincluded for reverse charge
     my ($used_tax_id) = split(/--/, $form->{"taxchart_$i"});
     my $tax = SL::DB::Manager::Tax->find_by(id => $used_tax_id);
-    if ($tax->reverse_charge_chart_id && $form->{taxincluded}) {
-      $form->error($locale->text('Cannot Post AP transaction with tax included!'));
+    # mark entry
+    if ($tax->reverse_charge_chart_id) {
+      $form->error($locale->text('Cannot Post AP transaction with tax included!')) if $form->{taxincluded};
+      $form->{"reverse_charge_$i"} = 1;
     }
 
     if ($form->parse_amount(\%myconfig, $form->{"amount_$i"})) {


### PR DESCRIPTION
... dennoch Steuerschlüssel für den DATEV-Export korrekt setzen