### PR TITLE
Ungenutzt Menüeinträge zu Modulen aus dem Reiter "Programm" entfernt

### DIFF
--- a/menus/user/00-erp.yaml
+++ b/menus/user/00-erp.yaml
@@ -1587,22 +1587,6 @@
     action: company_logo
     no_todo_list: 1
 - parent: program
-  id: program_kivitendo_modul
-  name: kivitendo modules
-  order: 350
-- parent: program_kivitendo_modul
-  id: program_kivitendo_modul_overview
-  name: Overview kivitendo modules
-  order: 100
-  href: http://www.kivitendo-premium.de/module.shtml
-  target: _blank
-- parent: program_kivitendo_modul
-  id: program_kivitendo_modul_activate
-  name: Activate kivitendo module
-  order: 200
-  href: http://www.kivitendo-premium.de/modul-aktivieren.shtml
-  target: _blank
-- parent: program
   id: program_administration_area
   name: Administration area
   order: 400


### PR DESCRIPTION
Verwaiste Einträge "Modul-Übersicht" und "Modul aktivieren" zu "Module" aus dem Reiter "Programm" entfernt.

Lokal ohne Fehler getestet