### PR TITLE
"hotreload" Feature für lokale Entwicklung

### DIFF
--- a/SL/Layout/None.pm
+++ b/SL/Layout/None.pm
@@ -32,6 +32,7 @@ sub static_javascripts {
     kivi.js
   ),
   'locale/'. $::myconfig{countrycode} .'.js',
+   $::lx_office_conf{devel}->{hot_reload} ? 'hotreload.js' : (),
 }
 
 sub static_stylesheets {

--- a/config/kivitendo.conf.default
+++ b/config/kivitendo.conf.default
@@ -372,6 +372,13 @@ superuser_password =
 # database ID or its name.
 client =
 
+# Enable hot reloading. This injects client side javascript to allow for
+# automatic page reloads on changes.
+# For usage details see scripts/hotreload-server.js
+# This is meant to be used during local development only. Do not use in
+# production.
+hot_reload = 0
+
 [debug]
 # Use DBIx::Log4perl for logging DBI calls. The string LXDEBUGFILE
 # will be replaced by the file name configured for $::lxdebug.

--- a/js/hotreload.js
+++ b/js/hotreload.js
@@ -1,0 +1,28 @@
+
+const hotReloadWebSocket = new WebSocket('ws://localhost:7575');
+
+hotReloadWebSocket.onmessage = (event) => {
+  let data;
+  try {
+    data = JSON.parse(event.data);
+  } catch (error) {
+    console.error('Error parsing message:', error);
+  }
+  if (data.type === 'reload') {
+    window.location.reload();
+  } else if (data.type === 'error') {
+    alert(`${data.message}\nCheck the hot reload server output for more information.`);
+  }
+};
+
+hotReloadWebSocket.onopen = () => {
+  console.log('Connected to WebSocket server');
+};
+
+hotReloadWebSocket.onerror = (error) => {
+  console.log('Error occurred:', error);
+};
+
+hotReloadWebSocket.onclose = () => {
+  console.log('Disconnected from WebSocket server');
+};

--- a/scripts/hotreload-server.js
+++ b/scripts/hotreload-server.js
@@ -1,0 +1,137 @@
+// Hot reload server for local development
+//
+// Description: This script implements a simple web socket server that watches
+// relevant directories for changes and sends a reload signal to the connected
+// browser clients to reload the page on a change. When the change occurs in the
+// less files, it also recompiles the less files to css.
+//
+// It is intended for local development, do not use it on a production server.
+//
+// The script is written for bun. A standalone javascript runtime, see: https://bun.sh/
+//
+// Requirements:
+// - bun (tested with version 1.2.9)
+// - lessc (when working with less files)
+//
+// Usage:
+// 1) enable hot_reload in the kivitendo.conf
+//    (this injects the minimal javascript required on the client side)
+// 2) run this server script alongside your regular web server using:
+//
+//      bun run hotreload-server.js
+//
+// 3) the browser client has to be refreshed once manually in order to load the
+//    javascript and connect to the websocket server, after that the browser
+//    should automatically reload the page when a change occurred (e.g. saving a file)
+//
+// Currently the port is hard coded in the javascript client. If you want to change
+// the port, you have to change it in the client script and below. See js/hotreload.js
+//
+
+import { watch } from "fs";
+import { $ } from "bun";
+
+// only accept local connections
+const hostname = "127.0.0.1";
+const port = 7575;
+
+const pathsToWatch = [
+  '../bin',
+  '../css',
+  '../dispatcher.fcgi',
+  '../dispatcher.pl',
+  '../locale',
+  '../SL',
+  '../templates',
+  '../config',
+  '../dispatcher.fpl',
+  '../js',
+  '../t',
+];
+
+let connections = [];
+
+// returns a function that wraps the given function and calls it
+// only if the timer has expired
+const rateLimit = (fn, delay) => {
+  let timer = null;
+  return (...args) => {
+    if (timer === null) {
+      fn(...args);
+      timer = setTimeout(() => {
+        timer = null;
+      }, delay);
+    }
+  };
+};
+
+const sendMessage = (ws, message) => {
+  try {
+    ws.send(JSON.stringify(message));
+  } catch (error) {
+    console.error("Error sending error message to browser:", error);
+  }
+};
+
+const reloadCallback = async (event, filename) => {
+  connections.forEach(async ws => {
+    console.info(`Detected ${event} in ${filename}`);
+    if (filename === "design40/main.css") {
+      // avoid re-detecting changes after compiling less
+      console.info("Change in design40/main.css detected, ignoring to avoid recursive detection.");
+      return;
+    }
+    if (filename.startsWith('design40/less/')) {
+      // execute lessc compiler
+      console.info("Compiling less files.");
+      try {
+        await $`lessc -x ../css/design40/less/style.less ../css/design40/style.css`.quiet();
+      } catch (err) {
+        const errorMessage = `Error compiling less files: Failed with code ${err.exitCode}`;
+        console.error(errorMessage);
+        // NOTE: it would be nice to send the entire message to the client and display it on
+        // an error page but that would require some more work on the client
+        sendMessage(ws, { type: "error", message: errorMessage });
+        console.error(err.stdout.toString());
+        console.error(err.stderr.toString());
+        return;
+      }
+    }
+    console.info("Sending reload to web socket client (browser).");
+    sendMessage(ws, { type: "reload" });
+    ws.close()
+  });
+}
+
+pathsToWatch.forEach(path => {
+  watch(
+    path,
+    { recursive: true, },
+    rateLimit(reloadCallback, 1000),
+  );
+});
+
+Bun.serve({
+  hostname,
+  port,
+  fetch(req, server) {
+    // upgrade the request to a WebSocket
+    // (according to bun example code)
+    if (server.upgrade(req)) {
+      return; // do not return a Response
+    }
+    return new Response("Upgrade failed.", { status: 500 });
+  },
+  websocket: {
+    open(ws) {
+      console.info("Connection established.");
+      connections.push(ws);
+    },
+    close(ws) {
+      console.info("Connection closed.");
+      connections = connections.filter(conn => conn !== ws);
+    },
+  },
+});
+
+console.info("Server started, refresh kivitendo in the browser to establish a connection.");


### PR DESCRIPTION
Parallel zum regulären Webserver wird manuell ein einfacher websocket Server gestartet. Dieser überwacht relevante Verzeichnisse auf Änderungen und triggert, in Kombination mit einem minimalen Client im Browser, einen reload.

Der websocket Server ist für bun geschrieben (JavaScript), Anwendung siehe scripts/hotreload-server.js.
___

Hier noch etwas was ich schon länger mal angefangen hatte aber bis jetzt nicht dazu gekommen war es zu testen/fertigzustellen. Etwas DX für kivitendo :smile: 
Wie erwähnt ist der Server für bun geschrieben (JavaScript), aber ich denke es wäre trotzdem cool wenn das in den master könnte, da die Verwendung ja komplett optional ist. Vor allem nützlich ist es wenn man am less/css arbeitet da dieses dann auch automatisch neu gebaut wird.

PS: Ich hatte zuerst versucht das auch in perl zu schreiben aber das ist mir nicht gelungen...