### PR TITLE
Angebote, Aufträge bearbeiten: zeige Positionsnummern mit Kapitelbildung (Zwischensumme)

### DIFF
--- a/SL/DO.pm
+++ b/SL/DO.pm
@@ -1022,9 +1022,9 @@ sub order_details {
   my $i;
   my @partsgroup = ();
   my $partsgroup;
-  my $position = 0;
-  my $subtotal_header = 0;
-  my $subposition = 0;
+  my $pos_level0 = 0;
+  my $pos_level1 = 0;
+  my $subtotal_active = 0;
   my $si_position = 0;
 
   my (@project_ids);
@@ -1119,19 +1119,16 @@ sub order_details {
     $form->{"qty_$i"} = $form->parse_amount($myconfig, $form->{"qty_$i"});
 
     # add number, description and qty to $form->{number}, ....
-    if ($form->{"subtotal_$i"} && !$subtotal_header) {
-      $subtotal_header = $i;
-      $position = int($position);
-      $subposition = 0;
-      $position++;
-    } elsif ($subtotal_header) {
-      $subposition += 1;
-      $position = int($position);
-      $position = $position.".".$subposition;
+    my $position;
+    if (!$subtotal_active) {
+      $pos_level0 += 1;
+      $pos_level1  = 0;
+      $position = "$pos_level0";
     } else {
-      $position = int($position);
-      $position++;
+      $pos_level1 += 1;
+      $position = "$pos_level0.$pos_level1";
     }
+    $subtotal_active ^= $form->{"subtotal_$i"};
 
     $si_position++;
 
@@ -1153,10 +1150,6 @@ sub order_details {
     push @{ $form->{TEMPLATE_ARRAYS}{reqdate} },         $form->{"reqdate_$i"};
     push @{ $form->{TEMPLATE_ARRAYS}{projectnumber} },   $project->projectnumber;
     push @{ $form->{TEMPLATE_ARRAYS}{projectdescription} }, $project->description;
-
-    if ($form->{"subtotal_$i"} && $subtotal_header && ($subtotal_header != $i)) {
-      $subtotal_header     = 0;
-    }
 
     my $lineweight = $form->{"qty_$i"} * $form->{"weight_$i"};
     $totalweight += $lineweight;

--- a/SL/IS.pm
+++ b/SL/IS.pm
@@ -153,9 +153,9 @@ sub invoice_details {
   my $yesdiscount;
   my $nodiscount_subtotal = 0;
   my $discount_subtotal = 0;
-  my $position = 0;
-  my $subtotal_header = 0;
-  my $subposition = 0;
+  my $pos_level0 = 0;
+  my $pos_level1 = 0;
+  my $subtotal_active = 0;
 
   $form->{discount} = [];
 
@@ -276,19 +276,17 @@ sub invoice_details {
 
 
       # add number, description and qty to $form->{number},
-      if ($form->{"subtotal_$i"} && !$subtotal_header) {
-        $subtotal_header = $i;
-        $position = int($position);
-        $subposition = 0;
-        $position++;
-      } elsif ($subtotal_header) {
-        $subposition += 1;
-        $position = int($position);
-        $position = $position.".".$subposition;
+      my $position;
+      if (!$subtotal_active) {
+        $pos_level0 += 1;
+        $pos_level1  = 0;
+        $position = "$pos_level0";
       } else {
-        $position = int($position);
-        $position++;
+        $pos_level1 += 1;
+        $position = "$pos_level0.$pos_level1";
       }
+      my $subtotal_turn_off = $subtotal_active && $form->{"subtotal_$i"};
+      $subtotal_active ^= $form->{"subtotal_$i"};
 
       my $price_factor = $price_factors{$form->{"price_factor_id_$i"}} || { 'factor' => 1 };
 
@@ -368,12 +366,12 @@ sub invoice_details {
       $form->{nodiscount_total} += $nodiscount_linetotal;
       $form->{discount_total}   += $discount;
 
-      if ($subtotal_header) {
+      if ($subtotal_active) {
         $discount_subtotal   += $linetotal;
         $nodiscount_subtotal += $nodiscount_linetotal;
       }
 
-      if ($form->{"subtotal_$i"} && $subtotal_header && ($subtotal_header != $i)) {
+      if ($subtotal_turn_off) {
         push @{ $form->{TEMPLATE_ARRAYS}->{discount_sub} },         $form->format_amount($myconfig, $discount_subtotal,   2);
         push @{ $form->{TEMPLATE_ARRAYS}->{discount_sub_nofmt} },   $discount_subtotal;
         push @{ $form->{TEMPLATE_ARRAYS}->{nodiscount_sub} },       $form->format_amount($myconfig, $nodiscount_subtotal, 2);
@@ -381,7 +379,6 @@ sub invoice_details {
 
         $discount_subtotal   = 0;
         $nodiscount_subtotal = 0;
-        $subtotal_header     = 0;
 
       } else {
         push @{ $form->{TEMPLATE_ARRAYS}->{$_} }, "" for qw(discount_sub nodiscount_sub discount_sub_nofmt nodiscount_sub_nofmt);

--- a/bin/mozilla/io.pl
+++ b/bin/mozilla/io.pl
@@ -260,6 +260,9 @@ sub display_row {
   # rows
 
   my @ROWS;
+  my $pos_level0 = 0;
+  my $pos_level1 = 0;
+  my $subtotal_active = 0;
   for my $i (1 .. $numrows) {
     my %column_data = ();
 
@@ -318,10 +321,21 @@ sub display_row {
     my $linetotal      = $form->round_amount($form->{"qty_$i"} * $form->{"sellprice_$i"} * (100 - $form->{"discount_$i"}) / 100 / $price_factor, 2);
     my $rows            = $form->numtextrows($form->{"description_$i"}, 30, 6);
 
+    my $position;
+    if (!$subtotal_active) {
+      $pos_level0 += 1;
+      $pos_level1  = 0;
+      $position = "$pos_level0";
+    } else {
+      $pos_level1 += 1;
+      $position = "$pos_level0.$pos_level1";
+    }
+    $subtotal_active ^= $form->{"subtotal_$i"};
+
     # quick delete single row
     $column_data{runningnumber}  = q|<a onclick= "$('#partnumber_| . $i . q|').val(''); $('#update_button').click();">| .
                                    q|<img class="icon-delete" alt="| . $locale->text('Remove') . q|"></a> |;
-    $column_data{runningnumber} .= $cgi->textfield(-name => "runningnumber_$i", -id => "runningnumber_$i", -size => 5,  -value => $i);    # HuT
+    $column_data{runningnumber} .= $cgi->textfield(-name => "runningnumber_$i", -id => "runningnumber_$i", -size => 5,  -value => $position);    # HuT
 
 
     $column_data{partnumber}    = $cgi->textfield(-name => "partnumber_$i",    -id => "partnumber_$i",    -size => 12, -value => $form->{"partnumber_$i"});

--- a/js/kivi.Order.js
+++ b/js/kivi.Order.js
@@ -447,18 +447,18 @@ namespace('kivi.Order', function(ns) {
   };
 
   ns.renumber_positions = function() {
-    var position = 0;
-    var subposition = 0;
+    var pos_level0 = 0;
+    var pos_level1 = 0;
     var subtotal_active = 0;
     $('.row_entry').each(function(idx, elt) {
       var $div = $(elt).find('[name="position_subposition"]');
       if (!subtotal_active) {
-        position += 1;
-        subposition = 0;
-        $div.html(position);
+        pos_level0 += 1;
+        pos_level1 = 0;
+        $div.html(pos_level0);
       } else {
-        subposition += 1;
-        $div.html(position + '.' + subposition);
+        pos_level1 += 1;
+        $div.html(pos_level0 + '.' + pos_level1);
       }
       subtotal_active ^= $(elt).find('[name="subtotal[]"]').val() == 1;
     });

--- a/js/kivi.Order.js
+++ b/js/kivi.Order.js
@@ -310,6 +310,13 @@ namespace('kivi.Order', function(ns) {
     html_elt.html(price_str);
   };
 
+  ns.on_subtotal_change = function(event) {
+    $(event.target).parents('tbody.row_entry.listrow')
+      .find('[name=\"subtotal[]\"]')
+      .val(event.target.value);
+    ns.renumber_positions();
+  }
+
   ns.load_second_row = function(row) {
     var item_id_dom = $(row).find('[name="orderitem_ids[+]"]');
     var div_elt     = $(row).find('[name="second_row"]');

--- a/js/kivi.Order.js
+++ b/js/kivi.Order.js
@@ -312,7 +312,7 @@ namespace('kivi.Order', function(ns) {
 
   ns.on_subtotal_change = function(event) {
     $(event.target).parents('tbody.row_entry.listrow')
-      .find('[name=\"subtotal[]\"]')
+      .find('[name="subtotal[]"]')
       .val(event.target.value);
     ns.renumber_positions();
   }

--- a/js/kivi.Order.js
+++ b/js/kivi.Order.js
@@ -443,10 +443,29 @@ namespace('kivi.Order', function(ns) {
     $('.row_entry [name="position"]').each(function(idx, elt) {
       $(elt).html(idx+1);
     });
+    var position = 0;
+    var subtotal_header = 0;
+    var subposition = 0;
     $('.row_entry').each(function(idx, elt) {
       var $sub = $(elt).find('[name="position_subposition"]');
       var $st  = $(elt).find('[name="subtotal[]"]');
-      $sub.html("p " + idx + " s: " + $st.val());
+      if ($st.val() == 1 && !subtotal_header) {
+        subtotal_header = idx+1;
+        position = parseInt(position);
+        position += 1;
+        subposition = 0;
+      } else if (subtotal_header) {
+        subposition += 1;
+        position = parseInt(position);
+        position = position + "." + subposition;
+      } else {
+        position = parseInt(position);
+        position++;
+      }
+      $sub.html(position);
+      if ($st.val() == 1 && subtotal_header && (subtotal_header != idx+1)) {
+        subtotal_header = 0;
+      }
     });
     $('.row_entry').each(function(idx, elt) {
       $(elt).data("position", idx+1);
@@ -1049,4 +1068,5 @@ $(function() {
 
   $('.reformat_number_as_null_number').change(kivi.Order.reformat_number_as_null_number);
 
+  kivi.Order.renumber_positions();
 });

--- a/js/kivi.Order.js
+++ b/js/kivi.Order.js
@@ -447,32 +447,23 @@ namespace('kivi.Order', function(ns) {
   };
 
   ns.renumber_positions = function() {
-    $('.row_entry [name="position"]').each(function(idx, elt) {
-      $(elt).html(idx+1);
-    });
     var position = 0;
-    var subtotal_header = 0;
     var subposition = 0;
+    var subtotal_active = 0;
     $('.row_entry').each(function(idx, elt) {
-      var $sub = $(elt).find('[name="position_subposition"]');
-      var $st  = $(elt).find('[name="subtotal[]"]');
-      if ($st.val() == 1 && !subtotal_header) {
-        subtotal_header = idx+1;
-        position = parseInt(position);
+      var $div = $(elt).find('[name="position_subposition"]');
+      if (!subtotal_active) {
         position += 1;
         subposition = 0;
-      } else if (subtotal_header) {
-        subposition += 1;
-        position = parseInt(position);
-        position = position + "." + subposition;
+        $div.html(position);
       } else {
-        position = parseInt(position);
-        position++;
+        subposition += 1;
+        $div.html(position + '.' + subposition);
       }
-      $sub.html(position);
-      if ($st.val() == 1 && subtotal_header && (subtotal_header != idx+1)) {
-        subtotal_header = 0;
-      }
+      subtotal_active ^= $(elt).find('[name="subtotal[]"]').val() == 1;
+    });
+    $('.row_entry [name="position"]').each(function(idx, elt) {
+      $(elt).html(idx+1);
     });
     $('.row_entry').each(function(idx, elt) {
       $(elt).data("position", idx+1);

--- a/js/kivi.Order.js
+++ b/js/kivi.Order.js
@@ -444,6 +444,11 @@ namespace('kivi.Order', function(ns) {
       $(elt).html(idx+1);
     });
     $('.row_entry').each(function(idx, elt) {
+      var $sub = $(elt).find('[name="position_subposition"]');
+      var $st  = $(elt).find('[name="subtotal[]"]');
+      $sub.html("p " + idx + " s: " + $st.val());
+    });
+    $('.row_entry').each(function(idx, elt) {
       $(elt).data("position", idx+1);
     });
   };

--- a/js/kivi.Order.js
+++ b/js/kivi.Order.js
@@ -510,7 +510,7 @@ namespace('kivi.Order', function(ns) {
     // selection by data does not seem to work if data is changed at runtime
     // var elt = $('.row_entry [data-position="' + wanted_pos + '"]');
     $('.row_entry').each(function(idx, elt) {
-      if ($(elt).data("position") == wanted_pos) {
+      if ($(elt).find('[name="position_subposition"]').html() == wanted_pos) {
         insert_before_item_id = $(elt).find('[name="orderitem_ids[+]"]').val();
         return false;
       }

--- a/js/kivi.Order.js
+++ b/js/kivi.Order.js
@@ -447,11 +447,11 @@ namespace('kivi.Order', function(ns) {
   };
 
   ns.renumber_positions = function() {
-    var pos_level0 = 0;
-    var pos_level1 = 0;
-    var subtotal_active = 0;
+    let pos_level0 = 0;
+    let pos_level1 = 0;
+    let subtotal_active = 0;
     $('.row_entry').each(function(idx, elt) {
-      var $div = $(elt).find('[name="position_subposition"]');
+      let $div = $(elt).find('[name="position_subposition"]');
       if (!subtotal_active) {
         pos_level0 += 1;
         pos_level1 = 0;

--- a/js/kivi.Order.js
+++ b/js/kivi.Order.js
@@ -392,6 +392,10 @@ namespace('kivi.Order', function(ns) {
       $(elt).change(ns.unit_change);
     });
 
+    kivi.run_once_for('.kivi_orderjs_subtotal', 'on_change_subtotal_change', function(elt) {
+      $(elt).change(ns.on_subtotal_change);
+    });
+
     kivi.run_once_for('.row_entry', 'on_kbd_click_show_hide', function(elt) {
       $(elt).keydown(function(event) {
         var row;

--- a/templates/design40_webpages/order/tabs/_row.html
+++ b/templates/design40_webpages/order/tabs/_row.html
@@ -22,8 +22,8 @@
       [% L.hidden_tag("basket_item_ids[+]", ITEM.basket_item_id) %]
       [% L.hidden_tag("subtotal[]", ITEM.subtotal) %]
     </td>
-    <td class="center"><div name="position">[% HTML.escape(ITEM.position) %]</div></td>
-    <td><div name="position_subposition">subpos</div></td>
+    <td class="hidden"><div name="position">[% HTML.escape(ITEM.position) %]</div></td>
+    <td class="center"><div name="position_subposition"></div></td>
     <td><img src="image/updown.png" alt="[% LxERP.t8('reorder item') %]" class="dragdrop"></td>
     <td>
       [% L.button_tag("kivi.Order.delete_order_item_row(this)",

--- a/templates/design40_webpages/order/tabs/_row.html
+++ b/templates/design40_webpages/order/tabs/_row.html
@@ -20,8 +20,10 @@
       [% L.hidden_tag("order.orderitems[+].id", ITEM.id, id='item_' _ ID) %]
       [% L.hidden_tag("order.orderitems[].parts_id", ITEM.parts_id) %]
       [% L.hidden_tag("basket_item_ids[+]", ITEM.basket_item_id) %]
+      [% L.hidden_tag("subtotal[]", ITEM.subtotal) %]
     </td>
     <td class="center"><div name="position">[% HTML.escape(ITEM.position) %]</div></td>
+    <td><div name="position_subposition">subpos</div></td>
     <td><img src="image/updown.png" alt="[% LxERP.t8('reorder item') %]" class="dragdrop"></td>
     <td>
       [% L.button_tag("kivi.Order.delete_order_item_row(this)",

--- a/templates/design40_webpages/order/tabs/_row.html
+++ b/templates/design40_webpages/order/tabs/_row.html
@@ -23,7 +23,7 @@
       [% L.hidden_tag("subtotal[]", ITEM.subtotal) %]
     </td>
     <td class="hidden"><div name="position">[% HTML.escape(ITEM.position) %]</div></td>
-    <td class="center"><div name="position_subposition"></div></td>
+    <td class="numeric"><div name="position_subposition"></div></td>
     <td><img src="image/updown.png" alt="[% LxERP.t8('reorder item') %]" class="dragdrop"></td>
     <td>
       [% L.button_tag("kivi.Order.delete_order_item_row(this)",

--- a/templates/design40_webpages/order/tabs/_second_row.html
+++ b/templates/design40_webpages/order/tabs/_second_row.html
@@ -14,7 +14,7 @@
       [% IF (TYPE == "sales_order_intake" || TYPE == "sales_order" || TYPE == "purchase_order" || TYPE == "purchase_order_confirmation") %]
         <b>[% 'Reqdate' | $T8 %]</b> [% L.date_tag("order.orderitems[].reqdate_as_date", ITEM.reqdate_as_date) %]
       [% END %]
-      <b>[% 'Subtotal' | $T8 %]</b> [% L.yes_no_tag("order.orderitems[].subtotal", ITEM.subtotal) %]
+      <b>[% 'Subtotal' | $T8 %]</b> [% L.yes_no_tag("order.orderitems[].subtotal", ITEM.subtotal, onchange="kivi.Order.on_subtotal_change(event)") %]
       [% IF TYPE == "sales_order" %]
         <b>[% 'Recurring billing' | $T8 %]</b>
         [% L.select_tag("order.orderitems[].recurring_billing_mode", [[ 'always', LxERP.t8('always') ], [ 'once',   LxERP.t8('once')   ], [ 'never',  LxERP.t8('never')  ]], default=ITEM.recurring_billing_mode) %]

--- a/templates/design40_webpages/order/tabs/_second_row.html
+++ b/templates/design40_webpages/order/tabs/_second_row.html
@@ -14,7 +14,7 @@
       [% IF (TYPE == "sales_order_intake" || TYPE == "sales_order" || TYPE == "purchase_order" || TYPE == "purchase_order_confirmation") %]
         <b>[% 'Reqdate' | $T8 %]</b> [% L.date_tag("order.orderitems[].reqdate_as_date", ITEM.reqdate_as_date) %]
       [% END %]
-      <b>[% 'Subtotal' | $T8 %]</b> [% L.yes_no_tag("order.orderitems[].subtotal", ITEM.subtotal, onchange="kivi.Order.on_subtotal_change(event)") %]
+      <b>[% 'Subtotal' | $T8 %]</b> [% L.yes_no_tag("order.orderitems[].subtotal", ITEM.subtotal, class="kivi_orderjs_subtotal") %]
       [% IF TYPE == "sales_order" %]
         <b>[% 'Recurring billing' | $T8 %]</b>
         [% L.select_tag("order.orderitems[].recurring_billing_mode", [[ 'always', LxERP.t8('always') ], [ 'once',   LxERP.t8('once')   ], [ 'never',  LxERP.t8('never')  ]], default=ITEM.recurring_billing_mode) %]


### PR DESCRIPTION
Diese Änderung bewirkt, dass beim Bearbeiten von Aufträgen in der Positionstabelle anstelle der Nummerierung von 1 bis n die Positionen wie im Ausdruck nummeriert werden. Der Unterschied wird sichtbar, sobald Zwischensummen verwendet werden. (Start/Stopp des Unterkapitels) Die Nummerierung wird aktualisiert, sobald die Einstellung der Zwischensumme an einer Position geändert wird.
Ebenso orientiert sich das "Artikel einfügen über Pos." an der Nummerierung mit Kapitelbildung.

Hier zur Illustration:
![image](https://github.com/user-attachments/assets/f5414f29-c961-4d0e-b4a0-ea122106c206)

getestet (nur mit design 4.0):
- Nummerierung wird in Angeboten, Aufträgen angezeigt wie im PDF-Ausdruck via LaTeX
- Artikel hinzufügen über Pos. klappt
- Umordnen der Artikel per drag-and-drop klappt

Mir ist nicht klar:
- Gibt es bei der Nummerierung Wechselwirkungen mit Sortimenten oder Erzeugnissen?