### PR TITLE
202503 Skontobuchung Einkaufsgutschrift Fix #699

### DIFF
--- a/SL/Controller/BankTransaction.pm
+++ b/SL/Controller/BankTransaction.pm
@@ -1074,9 +1074,9 @@ sub _check_and_book_credit_note {
   die "Invalid state" unless ($has_one_credit_note == 1 && $has_one_invoice == 1);
 
   foreach my $invoice (@{ $params{invoices} }) {
-    my $is_credit_note = $invoice->invoice_type =~ m/credit_note/ ? 1 : undef;
-    my $sign       = $invoice->invoice_type =~ m/credit_note/ ?  1 : -1;  # correct sign for bookings
-    my $paid_sign  = $invoice->invoice_type =~ m/credit_note/ ? -1 :  1;  # paid is always negative for credit_note
+    my $is_credit_note = $invoice->is_credit_note ?  1 : undef;
+    my $sign           = $invoice->is_credit_note ?  1 : -1;  # correct sign for bookings
+    my $paid_sign      = $invoice->is_credit_note ? -1 :  1;  # paid is always negative for credit_note
 
     my $new_acc_trans = SL::DB::AccTransaction->new(trans_id   => $invoice->id,
                                                     chart_id   => $params{transit_chart}->id,

--- a/SL/DB/Helper/Payment.pm
+++ b/SL/DB/Helper/Payment.pm
@@ -418,9 +418,16 @@ sub reference_account {
      SL::DB::Manager::AccTransaction->chart_link_filter("$link_filter")
   );
 
-  return undef unless ref $acc_trans;
+  my $id;
 
-  my $reference_account = SL::DB::Manager::Chart->find_by(id => $acc_trans->chart_id);
+  if (! $acc_trans) {
+    $id = $is_sales ? $::instance_conf->get_ar_chart_id : $::instance_conf->get_ap_chart_id;
+    return undef unless $id;
+  } else {
+    $id = $acc_trans->chart_id;
+  }
+
+  my $reference_account = SL::DB::Manager::Chart->find_by(id => $id);
 
   return $reference_account;
 }

--- a/SL/DB/Helper/Payment.pm
+++ b/SL/DB/Helper/Payment.pm
@@ -625,10 +625,12 @@ sub _skonto_charts_and_tax_correction {
     my $skonto_netamount_rounded   = _round($skonto_netamount_unrounded);
     my $chart_id                   = $is_sales ? $tax->skonto_sales_chart->id : $tax->skonto_purchase_chart->id;
 
+    my $credit_note_multiplier = $self->is_credit_note ? -1 : 1;
     # entry net + tax for caller
     my $rec_net = {
       chart_id               => $chart_id,
-      skonto_amount          => _round($skonto_netamount_unrounded + $skonto_taxamount_unrounded),
+      skonto_amount          => _round($skonto_netamount_unrounded + $skonto_taxamount_unrounded)
+                                * $credit_note_multiplier,
     };
     push @skonto_charts, $rec_net;
     $total_skonto_rounded += $rec_net->{skonto_amount};
@@ -644,6 +646,11 @@ sub _skonto_charts_and_tax_correction {
     croak("No such Chart ID")  unless ref $credit eq 'SL::DB::Chart' && ref $debit eq 'SL::DB::Chart';
     my $notes = SL::HTML::Util->strip($self->notes);
 
+    my $debit_state = ($is_sales && !$self->is_credit_note)          ? 1
+                    : $self->invoice_type eq 'purchase_credit_note'  ? 1
+                    : $self->invoice_type eq 'credit_note'           ? 0
+                    : die "invalid type state";
+
     my $current_transaction = SL::DB::GLTransaction->new(
          employee_id    => $self->employee_id,
          transdate      => $params{transdate_obj},
@@ -654,13 +661,13 @@ sub _skonto_charts_and_tax_correction {
          imported       => 0, # not imported
          taxincluded    => 0,
       )->add_chart_booking(
-         chart  => $is_sales ? $debit : $credit,
+         chart  => $debit_state ? $debit : $credit,
          debit  => abs($skonto_taxamount_rounded),
          source => t8('Skonto Tax Correction for') . " " . $self->invnumber,
          memo   => $params{memo},
          tax_id => 0,
       )->add_chart_booking(
-         chart  => $is_sales ? $credit : $debit,
+         chart  => $debit_state ? $credit : $debit,
          credit => abs($skonto_taxamount_rounded),
          source => t8('Skonto Tax Correction for') . " " . $self->invnumber,
          memo   => $params{memo},

--- a/SL/DB/Helper/Payment.pm
+++ b/SL/DB/Helper/Payment.pm
@@ -646,9 +646,10 @@ sub _skonto_charts_and_tax_correction {
     croak("No such Chart ID")  unless ref $credit eq 'SL::DB::Chart' && ref $debit eq 'SL::DB::Chart';
     my $notes = SL::HTML::Util->strip($self->notes);
 
-    my $debit_state = ($is_sales && !$self->is_credit_note)          ? 1
-                    : $self->invoice_type eq 'purchase_credit_note'  ? 1
-                    : $self->invoice_type eq 'credit_note'           ? 0
+    my $debit_state = ( $is_sales && !$self->is_credit_note)        ? 1
+                    : (!$is_sales && !$self->is_credit_note)        ? 0
+                    : $self->invoice_type eq 'purchase_credit_note' ? 1
+                    : $self->invoice_type eq 'credit_note'          ? 0
                     : die "invalid type state";
 
     my $current_transaction = SL::DB::GLTransaction->new(

--- a/SL/DB/Invoice.pm
+++ b/SL/DB/Invoice.pm
@@ -590,6 +590,12 @@ sub invoice_type {
   return 'invoice';
 }
 
+sub is_credit_note {
+  my ($self) = @_;
+
+  return $self->invoice_type eq 'credit_note' ? 1 : undef;
+}
+
 sub displayable_state {
   my $self = shift;
 

--- a/SL/DB/PurchaseInvoice.pm
+++ b/SL/DB/PurchaseInvoice.pm
@@ -137,6 +137,11 @@ sub invoice_type {
   return 'ap_transaction'        if !$self->invoice;
   return 'purchase_invoice';
 }
+sub is_credit_note {
+  my ($self) = @_;
+
+  return $self->invoice_type eq 'purchase_credit_note' ? 1 : undef;
+}
 
 sub displayable_type {
   my ($self) = @_;

--- a/t/bank/bank_transactions.t
+++ b/t/bank/bank_transactions.t
@@ -1,4 +1,4 @@
-use Test::More tests => 449;
+use Test::More tests => 462;
 
 use strict;
 
@@ -103,6 +103,7 @@ test_credit_note();
 test_ap_transaction();
 test_neg_ap_transaction(invoice => 0);
 test_neg_ap_transaction(invoice => 1);
+test_neg_ap_transaction_skonto();
 test_ap_payment_transaction();
 test_ap_payment_part_transaction();
 test_neg_sales_invoice();
@@ -658,6 +659,20 @@ sub test_full_workflow_ar_multiple_inv_skonto_reconciliate_and_undo {
   is(scalar @{ SL::DB::Manager::BankTransactionAccTrans->get_all(where => [bank_transaction_id => $bt->id ] )},
        9, "$testname 9 acc_trans entries created");
 
+  # check for record link and skonto corrections
+  my $rl_skonto = SL::DB::Manager::RecordLink->get_all(where => [ from_id => $ar_transaction_skonto->id, from_table => 'ar', to_table => 'gl' ]);
+  is (ref $rl_skonto->[0], 'SL::DB::RecordLink', "$testname record link skonto gl created");
+  my $acc_trans_skonto = SL::DB::Manager::AccTransaction->get_all(where => [trans_id => $rl_skonto->[0]->to_id]);
+  foreach my $entry (@{ $acc_trans_skonto }) {
+    if ($entry->chart_link =~ m/tax/) {
+      is($entry->amount, '-1.29000');
+    } elsif ($entry->chart_link =~ m/AR_paid/) {
+      is($entry->amount, '1.29000');
+    } else {
+      fail("invalid chart link state");
+    }
+  }
+
   # same loop as above, but only for the 3rd ar_id
   foreach my $acc_trans_id_entry (@{ SL::DB::Manager::BankTransactionAccTrans->get_all(where => [ar_id => $ar_transaction_skonto->id ] )}) {
     isnt($acc_trans_id_entry->ar_id, '', "$testname: bt linked with acc_trans and trans_id set");
@@ -773,6 +788,75 @@ sub test_credit_note {
   is($credit_note->paid     , '-844.90000', "$testname: paid ok");
   is($bt->invoice_amount    , '-844.90000', "$testname: bt invoice amount for credit note was assigned");
   is($bt->amount            , '-844.90000', "$testname: bt  amount for credit note was assigned");
+}
+
+sub test_neg_ap_transaction_skonto {
+  my (%params) = @_;
+  my $testname = 'test_neg_ap_transaction invoice with skonto';
+  my $netamount = -840.34;
+  my $amount    = $::form->round_amount($netamount * 1.19, 2);
+  my $payment_skonto = create_payment_terms(percent_skonto => 0.04, terms_skonto => 11);
+  my $invoice   = SL::DB::PurchaseInvoice->new(
+    invoice      => 1,
+    invnumber    => 'test_neg_ap_transaction_with_negative_skonto',
+    amount       => $amount,
+    netamount    => $netamount,
+    transdate    => $dt,
+    taxincluded  => 0,
+    vendor_id    => $vendor->id,
+    taxzone_id   => $vendor->taxzone_id,
+    currency_id  => $currency_id,
+    transactions => [],
+    notes        => 'test_neg_ap_transaction_with_skonto',
+    payment_id   => $payment_skonto->id,
+  );
+  $invoice->add_ap_amount_row(
+    amount     => $invoice->netamount,
+    chart      => $ap_amount_chart,
+    tax_id     => $tax_9->id,
+  );
+
+  $invoice->create_ap_row(chart => $ap_chart);
+  $invoice->save;
+
+  is($invoice->amount, -1000, "$testname: amount ok");
+
+  my $bt            = create_bank_transaction(record        => $invoice,
+                                              amount        => 960,
+                                              bank_chart_id => $bank->id,
+                                              transdate     => $dt_10,
+                                                               );
+  $::form->{invoice_skontos} = {
+    $bt->id => [ 'with_skonto_pt' ]
+  };
+
+  is($bt->amount, 960, "$testname: bt  amount for ap was assigned");
+
+  $::form->{invoice_ids} = {
+    $bt->id => [ $invoice->id ]
+  };
+
+  my $ret = save_btcontroller_to_string();
+  $invoice->load;
+  $bt->load;
+  is($invoice->amount   , '-1000.00000', "$testname: amount ok");
+  is($invoice->netamount, '-840.34000', "$testname: netamount ok");
+  is($invoice->paid     , '-1000.00000', "$testname: paid ok");
+  is($bt->invoice_amount, '960.00000', "$testname: bt invoice amount for ap was assigned");
+  is($bt->amount,         '960.00000', "$testname: bt  amount for ap was assigned");
+
+  my $rl_skonto = SL::DB::Manager::RecordLink->get_all(where => [ from_id => $invoice->id, from_table => 'ap', to_table => 'gl' ]);
+  is (ref $rl_skonto->[0], 'SL::DB::RecordLink', "$testname record link skonto gl created");
+  my $acc_trans_skonto = SL::DB::Manager::AccTransaction->get_all(where => [trans_id => $rl_skonto->[0]->to_id]);
+  foreach my $entry (@{ $acc_trans_skonto }) {
+    if ($entry->chart_link =~ m/tax/) {
+      is($entry->amount, '-6.39000');
+    } elsif ($entry->chart_link =~ m/AP_paid/) {
+      is($entry->amount, '6.39000');
+    } else {
+      fail("invalid chart link state");
+    }
+  }
 }
 
 sub test_neg_ap_transaction {


### PR DESCRIPTION
Behebt Fehler #699: Der Skonto-Betrag wird mit dem falschen Vorzeichen verbucht.

Tests hinzugefügt.