### PR TITLE
Benutze Poppler fuer PDF-Verarbeitung beim ZUGFeRD-Import

### DIFF
--- a/bin/mozilla/ap.pl
+++ b/bin/mozilla/ap.pl
@@ -125,7 +125,7 @@ sub load_zugferd {
     if $::form->{record_template_id};
   $template_ap ||= SL::DB::Manager::RecordTemplate->get_first(where => [vendor_id => $::form->{form_defaults}->{vendor_id}])
     if $::form->{form_defaults}->{vendor_id};
-  if ($template_ap) {
+  if ($template_ap and $template_ap->items->[0]) {
     $::form->{id} = $template_ap->id;
     # set default values for items
     my $template_item = $template_ap->items->[0];


### PR DESCRIPTION
Gegenwaertig benutzt Kivitendo PDF::API2 um die XML-Attachments aus ZUGFeRD-PDFs zu extrahieren. Das verschluckt sich an vielen PDF-Dateien und man bekommt gar nichts. Poppler, die Bibliothek hinter `pdfdetach(1)` funktioniert hingegen zuverlaessig.

Dieser Branch stellt Kivitendo auf Poppler um. Man braucht dazu Poppler selbst (Ubuntu-Paket libpoppler-dev) und das Perl-Modul Poppler (`cpan install poppler` - leider kein Ubuntu-Paket vorhanden), fuer die Perl-Bindings. Das Poppler-Modul braucht noch einige Abhaengigkeiten, ueber die man beim `cpan install poppler` dann stolpern wird. Wenn an diesem Pull-Request Interesse besteht, installiere ich das alles nochmal auf einem frischen System und dokumentiere das alles nochmal im Detail. Fuers Erste ein Dump aus meiner .bash_history ohne Anspruch auf Vollstaendigkeit:

```
aptitude install build-essential
aptitude install pkg-config
aptitude install poppler-glib
aptitude install libpoppler-glib-dev
aptitude install gobject-introspection
aptitude install libglib-perl
aptitude install libextutils-depends-perl libextutils-pkgconfig-perl
aptitude install libglib-object-introspection-perl
```