### PR TITLE
FIX: shopware6 connector: Bilder Upload für Shopware >= v6.6 Beheben

### DIFF
--- a/SL/ShopConnector/Shopware6.pm
+++ b/SL/ShopConnector/Shopware6.pm
@@ -374,8 +374,17 @@ sub sync_all_images {
 
     # 2.1 no image with this title, create metadata for media and upload image
     if (!$current_image_id) {
+      # get media folder id
+      $ret = $self->connector->GET('api/media-folder');
+      $response_code = $ret->responseCode();
+      die "Request failed, response code was: $response_code\n" . $ret->responseContent() unless $response_code == 200;
+      my $media_folder_id;
+      try {
+        $media_folder_id = from_json($ret->responseContent())->{data}->[0]->{id};
+      } catch { die "Malformed JSON Data: $_ " . $ret->responseContent();  };
+
       # not yet uploaded, create media entry
-      $ret = $self->connector->POST("/api/media?_response=true");
+      $ret = $self->connector->POST("/api/media?_response=true", to_json({"mediaFolderId" => $media_folder_id}));
       $response_code = $ret->responseCode();
       die "Request failed, response code was: $response_code\n" . $ret->responseContent() unless $response_code == 200;
       try {


### PR DESCRIPTION
Siehe auch:
https://forum.shopware.com/t/produkt-bilder-uber-api-hochladen/60780/5

Behebt: Fehler #686

------------------------------

Also bei mir behebt dieser Code das Problem ^^ mit shopware v6.6.

Aber es wäre vielleicht gut wenn das sonst mal noch jemand testen könnte. Ältere Shopware Version kann ich jetzt gerade nicht mehr testen da wir umgestellt haben, aber soweit ich das in der API Dokumentation sehe, sollte das eigentlich auch gehen.

https://www.kivitendo.de/redmine/issues/686