### PR TITLE
Berichte Angebote/Aufträge,Rechnungen,VK: Leerzeichen in SQL-Abfrage

### DIFF
--- a/SL/AR.pm
+++ b/SL/AR.pm
@@ -626,7 +626,7 @@ sub ar_transactions {
   }
   if ($form->{"project_id"}) {
     $where .=
-      qq|AND ((a.globalproject_id = ?) OR EXISTS | .
+      qq| AND ((a.globalproject_id = ?) OR EXISTS | .
       qq|  (SELECT * FROM invoice i | .
       qq|   WHERE i.project_id = ? AND i.trans_id = a.id) | .
       qq| OR EXISTS | .

--- a/SL/OE.pm
+++ b/SL/OE.pm
@@ -192,7 +192,7 @@ SQL
 
   if ($form->{"project_id"}) {
     $query .=
-      qq|AND ((globalproject_id = ?) OR EXISTS | .
+      qq| AND ((globalproject_id = ?) OR EXISTS | .
       qq|  (SELECT * FROM orderitems oi | .
       qq|   WHERE oi.project_id = ? AND oi.trans_id = o.id))|;
     push(@values, conv_i($form->{"project_id"}), conv_i($form->{"project_id"}));

--- a/SL/VK.pm
+++ b/SL/VK.pm
@@ -163,7 +163,7 @@ sub invoice_transactions {
   }
   if ($form->{project_id}) {
     $where .=
-      qq|AND ((ar.globalproject_id = ?) OR EXISTS | .
+      qq| AND ((ar.globalproject_id = ?) OR EXISTS | .
       qq|  (SELECT * FROM invoice i | .
       qq|   WHERE i.project_id = ? AND i.trans_id = ar.id))|;
     push(@values, $form->{"project_id"}, $form->{"project_id"});
@@ -202,4 +202,3 @@ sub invoice_transactions {
 }
 
 1;
-


### PR DESCRIPTION
Ab psql Version 15 oder 16 gibt es einen Fehler, wenn sowas abgfragt wird: SELECT * FROM oe WHERE 1 = 1AND ...;
(ERROR:  trailing junk after numeric literal at or near "1A")

Das passierte in älteren Versionen nicht, deshalb sind die fehlenden Leerzeiche wohl nie aufgefallen.