### PR TITLE
Konten auch ohne Eintrag in taxkeys bearbeiten können.

### DIFF
--- a/SL/AM.pm
+++ b/SL/AM.pm
@@ -97,8 +97,10 @@ sub get_account {
     }
 
     my $active_taxkey = $chart_obj->get_active_taxkey;
-    $form->{$_}  = $active_taxkey->$_ foreach qw(taxkey_id pos_ustva tax_id startdate);
-    $form->{tax} = $active_taxkey->tax_id . '--' . $active_taxkey->taxkey_id;
+    if ($active_taxkey) {
+      $form->{$_}  = $active_taxkey->$_ foreach qw(taxkey_id pos_ustva tax_id startdate);
+      $form->{tax} = $active_taxkey->tax_id . '--' . $active_taxkey->taxkey_id;
+    }
 
     # check if there are any transactions for this chart
     $form->{orphaned} = $chart_obj->has_transaction ? 0 : 1;


### PR DESCRIPTION
Das sollte zwar nicht vorkommen, aber es gibt auch in neu angelegten SKR03/04-Datenbanken Konten, die keinen Eintrag in taxkeys haben. Diese lassen sich dann nicht editieren/korrigieren.
Beim Speichern der Konten wird schon (und wurde vorher auch) überprüft, ob ein gültiger Steuerschlüssel vorliegt.

Evtl. sollte auch noch ein Upgrade-Skript für diese Konten gebaut werden.