### PR TITLE
Auftrags-/Reklamations-Controller: Wechselkurs soll nicht leer sein, …

### DIFF
--- a/templates/design40_webpages/order/tabs/basic_data.html
+++ b/templates/design40_webpages/order/tabs/basic_data.html
@@ -90,7 +90,7 @@
       <tr id="exchangerate_settings" [%- IF SELF.order.currency_id==INSTANCE_CONF.get_currency_id %]style='display:none'[%- END %]>
         <th>[% 'Exchangerate' | $T8 %]</th>
         <td> 1 <span id="currency_name">[% SELF.order.currency.name %]</span> =
-          [% L.input_tag('order.exchangerate_as_null_number', SELF.order.exchangerate_as_null_number, class="reformat_number_as_null_number numeric wi-small") %]
+          [% L.input_tag('order.exchangerate_as_null_number', SELF.order.exchangerate_as_null_number, 'data-validate'='required', class="reformat_number_as_null_number numeric wi-small") %]
           [% INSTANCE_CONF.default_currency %]
           [% L.hidden_tag('old_currency_id', currency_id) %]
           [% L.hidden_tag('old_exchangerate', SELF.order.exchangerate_as_null_number) %]

--- a/templates/design40_webpages/reclamation/tabs/basic_data.html
+++ b/templates/design40_webpages/reclamation/tabs/basic_data.html
@@ -94,7 +94,7 @@
       <tr id="exchangerate_settings" [%- IF SELF.reclamation.currency_id==INSTANCE_CONF.get_currency_id %]style='display:none'[%- END %]>
         <th>[% 'Exchangerate' | $T8 %]</th>
         <td> 1 <span id="currency_name">[% SELF.reclamation.currency.name %]</span> =
-          [% L.input_tag('reclamation.exchangerate_as_null_number', SELF.reclamation.exchangerate_as_null_number, size="15", class="reformat_number_as_null_number numeric") %]
+          [% L.input_tag('reclamation.exchangerate_as_null_number', SELF.reclamation.exchangerate_as_null_number, 'data-validate'='required', size="15", class="reformat_number_as_null_number numeric") %]
           [% INSTANCE_CONF.default_currency %]
           [% L.hidden_tag('old_currency_id', currency_id) %]
           [% L.hidden_tag('old_exchangerate', SELF.reclamation.exchangerate_as_null_number) %]

--- a/templates/webpages/order/tabs/basic_data.html
+++ b/templates/webpages/order/tabs/basic_data.html
@@ -82,7 +82,7 @@
           <tr id="exchangerate_settings" [%- IF SELF.order.currency_id==INSTANCE_CONF.get_currency_id %]style='display:none'[%- END %]>
             <th align="right">[% 'Exchangerate' | $T8 %]</th>
             <td> 1 <span id="currency_name">[% SELF.order.currency.name %]</span> =
-              [% L.input_tag('order.exchangerate_as_null_number', SELF.order.exchangerate_as_null_number, size="15", class="reformat_number_as_null_number numeric") %]
+              [% L.input_tag('order.exchangerate_as_null_number', SELF.order.exchangerate_as_null_number, 'data-validate'='required', size="15", class="reformat_number_as_null_number numeric") %]
               [% INSTANCE_CONF.default_currency %]
               [% L.hidden_tag('old_currency_id', currency_id) %]
               [% L.hidden_tag('old_exchangerate', SELF.order.exchangerate_as_null_number) %]

--- a/templates/webpages/reclamation/tabs/basic_data.html
+++ b/templates/webpages/reclamation/tabs/basic_data.html
@@ -82,7 +82,7 @@
           <tr id="exchangerate_settings" [%- IF SELF.reclamation.currency_id==INSTANCE_CONF.get_currency_id %]style='display:none'[%- END %]>
             <th align="right">[% 'Exchangerate' | $T8 %]</th>
             <td> 1 <span id="currency_name">[% SELF.reclamation.currency.name %]</span> =
-              [% L.input_tag('reclamation.exchangerate_as_null_number', SELF.reclamation.exchangerate_as_null_number, size="15", class="reformat_number_as_null_number numeric") %]
+              [% L.input_tag('reclamation.exchangerate_as_null_number', SELF.reclamation.exchangerate_as_null_number, 'data-validate'='required', size="15", class="reformat_number_as_null_number numeric") %]
               [% INSTANCE_CONF.default_currency %]
               [% L.hidden_tag('old_currency_id', currency_id) %]
               [% L.hidden_tag('old_exchangerate', SELF.reclamation.exchangerate_as_null_number) %]


### PR DESCRIPTION
… wenn eine andere als die Hauptwährung angegeben ist.