### PR TITLE
202502 fix is empty on undefined value

### DIFF
--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1805,7 +1805,7 @@ sub save {
       scope => SL::DB::ValidityToken::SCOPE_DELIVERY_ORDER_SAVE(),
       token => $::form->{form_validity_token}
     },
-    delete_custom_shipto       => $self->is_custom_shipto_to_delete || $self->order->custom_shipto->is_empty,
+    delete_custom_shipto       => $self->order->custom_shipto && ($self->is_custom_shipto_to_delete || $self->order->custom_shipto->is_empty),
     items_to_delete            => $items_to_delete,
   );
 

--- a/SL/Controller/Order.pm
+++ b/SL/Controller/Order.pm
@@ -2127,7 +2127,7 @@ sub save {
 
   SL::Model::Record->save($self->order,
                           with_validity_token  => { scope => SL::DB::ValidityToken::SCOPE_ORDER_SAVE(), token => $::form->{form_validity_token} },
-                          delete_custom_shipto => $self->is_custom_shipto_to_delete || $self->order->custom_shipto->is_empty,
+                          delete_custom_shipto => $self->order->custom_shipto && ($self->is_custom_shipto_to_delete || $self->order->custom_shipto->is_empty),
                           items_to_delete      => $items_to_delete,
                           objects_to_close     => $objects_to_close,
                           link_requirement_specs_linking_to_created_from_objects => \@converted_from_oe_ids,

--- a/SL/Controller/Reclamation.pm
+++ b/SL/Controller/Reclamation.pm
@@ -1559,7 +1559,7 @@ sub save {
 
   SL::Model::Record->save($self->reclamation,
                           with_validity_token  => { scope => SL::DB::ValidityToken::SCOPE_RECLAMATION_SAVE(), token => $::form->{form_validity_token} },
-                          delete_custom_shipto => $self->is_custom_shipto_to_delete || $self->reclamation->custom_shipto->is_empty,
+                          delete_custom_shipto => $self->reclamation->custom_shipto && ($self->is_custom_shipto_to_delete || $self->reclamation->custom_shipto->is_empty),
                           items_to_delete      => $items_to_delete,
   );
 


### PR DESCRIPTION
Behebt im Auftragsbericht unter Aktionen->Neuer Auftrag Fehler:
`Can't call method "is_empty" on an undefined value...`