### PR TITLE
FIX: S:C:DeliveryOrder: instances of SL::DB::Unit have attribute $name

### DIFF
--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -968,7 +968,7 @@ sub action_stock_in_out_dialog {
     WAREHOUSES => !$delivered ? SL::DB::Manager::Warehouse->get_all(query => [ or => [ invalid => 0, invalid => undef ]], with_objects=> ["bins",]) : [],
     part       => $part,
     do_qty     => $qty,
-    do_unit    => $unit->unit,
+    do_unit    => $unit->name,
     delivered  => $self->order->delivered,
     row        => $row,
     item_id    => $item_id,


### PR DESCRIPTION
Hier war der Name des scalar Attributes falsch. Statt '$unit->$unit' sollte es '$unit->$name' sein.
Bspw. ergibt
`$main::lxdebug->dump(0, "$unit", $unit);`

```
$VAR1 = {
          'base_unit' => undef,
          'factor' => undef,
          'id' => '1',
          'name' => 'Stck',
          'sortkey' => '1',
          'type' => 'dimension'
        };
```
In der Weboberfläche betrifft dies unter _Einkauf → Lieferschein_ bearbeiten im Popup _Lagerbewegungen_ das Feld _Menge laut Lieferschein_.