### PR TITLE
Nummern für Beistell-Lieferschein und Retouren-Lieferschein werden du…

### DIFF
--- a/SL/BackgroundJob/SetNumberRange.pm
+++ b/SL/BackgroundJob/SetNumberRange.pm
@@ -29,7 +29,7 @@ sub run {
 
   my $defaults   = SL::DB::Default->get;
 
-  foreach (qw(invnumber cnnumber soinumber pqinumber sonumber ponumber pocnumber sqnumber rfqnumber sdonumber pdonumber)) {
+  foreach (qw(invnumber cnnumber soinumber pqinumber sonumber ponumber pocnumber sqnumber rfqnumber sdonumber pdonumber sudonumber rdonumber)) {
     my $current_number = SL::PrefixedNumber->new(number => $defaults->{$_});
     $current_number->set_to($next_year * $multiplier);
     $defaults->{$_} = $current_number->get_current;


### PR DESCRIPTION
…rch SetNumerRange auch hochgezählt


Bei Testen hab ich gesehen, dass die beiden "neuen" Lieferscheine nicht mit auf das neue Jahr geändert werden.

Es fahlen auch noch Verkaufsreklamation und Einkaufsreklamation, aber da habe die korrekte '*number' nicht gefunden. Gerne noch auf diesem Branch oder so ergänzen.