### PR TITLE
Installation-Check: uniq wird nicht standardmäßig exportiert von List…

### DIFF
--- a/scripts/installation_check.pl
+++ b/scripts/installation_check.pl
@@ -197,7 +197,7 @@ sub check_template_dir {
   print_header("Checking LaTeX Dependencies for Master Templates '$dir'");
   kpsewhich($path, 'cls', $_) for SL::InstallationCheck::classes_from_latex($path, '\documentclass');
 
-  my @sty = sort { $a cmp $b } uniq (
+  my @sty = sort { $a cmp $b } List::MoreUtils::uniq (
     SL::InstallationCheck::classes_from_latex($path, '\usepackage'),
     qw(textcomp ulem embedfile)
   );


### PR DESCRIPTION
…::MoreUtils

Die Umstellung auf "require" hat damit die Prüfung der LaTeX-Pakete kaputt gemacht.