### PR TITLE
FIX: Keine Lücken in Positionen von Shopbildern

### DIFF
--- a/sql/Pg-upgrade2/shop_images_dont_skip_positon.sql
+++ b/sql/Pg-upgrade2/shop_images_dont_skip_positon.sql
@@ -1,0 +1,37 @@
+-- @tag: shop_images_dont_skip_position
+-- @description: Keine Lücken in Position bei Shopbilder
+-- @depends: release_3_9_0
+
+UPDATE shop_images
+SET position = reordered.new_position
+FROM (
+  SELECT id, rank() OVER (PARTITION BY object_id ORDER BY position ASC) AS new_position
+  FROM shop_images
+) reordered
+WHERE shop_images.id = reordered.id
+AND shop_images.position IS DISTINCT FROM reordered.new_position;
+
+CREATE OR REPLACE FUNCTION shop_images_reorder_position()
+RETURNS TRIGGER
+AS
+$$
+BEGIN
+  UPDATE shop_images
+  SET position = reordered.new_position
+  FROM (
+    SELECT id, rank() OVER (PARTITION BY object_id ORDER BY position ASC) AS new_position
+    FROM shop_images
+    WHERE shop_images.object_id = OLD.object_id
+  ) reordered
+  WHERE shop_images.id = reordered.id
+  AND shop_images.position IS DISTINCT FROM reordered.new_position;
+
+  RETURN OLD;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER after_delete_shop_images_trigger
+AFTER DELETE ON shop_images
+FOR EACH ROW
+EXECUTE FUNCTION shop_images_reorder_position();


### PR DESCRIPTION
    Coverbild im Shop wird auf Bild mit Position 1 gesetzt. Diese war
    nach Löschen des 1. Bildes nicht besetzt. Bild an Position 2 wurde
    nicht zu Position 1 geändert.