### PR TITLE
In Preisregeln benutze Objekte nicht löschen können.

### DIFF
--- a/SL/Controller/CustomerVendor.pm
+++ b/SL/Controller/CustomerVendor.pm
@@ -867,7 +867,7 @@ sub is_orphaned {
   }
 
   my $arap      = $self->is_vendor ? 'ap' : 'ar';
-  my $num_args  = 3;
+  my $num_args  = 4;
 
   my $cv = $self->is_vendor ? 'vendor' : 'customer';
 
@@ -889,7 +889,13 @@ sub is_orphaned {
     SELECT a.id
     FROM delivery_orders a
     JOIN '. $cv .' ct ON (a.'. $cv .'_id = ct.id)
-    WHERE ct.id = ?';
+    WHERE ct.id = ?
+
+    UNION
+
+    SELECT id
+    FROM price_rule_items
+    WHERE type LIKE \''. $cv .'\' AND value_int = ?';
 
 
   if ( $self->is_vendor ) {

--- a/SL/DB/PartsGroup.pm
+++ b/SL/DB/PartsGroup.pm
@@ -56,6 +56,9 @@ sub orphaned {
     return 0 if $class->_get_manager_class->get_all_count(query => [ partsgroup_id => $self->id ]);
   }
 
+  eval "require SL::DB::PriceRuleItem";
+  return 0 if SL::DB::Manager::PriceRuleItem->get_all_count(query => [ type => 'partsgroup', value_int => $self->id ]);
+
   return 1;
 }
 

--- a/SL/DB/Pricegroup.pm
+++ b/SL/DB/Pricegroup.pm
@@ -77,6 +77,9 @@ sub orphaned {
     return 0 if $class->_get_manager_class->get_all_count(query => [ active_price_source => 'pricegroup/' . $self->id ]);
   }
 
+  eval "require SL::DB::PriceRuleItem";
+  return 0 if SL::DB::Manager::PriceRuleItem->get_all_count(query => [ type => 'pricegroup', value_int => $self->id ]);
+
   return 1;
 }
 


### PR DESCRIPTION
Behebt #114 (redmine) bzw. die Reste davon.
Artikel löschen können wurde schon gelöst.