### PR TITLE
Lösche Bemerkungen beim Workflow Lieferantenanfrage/-auftrag von VK zu EK

### DIFF
--- a/SL/Controller/Order.pm
+++ b/SL/Controller/Order.pm
@@ -926,6 +926,8 @@ sub action_order_workflow {
   }
 
   if ($from_side eq 'sales' && $to_side eq 'purchase') {
+    $self->order->notes('');
+    $self->order->intnotes('');
     if ($::form->{use_shipto}) {
       $self->order->custom_shipto($custom_shipto) if $custom_shipto;
     } else {

--- a/SL/Controller/Order.pm
+++ b/SL/Controller/Order.pm
@@ -927,7 +927,6 @@ sub action_order_workflow {
 
   if ($from_side eq 'sales' && $to_side eq 'purchase') {
     $self->order->notes('');
-    $self->order->intnotes('');
     if ($::form->{use_shipto}) {
       $self->order->custom_shipto($custom_shipto) if $custom_shipto;
     } else {


### PR DESCRIPTION
Grund: Im Verkaufsbeleg können in den Bemerkungen Dinge stehen, welche den Lieferanten im Einkauf nichts angehen oder verwirren. Daher sollen die Bemerkungen beim Erzeugen eines EK-Beleges aus einem VK-Beleg nicht übernommen werden.

Ich habe das nun für die Bemerkungen und die internen Bemerkungen gemacht.