### PR TITLE
Ckeditor5: P.textarea(..., rows=x) Funktion wieder hergestellt

### DIFF
--- a/js/kivi.js
+++ b/js/kivi.js
@@ -352,11 +352,21 @@ namespace("kivi", function(ns) {
 
       // handle initial height
       const element = $element.get(0);
-      if (element.style.height)
+      if (element.style.height || element.rows)
         editor.editing.view.change((writer) => {
+          var height = element.style.height;
+
+          if (!height && element.rows) {
+            // ckeditor does not support height in rows, but ~30px is a good estimate.
+            // the correct way would be to either configure it, or to add a small dom
+            // element and get the line height at run-time, which is pretty overkill
+            // esp. since ckeditor itself has loads of spacing problems at high zoom
+            editor.editing.view.add
+            height = (element.rows * 30) + "px";
+          }
           writer.setStyle(
             "min-height",
-            element.style.height,
+            height,
             editor.editing.view.document.getRoot()
           );
         });

--- a/templates/design40_webpages/common/_send_email_dialog.html
+++ b/templates/design40_webpages/common/_send_email_dialog.html
@@ -69,7 +69,7 @@
     </tr>
     <tr>
       <th>[% LxERP.t8("Message") %] <sup> [% L.link("generictranslations.pl?action=edit_email_strings", "1)", title=LxERP.t8('Tired of copying always nice phrases for this message? Click here to use the new preset message option!'), target="_blank") %]</sup> </th>
-      <td>[% L.textarea_tag("email_form.message", email_form.message, rows="15", class="texteditor texteditor-space-for-toolbar wi-wider") %]</td>
+      <td>[% L.textarea_tag("email_form.message", email_form.message, style="height:150px", class="texteditor texteditor-space-for-toolbar wi-wider") %]</td>
     </tr>
     [% IF INSTANCE_CONF.get_doc_storage %]
       <tr>

--- a/templates/webpages/common/_send_email_dialog.html
+++ b/templates/webpages/common/_send_email_dialog.html
@@ -87,7 +87,7 @@
    <th align="right" nowrap>[% LxERP.t8("Message") %]
     <sup> [% L.link("generictranslations.pl?action=edit_email_strings", "1)", title=LxERP.t8('Tired of copying always nice phrases for this message? Click here to use the new preset message option!'), target="_blank") %]</sup>
   </th>
-   <td>[% L.textarea_tag("email_form.message", email_form.message, rows="15", cols="80", class="texteditor texteditor-space-for-toolbar") %]</td>
+   <td>[% L.textarea_tag("email_form.message", email_form.message, style="height:150px", class="texteditor texteditor-space-for-toolbar") %]</td>
   </tr>
 
 [% IF INSTANCE_CONF.get_doc_storage %]


### PR DESCRIPTION
Ckeditor5 übernimmt standardmäßig nicht die Höhe des unterliegenden texarea Elements.

Der initializer Code versucht diese Information zu übergeben, kann aber aus dem "rows" Attribute nicht einfach die Höhe ableiten, und leider auch nicht auf die Renderinformationen von sowohl dem textare als auch dem Ckeditor zugreifen.

Stattdessen wird als Heuristik ~30px pro Zeile angenommen.