### PR TITLE
S:H:UserPreferences:PositionsScrollbar: Höhe = 0 für neu angelegte Nutzer setzen

### DIFF
--- a/SL/Helper/UserPreferences/PositionsScrollbar.pm
+++ b/SL/Helper/UserPreferences/PositionsScrollbar.pm
@@ -14,7 +14,7 @@ use Rose::Object::MakeMethods::Generic (
 
 sub get_height {
   my $value = $_[0]->user_prefs->get('height');
-  return !defined($value) ? 25 : $value;
+  return !defined($value) ? 0 : $value;
 }
 
 sub store_height {


### PR DESCRIPTION
Der vorherige Wert Höhe = 25% war willkürlich gewählt. Es zeigt sich, dass in den meisten Fällen keine Scrollbar am ergonomischsten ist. Daher sollen neue Nutzer den Wert 0 erhalten.