### PR TITLE
design40: Toggle Wrapper in Belegen, Höhe korrigiert

### DIFF
--- a/templates/design40_webpages/common/toggle-buttons-for-wrapper.html
+++ b/templates/design40_webpages/common/toggle-buttons-for-wrapper.html
@@ -7,7 +7,7 @@
   <script type="text/javascript">
     var toggles_id = "#toggles" ; // container of the toggle buttons
     var wrapper = new Object() ;
-    $(document).ready(function(){
+    $( window ).on( "load", function() {
       if( $(toggles_id).parent().attr('class') == "wrapper" ) {
         wrapper = $(toggles_id).parent() ; // closest surrounding wrapper to toggle
         $(wrapper).addClass("toggled");

--- a/templates/design40_webpages/generic/toggle_wrapper.html
+++ b/templates/design40_webpages/generic/toggle_wrapper.html
@@ -12,7 +12,7 @@
   <script type="text/javascript">
     var toggles_id = "#toggles" ; // surrounding container of the toggle buttons
     var wrapper = new Object() ;
-    $(document).ready(function(){
+    $( window ).on( "load", function() {
       if( $(toggles_id).parent().attr('class') == "wrapper" ) {
         wrapper = $(toggles_id).parent() ; // closest surrounding wrapper to toggle, must have the class .wrapper
         $(wrapper).addClass("toggled") ; // change the wrapper into a inline-block instead of a 100%-width-block


### PR DESCRIPTION
window.onload anstatt document.ready verwenden. Dieses wartet bis das layout vollständig geladen ist und somit wird die richtige Höhe für den wrapper verwendet.

Behebt: #688