### PR TITLE
FIX: shopware6 connector: Check API Zeigt Fehlermeldung nicht an

### DIFF
--- a/SL/ShopConnector/Shopware6.pm
+++ b/SL/ShopConnector/Shopware6.pm
@@ -679,7 +679,7 @@ sub get_version {
   #  2. request version number
 
   $ret = $self->connector;
-  if (200 != $ret->responseCode()) {
+  if (!defined $ret || 200 != $ret->responseCode()) {
     $return->{success}         = 0;
     $return->{data}->{version} = $self->{errors}; # whatever init puts in errors
     return $return;


### PR DESCRIPTION
Behebt: Fehler #718

----------

Siehe: https://www.kivitendo.de/redmine/issues/718