### PR TITLE
FIX: S:C:DeiveryOrder: Zyklische Referenzen in Rose-Object

### DIFF
--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1202,14 +1202,14 @@ sub action_transfer_stock_default {
 
     $parts_qty{$part->id} += $qty if $qty;
     push @transfer_requests, {
-      'delivery_order_item_id' => $item->id,
-      'warehouse_id'           => $part->warehouse_id || $default_warehouse_id,
-      'bin_id'                 => $part->bin_id       || $default_bin_id,
-      'unit'                   => $item->unit,
-      'qty'                    => $qty,
+      'delivery_order_item' => $item,
+      'warehouse_id'        => $part->warehouse_id || $default_warehouse_id,
+      'bin_id'              => $part->bin_id       || $default_bin_id,
+      'unit'                => $item->unit,
+      'qty'                 => $qty,
       # added in check transfer_request out direction if possible
-      'chargenumber'           => undef, # $item->serialnumber, # Is not used in delivery order
-      'bestbefore'             => undef, # $item->bestbefore,   # Is not used in delivery order
+      'chargenumber'        => undef, # $item->serialnumber, # Is not used in delivery order
+      'bestbefore'          => undef, # $item->bestbefore,   # Is not used in delivery order
     }
   }
 
@@ -1263,8 +1263,7 @@ sub action_transfer_stock_default {
       # falls chargenumber, bestbefore oder anzahl nicht stimmt, auf automatischen
       # lagerplatz wegbuchen!
       foreach (@transfer_requests) {
-        my $item = SL::DB::DeliveryOrderItem->new(id => $_->{delivery_order_item_id})->load();
-        if ($item->parts_id eq $part_id){
+        if ($_->{delivery_order_item}->parts_id eq $part_id){
           $_->{bin_id}        = $default_bin_id_ignore_onhand;
           $_->{warehouse_id}  = $default_warehouse_id_ignore_onhand;
         }

--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1202,7 +1202,6 @@ sub action_transfer_stock_default {
 
     $parts_qty{$part->id} += $qty if $qty;
     push @transfer_requests, {
-      'delivery_order_item' => $item,
       'warehouse_id'        => $part->warehouse_id || $default_warehouse_id,
       'bin_id'              => $part->bin_id       || $default_bin_id,
       'unit'                => $item->unit,
@@ -1262,10 +1261,13 @@ sub action_transfer_stock_default {
       # entsprechende defaults holen
       # falls chargenumber, bestbefore oder anzahl nicht stimmt, auf automatischen
       # lagerplatz wegbuchen!
-      foreach (@transfer_requests) {
-        if ($_->{delivery_order_item}->parts_id eq $part_id){
-          $_->{bin_id}        = $default_bin_id_ignore_onhand;
-          $_->{warehouse_id}  = $default_warehouse_id_ignore_onhand;
+      for my $idx (0 .. scalar @transfer_requests - 1) {
+        my $transfer_request = $transfer_requests[$idx];
+        next unless $transfer_request->{qty}; # empty request
+
+        if ($items[$idx]->parts_id eq $part_id){
+          $transfer_request->{bin_id}        = $default_bin_id_ignore_onhand;
+          $transfer_request->{warehouse_id}  = $default_warehouse_id_ignore_onhand;
         }
       }
       delete %parts_errors{$part_id};

--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1205,7 +1205,7 @@ sub action_transfer_stock_default {
       'delivery_order_item_id' => $item->id,
       'warehouse_id'           => $part->warehouse_id || $default_warehouse_id,
       'bin_id'                 => $part->bin_id       || $default_bin_id,
-      'unit'                   => $part->unit,
+      'unit'                   => $item->unit,
       'qty'                    => $qty,
       # added in check transfer_request out direction if possible
       'chargenumber'           => undef, # $item->serialnumber, # Is not used in delivery order

--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1202,14 +1202,14 @@ sub action_transfer_stock_default {
 
     $parts_qty{$part->id} += $qty if $qty;
     push @transfer_requests, {
-      'delivery_order_item' => $item,
-      'warehouse_id'        => $part->warehouse_id || $default_warehouse_id,
-      'bin_id'              => $part->bin_id       || $default_bin_id,
-      'unit'                => $part->unit,
-      'qty'                 => $qty,
+      'delivery_order_item_id' => $item->id,
+      'warehouse_id'           => $part->warehouse_id || $default_warehouse_id,
+      'bin_id'                 => $part->bin_id       || $default_bin_id,
+      'unit'                   => $part->unit,
+      'qty'                    => $qty,
       # added in check transfer_request out direction if possible
-      'chargenumber'        => undef, # $item->serialnumber, # Is not used in delivery order
-      'bestbefore'          => undef, # $item->bestbefore,   # Is not used in delivery order
+      'chargenumber'           => undef, # $item->serialnumber, # Is not used in delivery order
+      'bestbefore'             => undef, # $item->bestbefore,   # Is not used in delivery order
     }
   }
 
@@ -1263,7 +1263,8 @@ sub action_transfer_stock_default {
       # falls chargenumber, bestbefore oder anzahl nicht stimmt, auf automatischen
       # lagerplatz wegbuchen!
       foreach (@transfer_requests) {
-        if ($_->{delivery_order_item}->parts_id eq $part_id){
+        my $item = SL::DB::DeliveryOrderItem->new(id => $_->{delivery_order_item_id})->load();
+        if ($item->parts_id eq $part_id){
           $_->{bin_id}        = $default_bin_id_ignore_onhand;
           $_->{warehouse_id}  = $default_warehouse_id_ignore_onhand;
         }


### PR DESCRIPTION
Wichtiger Commit, den wir leider in der Sprintwoche vergessen haben zu mergen, ohne den geht das auslagern über Standardlager nicht.