### PR TITLE
202408 fix taxincluded is lost in template

### DIFF
--- a/templates/design40_webpages/delivery_order/tabs/basic_data.html
+++ b/templates/design40_webpages/delivery_order/tabs/basic_data.html
@@ -316,6 +316,7 @@
 </div><!-- /#row_table_scroll_id /.wrapper -->
 
 [% L.hidden_tag('order.taxzone_id', SELF.order.taxzone_id) %]
+[% L.hidden_tag('order.taxincluded', SELF.order.taxincluded) %]
 
 </div><!-- /#ui-tabs-basic-data -->
 

--- a/templates/design40_webpages/order/tabs/basic_data.html
+++ b/templates/design40_webpages/order/tabs/basic_data.html
@@ -169,9 +169,9 @@
                             class = 'wi-mediumsmall-lightwide') %]
         </td>
       </tr>
-      <tr id="taxincluded_row_id">
-        <th>[% IF !SELF.taxes.size %]<label for="order.taxincluded">[% 'Tax Included' | $T8 %]</label> [% END %]</th>
-        <td>[% IF !SELF.taxes.size %][% L.yes_no_tag('order.taxincluded', SELF.order.taxincluded, class='recalc') %][% END %]</td>
+      <tr id="taxincluded_row_id" [% IF !SELF.taxes.size %]class="hidden"[% END %]>
+        <th><label for="order.taxincluded">[% 'Tax Included' | $T8 %]</label></th>
+        <td>[% L.yes_no_tag('order.taxincluded', SELF.order.taxincluded, class='recalc') %]</td>
       </tr>
       [% IF SELF.type == "sales_order" %]
         <tr>

--- a/templates/design40_webpages/reclamation/tabs/basic_data.html
+++ b/templates/design40_webpages/reclamation/tabs/basic_data.html
@@ -182,10 +182,9 @@
         </td>
       </tr>
 
-      <tr id="taxincluded_row_id" >
-        <th>[%- IF !SELF.taxes.size %]<label for="reclamation.taxincluded">[% 'Tax Included' | $T8 %]</label>[%- END %]</th>
-        <td>[%- IF !SELF.taxes.size %][% L.yes_no_tag('reclamation.taxincluded', SELF.reclamation.taxincluded, class='recalc') %][%- END %]
-        </td>
+      <tr id="taxincluded_row_id" [%- IF !SELF.taxes.size %]class="hidden"[% END %]>
+        <th><label for="reclamation.taxincluded">[% 'Tax Included' | $T8 %]</label></th>
+        <td>[% L.yes_no_tag('reclamation.taxincluded', SELF.reclamation.taxincluded, class='recalc') %]</td>
       </tr>
 
     </tbody>

--- a/templates/webpages/delivery_order/tabs/basic_data.html
+++ b/templates/webpages/delivery_order/tabs/basic_data.html
@@ -292,6 +292,7 @@
   </table>
 
   [% L.hidden_tag('order.taxzone_id', SELF.order.taxzone_id) %]
+  [% L.hidden_tag('order.taxincluded', SELF.order.taxincluded) %]
 
 </div>
 


### PR DESCRIPTION
In den Masken von Design40 wurde 'Steuer im Preis inbegriffen' falsch gerendert (Auftrag, Reklamation). Bei Lieferschein wurde das Hidden-Feld vergessen und somit nicht mitgenommen. Bei Rechnung wurde der Wert nicht dem Template übergeben und war somit immer bei default leer, aber für die Berechnung wurder der richtige Wert aus den Einstellung genommen.