### PR TITLE
202504 wip controller angleich

### DIFF
--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -713,6 +713,29 @@ sub action_unit_changed {
   $self->js->render();
 }
 
+# update item input row when a part ist picked
+sub action_update_item_input_row {
+  my ($self) = @_;
+
+  delete $::form->{add_item}->{$_} for qw(create_part_type sellprice_as_number discount_as_percent);
+
+  my $form_attr = $::form->{add_item};
+
+  return unless $form_attr->{parts_id};
+
+  my $record       = $self->order;
+  my $item         = SL::DB::DeliveryOrderItem->new(%$form_attr);
+  $item->qty(1) if !$item->qty;
+  $item->unit($item->part->unit);
+
+  my $texts = SL::Model::Record->get_part_texts($item->part, $record->language_id);
+
+  $self->js
+    ->val     ('#add_item_unit',                $item->unit)
+    ->val     ('#add_item_description',         $texts->{description})
+    ->render;
+}
+
 # add an item row for a new item entered in the input row
 sub action_add_item {
   my ($self) = @_;

--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1805,16 +1805,18 @@ sub new_item {
 
   my ($price_src, $discount_src) = SL::Model::Record->get_best_price_and_discount_source($record, $item, ignore_given => 0);
 
+  my $texts = SL::Model::Record->get_part_texts($item->part, $record->language_id);
+
   my %new_attr;
   $new_attr{part}                   = $part;
-  $new_attr{description}            = $part->description     if ! $item->description;
+  $new_attr{description}            = $texts->{description}  if ! $item->description;
   $new_attr{qty}                    = 1.0                    if ! $item->qty;
   $new_attr{price_factor_id}        = $part->price_factor_id if ! $item->price_factor_id;
   $new_attr{sellprice}              = $price_src->price;
   $new_attr{discount}               = $discount_src->discount;
   $new_attr{active_price_source}    = $price_src;
   $new_attr{active_discount_source} = $discount_src;
-  $new_attr{longdescription}        = $part->notes           if ! defined $attr->{longdescription};
+  $new_attr{longdescription}        = $texts->{longdescription} if ! defined $attr->{longdescription};
   $new_attr{project_id}             = $record->globalproject_id;
   $new_attr{lastcost}               = $record->is_sales ? $part->lastcost : 0;
 
@@ -1823,13 +1825,7 @@ sub new_item {
   # saved. Adding empty custom_variables to new orderitem here solves this problem.
   $new_attr{custom_variables} = [];
 
-  my $texts = SL::Model::Record->get_part_texts(
-    $part, $record->language_id,
-    description => $new_attr{description},
-    longdescription => $new_attr{longdescription}
-  );
-
-  $item->assign_attributes(%new_attr, %{ $texts });
+  $item->assign_attributes(%new_attr);
 
   return $item;
 }

--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1098,7 +1098,7 @@ sub action_update_row_from_master_data {
   foreach my $item_id (@{ $::form->{item_ids} }) {
     my $idx   = first_index { $_ eq $item_id } @{ $::form->{orderitem_ids} };
     my $item  = $self->order->items_sorted->[$idx];
-    my $texts = get_part_texts($item->part, $self->order->language_id);
+    my $texts = SL::Model::Record->get_part_texts($item->part, $self->order->language_id);
 
     $item->description($texts->{description});
     $item->longdescription($texts->{longdescription});
@@ -1750,7 +1750,7 @@ sub make_item {
   $item->assign_attributes(%$attr);
 
   if ($is_new) {
-    my $texts = get_part_texts($item->part, $record->language_id);
+    my $texts = SL::Model::Record->get_part_texts($item->part, $record->language_id);
     $item->longdescription($texts->{longdescription})              if !defined $attr->{longdescription};
     $item->project_id($record->globalproject_id)                   if !defined $attr->{project_id};
     $item->lastcost($record->is_sales ? $item->part->lastcost : 0) if !defined $attr->{lastcost_as_number};
@@ -1800,7 +1800,7 @@ sub new_item {
   # saved. Adding empty custom_variables to new orderitem here solves this problem.
   $new_attr{custom_variables} = [];
 
-  my $texts = get_part_texts(
+  my $texts = SL::Model::Record->get_part_texts(
     $part, $record->language_id,
     description => $new_attr{description},
     longdescription => $new_attr{longdescription}
@@ -2358,30 +2358,6 @@ sub get_item_cvpartnumber {
       @{$item->part->customerprices};
     $item->{cvpartnumber} = $cps[0]->customer_partnumber if scalar @cps;
   }
-}
-
-sub get_part_texts {
-  my ($part_or_id, $language_or_id, %defaults) = @_;
-
-  my $part        = ref($part_or_id)     ? $part_or_id         : SL::DB::Part->load_cached($part_or_id);
-  my $language_id = ref($language_or_id) ? $language_or_id->id : $language_or_id;
-  my $texts       = {
-    description     => $defaults{description}     // $part->description,
-    longdescription => $defaults{longdescription} // $part->notes,
-  };
-
-  return $texts unless $language_id;
-
-  my $translation = SL::DB::Manager::Translation->get_first(
-    where => [
-      parts_id    => $part->id,
-      language_id => $language_id,
-    ]);
-
-  $texts->{description}     = $translation->translation     if $translation && $translation->translation;
-  $texts->{longdescription} = $translation->longdescription if $translation && $translation->longdescription;
-
-  return $texts;
 }
 
 sub nr_key {

--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1809,9 +1809,9 @@ sub new_item {
 
   my %new_attr;
   $new_attr{part}                   = $part;
-  $new_attr{description}            = $texts->{description}  if ! $item->description;
-  $new_attr{qty}                    = 1.0                    if ! $item->qty;
-  $new_attr{price_factor_id}        = $part->price_factor_id if ! $item->price_factor_id;
+  $new_attr{description}            = $texts->{description}     if ! $item->description;
+  $new_attr{qty}                    = 1.0                       if ! $item->qty;
+  $new_attr{price_factor_id}        = $part->price_factor_id    if ! $item->price_factor_id;
   $new_attr{sellprice}              = $price_src->price;
   $new_attr{discount}               = $discount_src->discount;
   $new_attr{active_price_source}    = $price_src;

--- a/SL/Controller/Order.pm
+++ b/SL/Controller/Order.pm
@@ -1027,7 +1027,7 @@ sub action_update_item_input_row {
 
   my ($price_src, $discount_src) = SL::Model::Record->get_best_price_and_discount_source($record, $item, ignore_given => 0);
 
-  my $texts = get_part_texts($item->part, $record->language_id);
+  my $texts = SL::Model::Record->get_part_texts($item->part, $record->language_id);
 
   $self->js
     ->val     ('#add_item_unit',                $item->unit)
@@ -1332,7 +1332,7 @@ sub action_update_row_from_master_data {
   foreach my $item_id (@{ $::form->{item_ids} }) {
     my $idx   = first_index { $_ eq $item_id } @{ $::form->{orderitem_ids} };
     my $item  = $self->order->items_sorted->[$idx];
-    my $texts = get_part_texts($item->part, $self->order->language_id);
+    my $texts = SL::Model::Record->get_part_texts($item->part, $self->order->language_id);
 
     $item->description($texts->{description});
     $item->longdescription($texts->{longdescription});
@@ -1911,7 +1911,7 @@ sub make_item {
   $item->assign_attributes(%$attr);
 
   if ($is_new) {
-    my $texts = get_part_texts($item->part, $record->language_id);
+    my $texts = SL::Model::Record->get_part_texts($item->part, $record->language_id);
     $item->longdescription($texts->{longdescription})              if !defined $attr->{longdescription};
     $item->project_id($record->globalproject_id)                   if !defined $attr->{project_id};
     $item->lastcost($record->is_sales ? $item->part->lastcost : 0) if !defined $attr->{lastcost_as_number};
@@ -1941,7 +1941,7 @@ sub new_item {
 
   my ($price_src, $discount_src) = SL::Model::Record->get_best_price_and_discount_source($record, $item, ignore_given => 0);
 
-  my $texts = get_part_texts($item->part, $record->language_id);
+  my $texts = SL::Model::Record->get_part_texts($item->part, $record->language_id);
 
   my %new_attr;
   $new_attr{description}            = $texts->{description}        if ! $item->description;
@@ -2775,30 +2775,6 @@ sub get_item_cvpartnumber {
     my @cps = grep { $_->customer_id eq $self->order->customervendor->id } @{$item->part->customerprices};
     $item->{cvpartnumber} = $cps[0]->customer_partnumber if scalar @cps;
   }
-}
-
-sub get_part_texts {
-  my ($part_or_id, $language_or_id, %defaults) = @_;
-
-  my $part        = ref($part_or_id)     ? $part_or_id         : SL::DB::Part->load_cached($part_or_id);
-  my $language_id = ref($language_or_id) ? $language_or_id->id : $language_or_id;
-  my $texts       = {
-    description     => $defaults{description}     // $part->description,
-    longdescription => $defaults{longdescription} // $part->notes,
-  };
-
-  return $texts unless $language_id;
-
-  my $translation = SL::DB::Manager::Translation->get_first(
-    where => [
-      parts_id    => $part->id,
-      language_id => $language_id,
-    ]);
-
-  $texts->{description}     = $translation->translation     if $translation && $translation->translation;
-  $texts->{longdescription} = $translation->longdescription if $translation && $translation->longdescription;
-
-  return $texts;
 }
 
 sub nr_key {

--- a/SL/Controller/Reclamation.pm
+++ b/SL/Controller/Reclamation.pm
@@ -1489,16 +1489,18 @@ sub new_item {
 
   my ($price_src, $discount_src) = SL::Model::Record->get_best_price_and_discount_source($record, $item, ignore_given => 0);
 
+  my $texts = SL::Model::Record->get_part_texts($item->part, $record->language_id);
+
   my %new_attr;
   $new_attr{part}                   = $part;
-  $new_attr{description}            = $part->description     if ! $item->description;
+  $new_attr{description}            = $texts->{description}  if ! $item->description;
   $new_attr{qty}                    = 1.0                    if ! $item->qty;
   $new_attr{price_factor_id}        = $part->price_factor_id if ! $item->price_factor_id;
   $new_attr{sellprice}              = $price_src->price;
   $new_attr{discount}               = $discount_src->discount;
   $new_attr{active_price_source}    = $price_src;
   $new_attr{active_discount_source} = $discount_src;
-  $new_attr{longdescription}        = $part->notes           if ! defined $attr->{longdescription};
+  $new_attr{longdescription}        = $texts->{longdescription} if ! defined $attr->{longdescription};
   $new_attr{project_id}             = $record->globalproject_id;
   $new_attr{lastcost}               = $record->is_sales ? $part->lastcost : 0;
 
@@ -1507,12 +1509,7 @@ sub new_item {
   # saved. Adding empty custom_variables to new reclamationitem here solves this problem.
   $new_attr{custom_variables} = [];
 
-  my $texts = SL::Model::Record->get_part_texts($part, $record->language_id,
-                description => $new_attr{description},
-                longdescription => $new_attr{longdescription},
-              );
-
-  $item->assign_attributes(%new_attr, %{ $texts });
+  $item->assign_attributes(%new_attr);
 
   $item->reclamation($record);
   return $item;

--- a/SL/Controller/Reclamation.pm
+++ b/SL/Controller/Reclamation.pm
@@ -1493,9 +1493,9 @@ sub new_item {
 
   my %new_attr;
   $new_attr{part}                   = $part;
-  $new_attr{description}            = $texts->{description}  if ! $item->description;
-  $new_attr{qty}                    = 1.0                    if ! $item->qty;
-  $new_attr{price_factor_id}        = $part->price_factor_id if ! $item->price_factor_id;
+  $new_attr{description}            = $texts->{description}     if ! $item->description;
+  $new_attr{qty}                    = 1.0                       if ! $item->qty;
+  $new_attr{price_factor_id}        = $part->price_factor_id    if ! $item->price_factor_id;
   $new_attr{sellprice}              = $price_src->price;
   $new_attr{discount}               = $discount_src->discount;
   $new_attr{active_price_source}    = $price_src;

--- a/SL/Model/Record.pm
+++ b/SL/Model/Record.pm
@@ -488,6 +488,20 @@ entered.
 Returns an reference to an array where the first element is the best
 price source and the second element is the best discount source.
 
+=item C<get_part_texts>
+
+Get the description and longdescription of a part with or without translation.
+
+Expects a part object or it's id as first parameter (mandatory) and a language
+object or it's id as second parameter (optional).
+
+You can give optional default values for the texts as a hash with the keys
+C<description> and C<longdescription>. The defaults are returned if no
+translation for one text can be found.
+
+Returns a hasf ref with the keys C<description> and C<longdescription> and
+the texts as values.
+
 =item C<delete>
 
 Expects a record to delete.

--- a/js/kivi.DeliveryOrder.js
+++ b/js/kivi.DeliveryOrder.js
@@ -585,6 +585,15 @@ namespace('kivi.DeliveryOrder', function(ns) {
     return insert_before_item_id;
   };
 
+  ns.update_item_input_row = function() {
+    if (!ns.check_cv()) return;
+
+    var data = $('#order_form').serializeArray();
+    data.push({ name: 'action', value: 'DeliveryOrder/update_item_input_row' });
+
+    $.post("controller.pl", data, kivi.eval_json_result);
+  };
+
   ns.add_item = function() {
     if ($('#add_item_parts_id').val() === '') return;
     if (!ns.check_cv()) return;
@@ -817,8 +826,9 @@ $(function() {
   $('#order_transdate_as_date').change(kivi.DeliveryOrder.update_exchangerate);
   $('#order_exchangerate_as_null_number').change(kivi.DeliveryOrder.exchangerate_changed);
 
-  $('#add_item_parts_id').on('set_item:PartPicker', function(e,o) { $('#add_item_description').val(o.description) });
-  $('#add_item_parts_id').on('set_item:PartPicker', function(e,o) { $('#add_item_unit').val(o.unit) });
+  $('#add_item_parts_id').on('set_item:PartPicker', function() {
+    kivi.DeliveryOrder.update_item_input_row();
+  });
 
   $('.add_item_input').keydown(function(event) {
     if (event.keyCode == 13) {

--- a/js/kivi.Reclamation.js
+++ b/js/kivi.Reclamation.js
@@ -489,6 +489,15 @@ namespace('kivi.Reclamation', function(ns) {
     return insert_before_item_id;
   };
 
+  ns.update_item_input_row = function() {
+    if (!ns.check_cv()) return;
+
+    var data = $('#reclamation_form').serializeArray();
+    data.push({ name: 'action', value: 'Reclamation/update_item_input_row' });
+
+    $.post("controller.pl", data, kivi.eval_json_result);
+  };
+
   ns.add_item = function() {
     if ($('#add_item_parts_id').val() === '') return;
     if (!ns.check_cv()) return;
@@ -870,13 +879,9 @@ $(function() {
   $('#reclamation_transdate_as_date').change(kivi.Reclamation.update_exchangerate);
   $('#reclamation_exchangerate_as_null_number').change(kivi.Reclamation.exchangerate_changed);
 
-  if ($('#type').val() == 'sales_reclamation') {
-    $('#add_item_parts_id').on('set_item:PartPicker', function(e,o) { $('#add_item_sellprice_as_number').val(kivi.format_amount(o.sellprice, -2)) });
-  } else {
-    $('#add_item_parts_id').on('set_item:PartPicker', function(e,o) { $('#add_item_sellprice_as_number').val(kivi.format_amount(o.lastcost, -2)) });
-  }
-  $('#add_item_parts_id').on('set_item:PartPicker', function(e,o) { $('#add_item_description').val(o.description) });
-  $('#add_item_parts_id').on('set_item:PartPicker', function(e,o) { $('#add_item_unit').val(o.unit) });
+  $('#add_item_parts_id').on('set_item:PartPicker', function() {
+    kivi.Reclamation.update_item_input_row();
+  });
 
   $('.add_item_input').keydown(function(event) {
     if (event.keyCode == 13) {

--- a/js/kivi.Reclamation.js
+++ b/js/kivi.Reclamation.js
@@ -573,7 +573,7 @@ namespace('kivi.Reclamation', function(ns) {
     $.post("controller.pl", data, kivi.eval_json_result);
   };
 
-  ns.update_price_source = function(item_id, source, descr, price_str, price_editable) {
+  ns.set_price_and_source_text = function(item_id, source, descr, price_str, price_editable) {
     var row        = $('#item_' + item_id).parents("tbody").first();
     var source_elt = $(row).find('[name="reclamation.reclamation_items[].active_price_source"]');
     var button_elt = $(row).find('[name="price_chooser_button"]');
@@ -602,13 +602,17 @@ namespace('kivi.Reclamation', function(ns) {
       var html_elt  = $(row).find('[name="sellprice_text"]');
       price_elt.val(price_str);
       html_elt.html(price_str);
-      ns.recalc_amounts_and_taxes();
     }
+  };
 
+  ns.update_price_source = function(item_id, source, descr, price_str, price_editable) {
+    ns.set_price_and_source_text(item_id, source, descr, price_str, price_editable);
+
+    if (price_str) ns.recalc_amounts_and_taxes();
     kivi.io.close_dialog();
   };
 
-  ns.update_discount_source = function(item_id, source, descr, discount_str, price_editable) {
+  ns.set_discount_and_source_text = function(item_id, source, descr, discount_str, price_editable) {
     var row        = $('#item_' + item_id).parents("tbody").first();
     var source_elt = $(row).find('[name="reclamation.reclamation_items[].active_discount_source"]');
     var button_elt = $(row).find('[name="price_chooser_button"]');
@@ -637,9 +641,13 @@ namespace('kivi.Reclamation', function(ns) {
       var html_elt     = $(row).find('[name="discount_text"]');
       discount_elt.val(discount_str);
       html_elt.html(discount_str);
-      ns.recalc_amounts_and_taxes();
     }
+  };
 
+  ns.update_discount_source = function(item_id, source, descr, discount_str, price_editable) {
+    ns.set_discount_and_source_text(item_id, source, descr, discount_str, price_editable);
+
+    if (discount_str) ns.recalc_amounts_and_taxes();
     kivi.io.close_dialog();
   };
 

--- a/templates/design40_webpages/delivery_order/tabs/_item_input.html
+++ b/templates/design40_webpages/delivery_order/tabs/_item_input.html
@@ -16,7 +16,6 @@
             [%- SET PARAM_VAL = SELF.search_cvpartnumber -%]
             [% P.part.picker('add_item.parts_id', SELF.created_part,
                               class="add_item_input wi-normal",
-                              fat_set_item=1,
                               multiple_pos_input=1,
                               action={set_multi_items='kivi.DeliveryOrder.add_multi_items'},
                               classification_id=SELF.part_picker_classification_ids.as_list.join(','),

--- a/templates/design40_webpages/delivery_order/tabs/_item_input.html
+++ b/templates/design40_webpages/delivery_order/tabs/_item_input.html
@@ -28,7 +28,7 @@
           </td>
           <td>
             <span class="label above">[% 'Qty' | $T8 %]</span>
-            [% L.input_tag('add_item.qty_as_number', '', size = 5, class="add_item_input numeric") %]
+            [% L.input_tag('add_item.qty_as_number', '', placeholder="1", size = 5, class="add_item_input numeric") %]
             [% L.hidden_tag('add_item.unit', SELF.created_part.unit, class="add_item_input") %]
           </td>
           <td style="vertical-align:bottom;">

--- a/templates/design40_webpages/order/tabs/_item_input.html
+++ b/templates/design40_webpages/order/tabs/_item_input.html
@@ -19,7 +19,6 @@
           [%- SET PARAM_KEY = SELF.cv == "customer" ? 'with_customer_partnumber' : 'with_makemodel' -%]
           [%- SET PARAM_VAL = SELF.search_cvpartnumber -%]
           [% P.part.picker('add_item.parts_id', SELF.created_part, class="add_item_input wi-normal",
-             fat_set_item=1,
              multiple_pos_input=1,
              action={set_multi_items='kivi.Order.add_multi_items'},
              classification_id=SELF.part_picker_classification_ids.as_list.join(','),

--- a/templates/design40_webpages/reclamation/tabs/basic_data/_item_input.html
+++ b/templates/design40_webpages/reclamation/tabs/basic_data/_item_input.html
@@ -18,7 +18,6 @@
             [%- SET PARAM_KEY = SELF.cv == "customer" ? 'with_customer_partnumber' : 'with_makemodel' -%]
             [%- SET PARAM_VAL = SELF.search_cvpartnumber -%]
             [% P.part.picker('add_item.parts_id', SELF.created_part, class="add_item_input wi-normal",
-                              fat_set_item=1,
                               multiple_pos_input=1,
                               action={set_multi_items='kivi.Reclamation.add_multi_items'},
                               classification_id=SELF.part_picker_classification_ids.as_list.join(','),

--- a/templates/webpages/delivery_order/tabs/_item_input.html
+++ b/templates/webpages/delivery_order/tabs/_item_input.html
@@ -25,7 +25,6 @@
           [%- SET PARAM_KEY = SELF.type_data.properties('is_customer') ? 'with_customer_partnumber' : 'with_makemodel' -%]
           [%- SET PARAM_VAL = SELF.search_cvpartnumber -%]
           [% P.part.picker('add_item.parts_id', SELF.created_part, style='width: 300px', class="add_item_input",
-                            fat_set_item=1,
                             multiple_pos_input=1,
                             action={set_multi_items='kivi.DeliveryOrder.add_multi_items'},
                             classification_id=SELF.part_picker_classification_ids.as_list.join(','),

--- a/templates/webpages/delivery_order/tabs/_item_input.html
+++ b/templates/webpages/delivery_order/tabs/_item_input.html
@@ -32,7 +32,7 @@
                             $PARAM_KEY=PARAM_VAL) %]</td>
         <td>[% L.input_tag('add_item.description', SELF.created_part.description, class="add_item_input") %]</td>
         <td>
-          [% L.input_tag('add_item.qty_as_number', '', size = 5, class="add_item_input numeric") %]
+          [% L.input_tag('add_item.qty_as_number', '', placeholder="1", size = 5, class="add_item_input numeric") %]
           [% L.hidden_tag('add_item.unit', SELF.created_part.unit, class="add_item_input") %]
         </td>
         <td>[% L.button_tag('kivi.DeliveryOrder.add_item()', LxERP.t8('Add part')) %]</td>

--- a/templates/webpages/reclamation/tabs/basic_data/_item_input.html
+++ b/templates/webpages/reclamation/tabs/basic_data/_item_input.html
@@ -27,14 +27,13 @@
           [%- SET PARAM_KEY = SELF.cv == "customer" ? 'with_customer_partnumber' : 'with_makemodel' -%]
           [%- SET PARAM_VAL = SELF.search_cvpartnumber -%]
           [% P.part.picker('add_item.parts_id', SELF.created_part, style='width: 300px', class="add_item_input",
-                            fat_set_item=1,
                             multiple_pos_input=1,
                             action={set_multi_items='kivi.Reclamation.add_multi_items'},
                             classification_id=SELF.part_picker_classification_ids.as_list.join(','),
                             $PARAM_KEY=PARAM_VAL) %]</td>
         <td>[% L.input_tag('add_item.description', SELF.created_part.description, class="add_item_input") %]</td>
         <td>
-          [% L.input_tag('add_item.qty_as_number', '', size = 5, class="add_item_input numeric") %]
+          [% L.input_tag('add_item.qty_as_number', '', placeholder="1", size = 5, class="add_item_input numeric") %]
           [% L.hidden_tag('add_item.unit', SELF.created_part.unit, class="add_item_input") %]
         </td>
         [%- SET price = LxERP.format_amount(((SELF.type == 'sales_reclamation') ? SELF.created_part.sellprice : SELF.created_part.lastcost), -2) -%]


### PR DESCRIPTION
Die Controller, die auf dem Order-Controller basieren, sind an manchen Stellen in der Funktionsweise auseinander gelaufen. In diesem Branch habe ich ein paar Dinge wieder gerade gezogen. Dann kann man auch besser sehen, was gleich und was unterschiedlich ist, damit Code ausgelagert werden kann. Im Moment gleicht das folgende Verhalten an:
- Behandlung Texte/Übersetzungen
- Übernahme einer evtl. geänderten Beschreibung in der Eingabezeile
- Behandlung von Preis- und Rabattquellen (Übernahme der besten Preis-/Rabattquelle / Anzeige als Platzhalter)
- Preis- und Rabattquellen-Übernahme bei Aktualsieren aus Stammdaten (das fehlt noch im LS)
