### PR TITLE
S:H:UserPreferences: login aus myconfig holen, nicht über S:D:M:Emplo…

### DIFF
--- a/SL/Helper/UserPreferences.pm
+++ b/SL/Helper/UserPreferences.pm
@@ -139,7 +139,7 @@ sub _update {
 
 ### defaults stuff
 
-sub init_login             { SL::DB::Manager::Employee->current->login    }
+sub init_login             { $::myconfig{login}                           }
 sub init_namespace         { ref $_[0]                                    }
 sub init_upgrade_callbacks { +{}                                          }
 sub init_current_version   { version->parse((ref $_[0])->VERSION)->numify }


### PR DESCRIPTION
…yee->current

Verhindert einen Fehler, falls user preferences bei einer neuen DB abgefragt werden, da es dann u.U. noch keine Einträge in der employee-Tabelle gibt.

Der Fehler trat auf beim Prüfen auf den erzwungenen Layout-Stil bei neuen DBs.