### PR TITLE
XMLInvoice: gültige namespaces aus der xml holen ...

### DIFF
--- a/SL/XMLInvoice.pm
+++ b/SL/XMLInvoice.pm
@@ -64,7 +64,7 @@ sub new {
     return $self;
   }
 
-  # Determine parser class to use
+  # Determine parser class and namespaces to use
   my $type = first {
     $_->check_signature($self->{dom})
   } @document_modules;
@@ -79,8 +79,11 @@ sub new {
                         );
     return $self;
   }
-
   bless $self, $type;
+
+  my $namespaces = $self->namespaces($self->{dom});
+
+  $self->{namespaces} =  $namespaces;
 
   # Implementation sanity check for child classes: make sure they are aware of
   # the keys the hash returned by their metadata() method must contain.

--- a/SL/XMLInvoice/Base.pm
+++ b/SL/XMLInvoice/Base.pm
@@ -55,6 +55,7 @@ to discover the metadata keys guaranteed to be present.
 =cut
 
 sub data_keys {
+  my $self = shift;
   my @keys = (
     'currency',      # The bill's currency, such as "EUR"
     'direct_debit',  # Boolean: whether the bill will get paid by direct debit (1) or not (0)
@@ -85,6 +86,7 @@ to discover the metadata keys guaranteed to be present.
 =cut
 
 sub item_keys  {
+  my $self = shift;
   my @keys = (
     'currency',
     'description',
@@ -142,6 +144,17 @@ child classes must implement this method.
 sub check_signature {
   my $self = shift;
   die "Children of $self must implement a check_signature() method returning 1 for supported XML, 0 for unsupported XML.";
+}
+
+=item namespaces($dom)
+
+This static method takes a DOM object and returns an ArrayofHashes[ data => localname ]. C<SL::XMLInvoice> uses this method to determine which ns is valid for wich data. All child classes must implement this method.
+
+=cut
+
+sub namespaces {
+  my $self = shift;
+  die "Children of $self must implement a namespaces() method returning an aoh with the namespaces";
 }
 
 =item supported()
@@ -227,6 +240,7 @@ C<item_keys>. Omitting this method from a child class will cause an exception.
 =head1 AUTHOR
 
   Johannes Grassler <info@computer-grassler.de>
+  Werner Hahn <wh@futureworldsearch.net>
 
 =cut
 

--- a/SL/XMLInvoice/CrossIndustryDocument.pm
+++ b/SL/XMLInvoice/CrossIndustryDocument.pm
@@ -5,8 +5,6 @@ use warnings;
 
 use parent qw(SL::XMLInvoice::Base);
 
-use constant ITEMS_XPATH => '//ram:IncludedSupplyChainTradeLineItem';
-
 =head1 NAME
 
 SL::XMLInvoice::CrossIndustryDocument - XML parser for UN/CEFACT Cross Industry Document
@@ -51,6 +49,7 @@ returned by the C<items()> method.
 =head1 AUTHOR
 
   Johannes Grassler <info@computer-grassler.de>
+  Werner Hahn <wh@futureworldsearch.net>
 
 =cut
 
@@ -73,39 +72,75 @@ sub check_signature {
   return 0;
 }
 
+sub namespaces {
+  my ($self, $dom) = @_;
+  my $rootnode = $dom->documentElement;
+  my @nodes = $rootnode->findnodes('namespace::*');
+  my @namespaces = map {[ $_->getData, $_->getLocalName]} @nodes;
+  return \@namespaces;
+}
+
 # XML XPath expressions for global metadata
 sub scalar_xpaths {
+  my ($self) = @_;
+
+  my $rsm = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100'};
+  my $ram = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100'};
+  my $udt = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100'};
+  $ram .= ":" if $ram;
+  $rsm .= ":" if $rsm;
+  $udt .= ":" if $udt;
+
   return {
-    currency => ['//ram:InvoiceCurrencyCode'],
-    direct_debit => ['//ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode'],
-    duedate => ['//ram:DueDateDateTime/udt:DateTimeString', '//ram:EffectiveSpecifiedPeriod/ram:CompleteDateTime/udt:DateTimeString'],
-    gross_total => ['//ram:DuePayableAmount'],
-    iban => ['//ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount/ram:IBANID'],
-    invnumber => ['//rsm:HeaderExchangedDocument/ram:ID'],
-    net_total => ['//ram:TaxBasisTotalAmount'],
-    transdate => ['//ram:IssueDateTime/udt:DateTimeString'],
-    taxnumber => ['//ram:SellerTradeParty/ram:SpecifiedTaxRegistration/ram:ID[@schemeID="FC"]'],
-    type => ['//rsm:HeaderExchangedDocument/ram:TypeCode'],
-    ustid => ['//ram:SellerTradeParty/ram:SpecifiedTaxRegistration/ram:ID[@schemeID="VA"]'],
-    vendor_name => ['//ram:SellerTradeParty/ram:Name'],
+    currency     => ['//' . $ram . 'InvoiceCurrencyCode'],
+    direct_debit => ['//' . $ram . 'SpecifiedTradeSettlementPaymentMeans/' . $ram . 'TypeCode'],
+    duedate      => ['//' . $ram . 'DueDateDateTime/' . $udt . 'DateTimeString', '//' . $ram . 'EffectiveSpecifiedPeriod/' . $ram . 'CompleteDateTime/' . $udt . 'DateTimeString'],
+    gross_total  => ['//' . $ram . 'DuePayableAmount'],
+    iban         => ['//' . $ram . 'SpecifiedTradeSettlementPaymentMeans/' . $ram . 'PayeePartyCreditorFinancialAccount/' . $ram . 'IBANID'],
+    invnumber    => ['//' . $rsm . 'HeaderExchangedDocument/' . $ram . 'ID'],
+    net_total    => ['//' . $ram . 'TaxBasisTotalAmount'],
+    transdate    => ['//' . $ram . 'IssueDateTime/' . $udt . 'DateTimeString'],
+    taxnumber    => ['//' . $ram . 'SellerTradeParty/' . $ram . 'SpecifiedTaxRegistration/' . $ram . 'ID[@schemeID="FC"]'],
+    type         => ['//' . $rsm . 'HeaderExchangedDocument/' . $ram . 'TypeCode'],
+    ustid        => ['//' . $ram . 'SellerTradeParty/' . $ram . 'SpecifiedTaxRegistration/' . $ram . 'ID[@schemeID="VA"]'],
+    vendor_name  => ['//' . $ram . 'SellerTradeParty/' . $ram . 'Name'],
   };
 }
 
 sub item_xpaths {
+  my ($self) = @_;
+
+  my $rsm = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100'};
+  my $ram = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100'};
+  my $udt = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100'};
+  $ram .= ":" if $ram;
+  $rsm .= ":" if $rsm;
+  $udt .= ":" if $udt;
+
   return {
-    'currency' => ['./ram:SpecifiedSupplyChainTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount[attribute::currencyID]',
-                   './ram:SpecifiedSupplyChainTradeAgreement/ram:GrossPriceProductTradePrice/ram:BasisAmount'],
-    'price' => ['./ram:SpecifiedSupplyChainTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount',
-               './ram:SpecifiedSupplyChainTradeAgreement/ram:GrossPriceProductTradePrice/ram:BasisAmount'],
-    'description' => ['./ram:SpecifiedTradeProduct/ram:Name'],
-    'quantity' => ['./ram:SpecifiedSupplyChainTradeDelivery/ram:BilledQuantity',],
-    'subtotal' => ['./ram:SpecifiedSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementMonetarySummation/ram:LineTotalAmount'],
-    'tax_rate' => ['./ram:SpecifiedSupplyChainTradeSettlement/ram:ApplicableTradeTax/ram:ApplicablePercent'],
-    'tax_scheme' => ['./ram:SpecifiedSupplyChainTradeSettlement/ram:ApplicableTradeTax/ram:TypeCode'],
-    'vendor_partno' => ['./ram:SpecifiedTradeProduct/ram:SellerAssignedID'],
+    'currency'      => ['./' . $ram . ':SpecifiedSupplyChainTradeAgreement/' . $ram . ':GrossPriceProductTradePrice/' . $ram . ':ChargeAmount[attribute::currencyID]',
+                        './' . $ram . ':SpecifiedSupplyChainTradeAgreement/' . $ram . ':GrossPriceProductTradePrice/' . $ram . ':BasisAmount'],
+    'price'         => ['./' . $ram . ':SpecifiedSupplyChainTradeAgreement/' . $ram . ':GrossPriceProductTradePrice/' . $ram . ':ChargeAmount',
+                        './' . $ram . ':SpecifiedSupplyChainTradeAgreement/' . $ram . ':GrossPriceProductTradePrice/' . $ram . ':BasisAmount'],
+    'description'   => ['./' . $ram . ':SpecifiedTradeProduct/' . $ram . ':Name'],
+    'quantity'      => ['./' . $ram . ':SpecifiedSupplyChainTradeDelivery/' . $ram . ':BilledQuantity',],
+    'subtotal'      => ['./' . $ram . ':SpecifiedSupplyChainTradeSettlement/' . $ram . ':SpecifiedTradeSettlementMonetarySummation/' . $ram . ':LineTotalAmount'],
+    'tax_rate'      => ['./' . $ram . ':SpecifiedSupplyChainTradeSettlement/' . $ram . ':ApplicableTradeTax/' . $ram . ':ApplicablePercent'],
+    'tax_scheme'    => ['./' . $ram . ':SpecifiedSupplyChainTradeSettlement/' . $ram . ':ApplicableTradeTax/' . $ram . ':TypeCode'],
+    'vendor_partno' => ['./' . $ram . ':SpecifiedTradeProduct/' . $ram . ':SellerAssignedID'],
   };
 }
 
+sub items_xpath {
+  my ($self) = @_;
+  my $rsm = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100'};
+  my $ram = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100'};
+  my $udt = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100'};
+  $ram .= ":" if $ram;
+  $rsm .= ":" if $rsm;
+  $udt .= ":" if $udt;
+  return '//' . $ram . 'IncludedSupplyChainTradeLineItem';
+}
 
 # Metadata accessor method
 sub metadata {
@@ -145,6 +180,9 @@ sub parse_xml {
   $self->{_metadata} = {};
   $self->{_items} = ();
 
+  my $ram = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100'};
+  $ram .= ":" if $ram;
+  my $udt = $self->{namespaces}->{'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100'};
   # Retrieve scalar metadata from DOM
   foreach my $key ( keys %{$self->scalar_xpaths} ) {
     foreach my $xpath ( @{${$self->scalar_xpaths}{$key}} ) {
@@ -154,6 +192,10 @@ sub parse_xml {
         next;
       }
       my $value = $self->{dom}->findnodes($xpath);
+      unless ($udt) {
+        $value = $self->{dom}->findnodes('//' . $ram . 'DueDateDateTime','DateTimeString') if $key eq 'duedate';
+        $value = $self->{dom}->findnodes('//' . $ram . 'IssueDateTime','DateTimeString') if $key eq 'transdate';
+      }
       if ( $value ) {
         # Get rid of extraneous white space
         $value = $value->string_value;
@@ -175,7 +217,7 @@ sub parse_xml {
   my @items;
   $self->{_items} = \@items;
 
-  foreach my $item ( $self->{dom}->findnodes(ITEMS_XPATH)) {
+  foreach my $item ( $self->{dom}->findnodes($self->items_xpath)) {
     my %line_item;
     foreach my $key ( keys %{$self->item_xpaths} ) {
       foreach my $xpath ( @{${$self->item_xpaths}{$key}} ) {


### PR DESCRIPTION
Die namespaces CrossIndustryInvoice, ReusableAggregateBusinessInformationEntity, UnqualifiedDataType können beliebig sein und sind von ZUGfERD nicht festgelegt. Deswegen werden die ns jetzt vorher ausgelesen.

Ich hatte seit Herbst Probleme mit den ZUGfERD Rechnungen von MEMO. Und hatte die mal angeschrieben, da es zuvor ging. Hier die Antwort 

> 
> Hallo Herr Hahn,
> ich gehe Ihre Anliegen mal Punkt für Punkt durch:
> 
> >     „Bei meinem Kunden xxx funktioniert seit Herbst nicht mehr der ZUGfERD Import in das Warenwirtschaftssystem kivitendo.“
> >         Ich habe einen kurzen Blick auf den Quellcode von kivitendo und dessen Online-Demo geworfen. Die vollständige Fehlermeldung lautet: Fehler bei //ram:DuePayableAmount :XPath error : Undefined namespace prefix
> >         Das (Und der Code in CrossIndustryInvoice.pm) deuten darauf hin, dass diese Software feste Namespace-Präfixe erwartet. Feste Namespace-Präfixe zu erwarten, ist schlicht nicht ZUGFeRD-kompatibel, weil Namespace-Präfixe im Ermessen des Erstellers liegen. Siehe dazu meinen Abschnitt zu XML-Namespace-Präfixes am Ende. 
> >     „Der Onlinevalidator zeigt https://erechnungs-validator.de/ ‚Ungültige Anfrage‘ “
> >         Ich bekomme da ein etwas anderes Ergebnis („Keine gültige ZUGFeRD-Datei.“). Leider findet man im Internet immer mal Validatoren, die nicht korrekt validieren, entweder, weil sie noch nicht auf neuere ZUGFeRD-Versionen ausgelegt sind, oder, weil sie Fehler wie den mit den Namespace-Präfixen machen.
> >         Als Gegenbeispiel: Der Validator des Mustang-Projekts (https://www.mustangproject.org/kommandozeile/?lang=de#validate) validiert unsere Rechnungen einwandfrei

> Ein kleiner Exkurs zu XML Namespaces und Präfixes: XML-Namespace-Präfixe können vom Ersteller des XML beliebig gewählt werden. Sie tragen grundsätzlich keine spezielle Bedeutung. Sie werden über eine 'xmlns'-Deklaration einer URI zugeordnet und diese URI ist das, was übereinstimmen muss.
> Z.B. sind diese beiden XML-Dokumente inhaltlich absolut gleich:
> ```
> <h:dokument xmlns:h="http://www.example.org/pfad/">
>   <h:element>Text</h:element>
> </h:dokument>
> <ns1:dokument xmlns:ns1="http://www.example.org/pfad/">
>   <ns1:element>Text</ns1:element>
> </ns1:dokument>
> ```
> 
> Dies ist in https://www.w3.org/TR/REC-xml-names/ festgelegt.
> Für Perl gibt es dafür ein entsprechendes Tutorial: http://grantm.github.io/perl-libxml-by-example/namespaces.html. Offenbar ist wichtig, einen XPathContext zu verwenden und die Namespace-Präfixe, die auf Seiten des XPath-Ausdrucks verwendet werden, mit den offiziellen URIs per registerNs zu verknüpfen. In SL/ZUGFeRD.pm z.B. wird das bereits gemacht.