### PR TITLE
SEPA-Bankeinzüge: Sequenz-Typ RCUR nutzen

### DIFF
--- a/SL/SEPA/XML.pm
+++ b/SL/SEPA/XML.pm
@@ -246,7 +246,7 @@ sub to_xml {
       $xml->startTag('LclInstrm');
       $xml->dataElement('Cd', 'CORE');
       $xml->endTag('LclInstrm');
-      $xml->dataElement('SeqTp', 'OOFF');
+      $xml->dataElement('SeqTp', 'RCUR');
     }
     $xml->endTag('PmtTpInf');
 


### PR DESCRIPTION
Der Sequenztyp `OOFF` = `one-off` ist nur für Mandate gedacht, die nur eine einzige Verwendung, nur einen einzigen Einzug zulassen. Für mehrfach verwendbare Mandate gibt es hingegen die Sequenztypen `FRST` = `first` (für erstmalige Verwendung), `RCUR` = `recurring` (für folgende Verwendungen) und `FNAL` = `final` (letzte Verwendung).

Der SEPA-Standard erlaubt explizit die Verwendung von `RCUR` auch für die allererste Verwendung. Daher nutzen wir in kivitendo ausschließlich `RCUR` & tracken nicht, ob ein Mandat schon verwendet wurde.