### PR TITLE
Druckvorlagen marei: falsche Klammersetzung bei natürlicher Person be…

### DIFF
--- a/templates/print/marei/credit_note.tex
+++ b/templates/print/marei/credit_note.tex
@@ -80,7 +80,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}

--- a/templates/print/marei/invoice.tex
+++ b/templates/print/marei/invoice.tex
@@ -110,7 +110,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}

--- a/templates/print/marei/proforma.tex
+++ b/templates/print/marei/proforma.tex
@@ -82,7 +82,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}

--- a/templates/print/marei/purchase_order.tex
+++ b/templates/print/marei/purchase_order.tex
@@ -75,7 +75,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}

--- a/templates/print/marei/purchase_quotation_intake.tex
+++ b/templates/print/marei/purchase_quotation_intake.tex
@@ -69,7 +69,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}

--- a/templates/print/marei/request_quotation.tex
+++ b/templates/print/marei/request_quotation.tex
@@ -48,7 +48,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}

--- a/templates/print/marei/sales_order.tex
+++ b/templates/print/marei/sales_order.tex
@@ -84,7 +84,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}

--- a/templates/print/marei/sales_quotation.tex
+++ b/templates/print/marei/sales_quotation.tex
@@ -75,7 +75,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}

--- a/templates/print/marei/statement.tex
+++ b/templates/print/marei/statement.tex
@@ -52,7 +52,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}

--- a/templates/print/marei/zahlungserinnerung.tex
+++ b/templates/print/marei/zahlungserinnerung.tex
@@ -53,7 +53,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}

--- a/templates/print/marei/zahlungserinnerung_invoice.tex
+++ b/templates/print/marei/zahlungserinnerung_invoice.tex
@@ -59,7 +59,7 @@
   % Bei natürlichen Personen persönliche Anrede, sonst allgemeine Anrede.
   \opening{
     \Ifstr{<%cp_name%>}{}
-    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede}<%end if%>
+    {<%if natural_person%><%greeting%> <%name%>,<%else%>\anrede<%end if%>}
     {
       \Ifstr{<%cp_gender%>}{f}
       {\anredefrau}


### PR DESCRIPTION
…hoben.

sed -i 's/\(\\anrede\)\}\(<\%end if\%>\)/\1\2}/' `git grep -l natural_person templates/print/marei/`

Behebt #676 (redmine)