### PR TITLE
DB: alle Benutzer auf Stilvorlage design40 setzen

### DIFF
--- a/SL/Controller/Admin.pm
+++ b/SL/Controller/Admin.pm
@@ -119,7 +119,7 @@ sub action_new_user {
       countrycode  => $defaults->language('de'),
       numberformat => $defaults->numberformat('1.000,00'),
       dateformat   => $defaults->dateformat('dd.mm.yy'),
-      stylesheet   => "kivitendo.css",
+      stylesheet   => "design40.css",
       menustyle    => "neu",
     },
   ));

--- a/config/kivitendo.conf.default
+++ b/config/kivitendo.conf.default
@@ -96,9 +96,9 @@ language = de
 
 # Set stylesheet for login and admin forms. Supported:
 #  lx-office-erp
-#  kivitendo - default
-#  design40
-stylesheet = kivitendo
+#  kivitendo - was the default until version 3.9.2; will be dropped in version 4.0
+#  design40 - default
+stylesheet = design40
 
 # MassPrint Timeout
 # must be less than cgi timeout

--- a/sql/Pg-upgrade2-auth/set_all_users_to_design40.sql
+++ b/sql/Pg-upgrade2-auth/set_all_users_to_design40.sql
@@ -1,0 +1,6 @@
+-- @tag: set_all_users_to_design40
+-- @description: Alle Benutzer werden einmalig auf die Stilvorlage design40.css gesetzt. (Die Einstellung kann manuell in den Benutzereinstellungen rückgängig gemacht werden.)
+-- @depends: release_3_9_1
+
+UPDATE auth.user_config SET cfg_value = 'design40.css'
+  WHERE cfg_key = 'stylesheet';


### PR DESCRIPTION
Wie in letzter Partnerkonferenz besprochen:

Alle Benutzer auf design4.0 umstellen per DB-Upgrade