### PR TITLE
Fix: Auftrags-/Reklamations-Controller: Wechselkurs soll nicht leer s…

### DIFF
--- a/js/kivi.Order.js
+++ b/js/kivi.Order.js
@@ -251,9 +251,11 @@ namespace('kivi.Order', function(ns) {
           } else {
             rate_input.val('');
           }
+          $('#order_exchangerate_as_null_number').data('validate', 'required');
           $('#exchangerate_settings').show();
         } else {
           rate_input.val('');
+          $('#order_exchangerate_as_null_number').data('validate', '');
           $('#exchangerate_settings').hide();
         }
         if ($('#order_currency_id').val() != $('#old_currency_id').val() ||

--- a/js/kivi.Reclamation.js
+++ b/js/kivi.Reclamation.js
@@ -245,9 +245,11 @@ namespace('kivi.Reclamation', function(ns) {
           } else {
             rate_input.val('');
           }
+          $('#reclamation_exchangerate_as_null_number').data('validate', 'required');
           $('#exchangerate_settings').show();
         } else {
           rate_input.val('');
+          $('#reclamation_exchangerate_as_null_number').data('validate', '');
           $('#exchangerate_settings').hide();
         }
         if ($('#reclamation_currency_id').val() != $('#old_currency_id').val() ||

--- a/templates/design40_webpages/order/tabs/basic_data.html
+++ b/templates/design40_webpages/order/tabs/basic_data.html
@@ -77,14 +77,15 @@
         <td>[% L.select_tag('order.taxzone_id', SELF.all_taxzones, default=SELF.order.taxzone_id, title_key='description', class='recalc wi-lightwide') %]</td>
       </tr>
       [% SET currency_id = SELF.order.currency_id || INSTANCE_CONF.get_currency_id  # use default currency for new order %]
+      [% SET show_exchangerate = (SELF.order.currency_id != INSTANCE_CONF.get_currency_id) %]
       <tr id="currency_settings">
         <th>[% 'Currency' | $T8 %]</th>
         <td>[% L.select_tag('order.currency_id', SELF.all_currencies, default=currency_id, value_key='id', title_key='name', class='wi-lightwide') %]</td>
       </tr>
-      <tr id="exchangerate_settings" [%- IF SELF.order.currency_id==INSTANCE_CONF.get_currency_id %]style='display:none'[%- END %]>
+      <tr id="exchangerate_settings" [%- IF !show_exchangerate %]style='display:none'[%- END %]>
         <th>[% 'Exchangerate' | $T8 %]</th>
         <td> 1 <span id="currency_name">[% SELF.order.currency.name %]</span> =
-          [% L.input_tag('order.exchangerate_as_null_number', SELF.order.exchangerate_as_null_number, 'data-validate'='required', class="reformat_number_as_null_number numeric wi-small") %]
+          [% L.input_tag('order.exchangerate_as_null_number', SELF.order.exchangerate_as_null_number, 'data-validate'=show_exchangerate ? 'required' : '', class="reformat_number_as_null_number numeric wi-small") %]
           [% INSTANCE_CONF.default_currency %]
           [% L.hidden_tag('old_currency_id', currency_id) %]
           [% L.hidden_tag('old_exchangerate', SELF.order.exchangerate_as_null_number) %]

--- a/templates/design40_webpages/reclamation/tabs/basic_data.html
+++ b/templates/design40_webpages/reclamation/tabs/basic_data.html
@@ -81,14 +81,15 @@
       </tr>
 
       [% SET currency_id = SELF.reclamation.currency_id || INSTANCE_CONF.get_currency_id  # use default currency for new reclamation %]
+      [% SET show_exchangerate = (SELF.reclamation.currency_id != INSTANCE_CONF.get_currency_id) %]
       <tr id="currency_settings">
         <th>[% 'Currency' | $T8 %]</th>
         <td>[% L.select_tag('reclamation.currency_id', SELF.all_currencies, default=currency_id, value_key='id', title_key='name') %]</td>
       </tr>
-      <tr id="exchangerate_settings" [%- IF SELF.reclamation.currency_id==INSTANCE_CONF.get_currency_id %]style='display:none'[%- END %]>
+      <tr id="exchangerate_settings" [%- IF !show_exchangerate %]style='display:none'[%- END %]>
         <th>[% 'Exchangerate' | $T8 %]</th>
         <td> 1 <span id="currency_name">[% SELF.reclamation.currency.name %]</span> =
-          [% L.input_tag('reclamation.exchangerate_as_null_number', SELF.reclamation.exchangerate_as_null_number, 'data-validate'='required', size="15", class="reformat_number_as_null_number numeric") %]
+          [% L.input_tag('reclamation.exchangerate_as_null_number', SELF.reclamation.exchangerate_as_null_number, 'data-validate'=show_exchangerate ? 'required' : '', size="15", class="reformat_number_as_null_number numeric") %]
           [% INSTANCE_CONF.default_currency %]
           [% L.hidden_tag('old_currency_id', currency_id) %]
           [% L.hidden_tag('old_exchangerate', SELF.reclamation.exchangerate_as_null_number) %]

--- a/templates/webpages/order/tabs/basic_data.html
+++ b/templates/webpages/order/tabs/basic_data.html
@@ -74,14 +74,15 @@
           </tr>
 
           [% SET currency_id = SELF.order.currency_id || INSTANCE_CONF.get_currency_id  # use default currency for new order %]
+          [% SET show_exchangerate = (SELF.order.currency_id !=INSTANCE_CONF.get_currency_id) %]
           <tr id="currency_settings">
             <th align="right">[% 'Currency' | $T8 %]</th>
             <td>[% L.select_tag('order.currency_id', SELF.all_currencies, default=currency_id, value_key='id', title_key='name') %]</td>
           </tr>
-          <tr id="exchangerate_settings" [%- IF SELF.order.currency_id==INSTANCE_CONF.get_currency_id %]style='display:none'[%- END %]>
+          <tr id="exchangerate_settings" [%- IF !show_exchangerate %]style='display:none'[%- END %]>
             <th align="right">[% 'Exchangerate' | $T8 %]</th>
             <td> 1 <span id="currency_name">[% SELF.order.currency.name %]</span> =
-              [% L.input_tag('order.exchangerate_as_null_number', SELF.order.exchangerate_as_null_number, 'data-validate'='required', size="15", class="reformat_number_as_null_number numeric") %]
+              [% L.input_tag('order.exchangerate_as_null_number', SELF.order.exchangerate_as_null_number, 'data-validate'=show_exchangerate ? 'required' : '', size="15", class="reformat_number_as_null_number numeric") %]
               [% INSTANCE_CONF.default_currency %]
               [% L.hidden_tag('old_currency_id', currency_id) %]
               [% L.hidden_tag('old_exchangerate', SELF.order.exchangerate_as_null_number) %]

--- a/templates/webpages/reclamation/tabs/basic_data.html
+++ b/templates/webpages/reclamation/tabs/basic_data.html
@@ -74,14 +74,15 @@
           </tr>
 
           [% SET currency_id = SELF.reclamation.currency_id || INSTANCE_CONF.get_currency_id  # use default currency for new reclamation %]
+          [% SET show_exchangerate = (SELF.reclamation.currency_id != INSTANCE_CONF.get_currency_id) %]
           <tr id="currency_settings">
             <th align="right">[% 'Currency' | $T8 %]</th>
             <td>[% L.select_tag('reclamation.currency_id', SELF.all_currencies, default=currency_id, value_key='id', title_key='name') %]</td>
           </tr>
-          <tr id="exchangerate_settings" [%- IF SELF.reclamation.currency_id==INSTANCE_CONF.get_currency_id %]style='display:none'[%- END %]>
+          <tr id="exchangerate_settings" [%- IF !show_exchangerate %]style='display:none'[%- END %]>
             <th align="right">[% 'Exchangerate' | $T8 %]</th>
             <td> 1 <span id="currency_name">[% SELF.reclamation.currency.name %]</span> =
-              [% L.input_tag('reclamation.exchangerate_as_null_number', SELF.reclamation.exchangerate_as_null_number, 'data-validate'='required', size="15", class="reformat_number_as_null_number numeric") %]
+              [% L.input_tag('reclamation.exchangerate_as_null_number', SELF.reclamation.exchangerate_as_null_number, 'data-validate'=show_exchangerate ? 'required' : '', size="15", class="reformat_number_as_null_number numeric") %]
               [% INSTANCE_CONF.default_currency %]
               [% L.hidden_tag('old_currency_id', currency_id) %]
               [% L.hidden_tag('old_exchangerate', SELF.reclamation.exchangerate_as_null_number) %]


### PR DESCRIPTION
…ein.

Das Wechselkursfeld war immer auf 'required' gesetzt, also auch wenn es nicht angezeigt wurde. Das hat das Speichern des Belegs verhindert, wenn die Hauptwährung ausgewählt war.