### PR TITLE
Fertigen eines Erzeugnisses ohne Artikel abfangen

### DIFF
--- a/bin/mozilla/wh.pl
+++ b/bin/mozilla/wh.pl
@@ -395,6 +395,8 @@ sub create_assembly {
   $bin = SL::DB::Manager::Bin->find_by(id => $form->{bin_id});
   $form->show_generic_error($locale->text('Invalid bin')) unless ref $bin eq 'SL::DB::Bin';
 
+  $form->show_generic_error($locale->text('The assembly doesn\'t have any items.')) unless (scalar @{$assembly->assemblies});
+
   if (!$::instance_conf->get_show_bestbefore) {
     $form->{bestbefore} = '';
   }


### PR DESCRIPTION
Erzeugnisse ohne Artikel können beim CSV Import entstehen. Für sie liefert der Schritt "Erzeugnis fertigen" nun eine für Anwender verständliche Fehlermeldung.