### PR TITLE
Fix Pricesource Bug of SW6 Controller

### DIFF
--- a/SL/DB/ShopPart.pm
+++ b/SL/DB/ShopPart.pm
@@ -26,8 +26,8 @@ sub get_tax_and_price {
     $part = SL::DB::Manager::Part->find_by( id => $self->part_id );
     $price = $part->$price_src_id;
   }else{
-    $part = SL::DB::Manager::Part->find_by( id => $self->part_id );
-    $price =  $part->prices->[0]->price;
+    $part = SL::DB::Manager::Part->get_all( where => [id => $self->part_id, 'prices.'.pricegroup_id => $price_src_id], with_objects => ['prices'],limit => 1)->[0];
+    $price = $part->prices->[0]->price;
   }
 
   my $taxrate;


### PR DESCRIPTION
DB/ShopPart.pm Code did not filter price by pricegroup in sub get_tax_and_price. This caused trouble when using price_src:

The price pushed to Shopware API was always the "first" pricesource instead of the one configured.

Use the same logic to get price in DB/ShopPart.pm as is used in Controller/ShopPart.pm fixed the bug.
