### PR TITLE
S:Form: check_exchagerate: die id kann bzw. darf auch "undef" sein.

### DIFF
--- a/SL/Form.pm
+++ b/SL/Form.pm
@@ -1506,7 +1506,7 @@ sub check_exchangerate {
                  { type => SCALAR, callbacks  => { is_fx_currency       => sub { shift ne $_[1]->[0]->{defaultcurrency} } } }, # should be ISO three letter codes for currency identification (ISO 4217)
                  { type => SCALAR | HASHREF, callbacks  => { is_valid_kivi_date   => sub { shift =~ m/\d+.\d+.\d+/ } } }, # we have three numbers. Either DateTime or form scalar
                  { type => SCALAR, callbacks  => { is_buy_or_sell_rate  => sub { shift =~ m/^(buy|sell)$/ } } },
-                 { type => SCALAR, callbacks  => { is_current_form_id   => sub { $_[0] == $_[1]->[0]->{id} } },              optional => 1 },
+                 { type => SCALAR | UNDEF,   callbacks  => { is_current_form_id   => sub { $_[0] == $_[1]->[0]->{id} } },              optional => 1 },
                  { type => SCALAR, callbacks  => { is_valid_fx_table    => sub { shift =~ m/^(ar|ap)$/  } }, optional => 1 }
               );
   my ($self, $myconfig, $currency, $transdate, $fld, $id, $record_table) = @_;


### PR DESCRIPTION
Das gab z.B. einen Fehler beim Neuanlegen einer Debitorenbuchungen für Kunden, bei denen eine Fremdwärung eingestellt ist.