### PR TITLE
Absatz mit pg_createcluster ist veraltet?

### DIFF
--- a/doc/dokumentation.xml
+++ b/doc/dokumentation.xml
@@ -1005,36 +1005,6 @@ default_manager = german</programlisting>
               <para><ulink url="https://de.opensuse.org/PostgreSQL">OpenSuSE (aktuell nur bis Version OpenSuSE 13 verifiziert)</ulink></para>
             </listitem>
           </itemizedlist>
-      <sect2 id="Zeichensätze-die-Verwendung-von-UTF-8">
-        <title>Zeichensätze/die Verwendung von Unicode/UTF-8</title>
-
-        <para>kivitendo setzt zwingend voraus, dass die Datenbank
-        Unicode/UTF-8 als Encoding einsetzt. Bei aktuellen
-        Serverinstallationen braucht man hier meist nicht einzugreifen.</para>
-
-        <para>Das Encoding des Datenbankservers kann überprüft werden. Ist das
-        Encoding der Datenbank "template1" "Unicode" bzw. "UTF-8", so braucht
-        man nichts weiteres diesbezüglich unternehmen. Zum Testen:</para>
-
-        <programlisting>su postgres
-echo '\l' | psql
-exit </programlisting>
-
-        <para>Andernfalls ist es notwendig, einen neuen Datenbankcluster mit
-        Unicode-Encoding anzulegen und diesen zu verwenden. Unter Debian und
-        Ubuntu kann dies z.B. für PostgreSQL 9.3 mit dem folgenden Befehl
-        getan werden:</para>
-
-        <programlisting>pg_createcluster --locale=de_DE.UTF-8 --encoding=UTF-8 9.3 clustername</programlisting>
-
-        <para>Die Datenbankversionsnummer muss an die tatsächlich verwendete
-        Versionsnummer angepasst werden.</para>
-
-        <para>Unter anderen Distributionen gibt es ähnliche Methoden.</para>
-
-        <para>Das Encoding einer Datenbank kann in <command>psql</command> mit
-        <literal>\l</literal> geprüft werden.</para>
-      </sect2>
 
       <sect2 id="Änderungen-an-Konfigurationsdateien">
         <title>Änderungen an Konfigurationsdateien</title>


### PR DESCRIPTION
Wie im Austausch mit Niklas besprochen ein PR zur Doku. Mein Vorschlag ist, den ganzen Absatz zu entfernen. Zum einen kann auf Systemen, auf denen eine Neuinstallation von Kivitendo zu erwarten ist, heutzutage davon ausgegangen werden, dass UTF8 zum Enkodieren benutzt wird. Der gegenteilige Fall ist zum Anderen nicht besonders gut beschrieben.

* `--locale` funktioniert nicht auf jedem System einfach so; wurden die locales nicht generiert, dann bricht pg_createcluster ab, und meiner Erinnerung nach war nicht so offensichtlich, warum
* `pg_createcluster` ist ein distrospezifischer Wrapper um initdb
* andere locales als C und en_US (oder vielleicht auch andere en_*) werfen bei meinen Installationen im Betrieb jede Menge Warnungen `WARNING:  could not determine encoding for locale "de_DE.UTF-8": codeset is "ANSI_X3.4-1968"`. It is right there in the name! `--encoding` ist in diesem Fall notwendig, damit das Kommande akzeptiert wird (jedenfalls mit dem default `--locale-provider=libc`, ìcu`kann nur UTF8), gegen die Empfehlung der manpage, mit `en_US` dagegen nicht. Diese Warnung kommt sowohl mehrfach in der Minute im Hintergrund, bevor irgendwas auch nur in die Datenbank geschrieben wird, aber auch im stderr von `psql`. Selbst, wenn die locales generiert werden, bevor Postgres installiert wird. Ich habe nicht herausgefunden, welche Konsequenzen folgen, aber es ist eine Warnung.
* vielleicht war `9.3` bei Version 9.3 korrekt, aber heutzutage ist es lediglich die major version
* der Hinweis zu `\l` kam zweimal vor

Wenn wir diesen Absatz nicht ersatzlos streichen wollen, dann kann ich ihn so umschreiben, dass er hoffentlich weniger Verwirrung stiftet. Vielleicht bietet sich der Hinweis and, dass man einen eigenen Cluster verwenden kann, aber dann im Wesentlichen auf die Doku von postgres zu verweisen.
