### PR TITLE
design4.0: Preisliste (Kunden/Lieferanten): setze CSS wrapper

### DIFF
--- a/templates/design40_webpages/customer_vendor/tabs/price_list.html
+++ b/templates/design40_webpages/customer_vendor/tabs/price_list.html
@@ -3,8 +3,6 @@
 [% USE HTML %]
 [% USE L %]
 
-<div id="price_list">
-<div class="wrapper">
+<div class="wrapper" id="price_list">
   [%- LxERP.t8("Loading...") %]
-</div><!-- /.wrapper -->
 </div><!-- /#price_list -->


### PR DESCRIPTION
Zuvor wurde das `<div class="wrapper">` in js/kivi.CustomerVendor.js entfernt beim Nachladen der Daten. Dies hatte zur Folge, dass der seitliche Abstand, den der Wrapper bewirkt, bei der Preisliste fehlte.
Hier die relevante stelle aus js/kivi.CustomerVendor.js:

```
  if (ui.newPanel.attr('id') == 'price_list') {
    ns.get_price_report('#price_list',
      "controller.pl?action=CustomerVendor/ajax_list_prices&id="
      + $('#cv_id').val() + "&db=" + $('#db').val()
      + "&callback=" + $('#callback').val());
  }
```

Repariert mit diesem Commit:
![grafik](https://github.com/user-attachments/assets/74a263de-f4eb-40e4-bf8c-363ca3ded41d)

Zuvor sah es so aus:
![grafik](https://github.com/user-attachments/assets/af9c2fc1-c47e-4ad1-ba18-31e3d6529642)
