### PR TITLE
2025 zugferd export gln ean 2

### DIFF
--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -434,7 +434,7 @@ sub _payment_terms {
     #       <ram:ApplicableTradePaymentDiscountTerms>
     $params{xml}->startTag("ram:ApplicableTradePaymentDiscountTerms");
     $params{xml}->dataElement("ram:BasisPeriodMeasure", $self->payment_terms->terms_skonto, unitCode => "DAY");
-    $params{xml}->dataElement("ram:BasisAmount",        _r2($payment_terms_vars{amounts}->{invtotal}), currencyID => $currency_id);
+    $params{xml}->dataElement("ram:BasisAmount",        _r2($payment_terms_vars{amounts}->{invtotal}));
     $params{xml}->dataElement("ram:CalculationPercent", _r2($self->payment_terms->percent_skonto * 100));
     $params{xml}->endTag;
     #       </ram:ApplicableTradePaymentDiscountTerms>

--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -560,12 +560,13 @@ sub _seller_trade_party {
   $params{xml}->startTag("ram:SellerTradeParty");
   # 0088 = GLN, 0060 = D-U-N-S, only one ID is allowed
   if ($self->customer->c_vendor_id) {
-    $params{xml}->dataElement("ram:ID",   _u8($self->customer->c_vendor_id));
+    $params{xml}->dataElement("ram:ID", _u8($self->customer->c_vendor_id));
   } elsif($::instance_conf->get_gln) {
     $params{xml}->dataElement("ram:ID", _u8($::instance_conf->get_gln), schemeID => '0088');
   } elsif($::instance_conf->get_duns) {
     $params{xml}->dataElement("ram:ID", _u8($::instance_conf->get_duns), schemeID => '0060');
   } else {
+    # no sensible default yet
   }
   $params{xml}->dataElement("ram:Name", _u8($::instance_conf->get_company));
 


### PR DESCRIPTION
Neue Version vom GLN/EAN Export, diesmal CIUS kompatibel.

- GLN jetzt in ram:ID von Seller/BuyerTradeParty (statt Customernumber und Leitwegid)
- EAN jetzt im ram:SellerAssignedID (statt Partnumber)

Es ist sehr schade, dass CIUS die dafür vorgesehenen Felder nicht akzeptiert. Wenn wir das doch nochmal brauchen, müssen wir dafür ein neuen Profil aufmachen.

Zusätzlich habe ich auch noch die currencyId aus ram:ApplicableTradePaymentDiscountTerms entfernt, die wurde auch noch angemeckert.