### PR TITLE
Artikelbericht: Buchungsgruppe zur Anzeige auswählbar anbieten

### DIFF
--- a/SL/IC.pm
+++ b/SL/IC.pm
@@ -201,34 +201,34 @@ sub all_parts {
 
   my %joins = (
     bookinggroup => 'LEFT JOIN buchungsgruppen bg ON (p.buchungsgruppen_id = bg.id)',
-    partsgroup => 'LEFT JOIN partsgroup pg      ON (pg.id       = p.partsgroup_id)',
-    makemodel  => "LEFT JOIN LATERAL (
-                      SELECT string_agg(mv.vendornumber || ' ' || mv.name, ', ') AS make,
-                             string_agg(mm.model, ', ')                          AS model
-                        FROM makemodel mm
-                             LEFT JOIN vendor mv ON (mv.id = mm.make)
-                      WHERE  mm.parts_id = p.id
-                   ) mm ON TRUE",
-    pfac       => 'LEFT JOIN price_factors pfac ON (pfac.id     = p.price_factor_id)',
-    invoice_oi =>
+    partsgroup   => 'LEFT JOIN partsgroup pg      ON (pg.id       = p.partsgroup_id)',
+    makemodel    => "LEFT JOIN LATERAL (
+                        SELECT string_agg(mv.vendornumber || ' ' || mv.name, ', ') AS make,
+                               string_agg(mm.model, ', ')                          AS model
+                          FROM makemodel mm
+                               LEFT JOIN vendor mv ON (mv.id = mm.make)
+                        WHERE  mm.parts_id = p.id
+                     ) mm ON TRUE",
+    pfac         => 'LEFT JOIN price_factors pfac ON (pfac.id     = p.price_factor_id)',
+    invoice_oi   =>
       q|LEFT JOIN (
          SELECT parts_id, description, serialnumber, trans_id, unit, sellprice, qty,          assemblyitem,         deliverydate, 'invoice'    AS ioi, project_id, id FROM invoice UNION
          SELECT parts_id, description, serialnumber, trans_id, unit, sellprice, qty, FALSE AS assemblyitem, NULL AS deliverydate, 'orderitems' AS ioi, project_id, id FROM orderitems
        ) AS ioi ON ioi.parts_id = p.id|,
-    apoe       =>
+    apoe         =>
       q|LEFT JOIN (
          SELECT id, transdate, 'ir' AS module, ordnumber, quonumber,         invnumber, 'purchase_invoice' AS record_type, NULL AS customer_id,         vendor_id,    NULL AS deliverydate, globalproject_id, 'invoice'    AS ioi FROM ap UNION
          SELECT id, transdate, 'is' AS module, ordnumber, quonumber,         invnumber, 'sales_invoice'    AS record_type,         customer_id, NULL AS vendor_id,            deliverydate, globalproject_id, 'invoice'    AS ioi FROM ar UNION
          SELECT id, transdate, 'oe' AS module, ordnumber, quonumber, NULL AS invnumber,                       record_type::text,   customer_id,         vendor_id, reqdate AS deliverydate, globalproject_id, 'orderitems' AS ioi FROM oe
        ) AS apoe ON ((ioi.trans_id = apoe.id) AND (ioi.ioi = apoe.ioi))|,
-    cv         =>
+    cv           =>
       q|LEFT JOIN (
            SELECT id, name, 'customer' AS cv FROM customer UNION
            SELECT id, name, 'vendor'   AS cv FROM vendor
          ) AS cv ON cv.id = apoe.customer_id OR cv.id = apoe.vendor_id|,
-    project    => 'LEFT JOIN project AS pj ON pj.id = COALESCE(ioi.project_id, apoe.globalproject_id)',
-    warehouse  => 'LEFT JOIN warehouse AS wh ON wh.id = p.warehouse_id',
-    bin        => 'LEFT JOIN bin ON bin.id = p.bin_id',
+    project      => 'LEFT JOIN project AS pj ON pj.id = COALESCE(ioi.project_id, apoe.globalproject_id)',
+    warehouse    => 'LEFT JOIN warehouse AS wh ON wh.id = p.warehouse_id',
+    bin          => 'LEFT JOIN bin ON bin.id = p.bin_id',
   );
   my @join_order = qw(bookinggroup partsgroup makemodel invoice_oi apoe cv pfac project warehouse bin);
 
@@ -455,15 +455,15 @@ sub all_parts {
   push @where_tokens, join ' OR ', map { "($_)" } @bsooqr_tokens              if $bsooqr;
 
   $joins_needed{bookinggroup} = 1 if $form->{l_bookinggroup};
-  $joins_needed{partsgroup}  = 1;
-  $joins_needed{pfac}        = 1;
-  $joins_needed{project}     = 1 if grep { $form->{$_} || $form->{"l_$_"} } @project_filters;
-  $joins_needed{makemodel}   = 1 if grep { $form->{$_} || $form->{"l_$_"} } @makemodel_filters;
-  $joins_needed{cv}          = 1 if $bsooqr;
-  $joins_needed{apoe}        = 1 if $joins_needed{project} || $joins_needed{cv}   || grep { $form->{$_} || $form->{"l_$_"} } @apoe_filters;
-  $joins_needed{invoice_oi}  = 1 if $joins_needed{project} || $joins_needed{apoe} || grep { $form->{$_} || $form->{"l_$_"} } @invoice_oi_filters;
-  $joins_needed{bin}         = 1 if $form->{l_bin};
-  $joins_needed{warehouse}   = 1 if $form->{l_warehouse};
+  $joins_needed{partsgroup}   = 1;
+  $joins_needed{pfac}         = 1;
+  $joins_needed{project}      = 1 if grep { $form->{$_} || $form->{"l_$_"} } @project_filters;
+  $joins_needed{makemodel}    = 1 if grep { $form->{$_} || $form->{"l_$_"} } @makemodel_filters;
+  $joins_needed{cv}           = 1 if $bsooqr;
+  $joins_needed{apoe}         = 1 if $joins_needed{project} || $joins_needed{cv}   || grep { $form->{$_} || $form->{"l_$_"} } @apoe_filters;
+  $joins_needed{invoice_oi}   = 1 if $joins_needed{project} || $joins_needed{apoe} || grep { $form->{$_} || $form->{"l_$_"} } @invoice_oi_filters;
+  $joins_needed{bin}          = 1 if $form->{l_bin};
+  $joins_needed{warehouse}    = 1 if $form->{l_warehouse};
 
   # special case for description search.
   # up in the simple filter section the description filter got interpreted as something like: WHERE description ILIKE '%$form->{description}%'

--- a/bin/mozilla/ic.pl
+++ b/bin/mozilla/ic.pl
@@ -151,7 +151,7 @@ sub top100 {
 #  bought sold onorder ordered rfq quoted
 #  l_partnumber l_description l_serialnumber l_unit l_listprice l_sellprice l_lastcost
 #  l_linetotal l_priceupdate l_bin l_rop l_weight l_image l_drawing l_microfiche
-#  l_partsgroup l_subtotal l_soldtotal l_deliverydate l_pricegroups
+#  l_partsgroup l_subtotal l_soldtotal l_deliverydate l_pricegroup l_bookinggroup
 #
 # hiddens:
 #  nextsub revers lastsort sort ndxs_counter
@@ -208,6 +208,7 @@ sub generate_report {
     'make'               => { 'text' => $locale->text('Make'), },
     'model'              => { 'text' => $locale->text('Model'), },
     'price_factor_description' => { 'text' => $locale->text('Price Factor'), },
+    'bookinggroup'       => { 'text' => $locale->text('Booking group'), },
   );
 
   $revers     = $form->{revers};
@@ -397,7 +398,7 @@ sub generate_report {
     linetotallistprice sellprice linetotalsellprice lastcost assembly_lastcost linetotallastcost
     priceupdate weight image drawing microfiche invnumber ordnumber quonumber
     transdate name serialnumber deliverydate ean projectnumber projectdescription
-    insertdate shop
+    insertdate shop bookinggroup
   );
 
   my $pricegroups = SL::DB::Manager::Pricegroup->get_all_sorted;
@@ -422,7 +423,7 @@ sub generate_report {
 
   %column_defs = (%column_defs, %column_defs_cvars, %column_defs_pricegroups);
   map { $column_defs{$_}->{visible} ||= $form->{"l_$_"} ? 1 : 0 } @columns;
-  map { $column_defs{$_}->{align}   = 'right' } qw(assembly_qty onhand sellprice listprice lastcost assembly_lastcost linetotalsellprice linetotallastcost linetotallistprice rop weight soldtotal shop price_factor_description), @pricegroup_columns;
+  map { $column_defs{$_}->{align}   = 'right' } qw(assembly_qty onhand sellprice listprice lastcost assembly_lastcost linetotalsellprice linetotallastcost linetotallistprice rop weight soldtotal shop price_factor_description bookinggroup), @pricegroup_columns;
 
   my @hidden_variables = (
     qw(l_subtotal l_linetotal searchitems itemstatus bom l_pricegroups insertdatefrom insertdateto),

--- a/templates/design40_webpages/ic/search.html
+++ b/templates/design40_webpages/ic/search.html
@@ -189,6 +189,7 @@
     <p>[% L.checkbox_tag('l_linetotal', label=LxERP.t8('Line Total'), value='Y', checked=1) %]</p>
     <p>[% L.checkbox_tag('l_pricegroups', label=LxERP.t8('Pricegroups'), value='Y', checked=1) %]</p>
     <p>[% L.checkbox_tag('l_price_factor_description', label=LxERP.t8('Price Factor'), value='Y') %]</p>
+    <p>[% L.checkbox_tag('l_bookinggroup', label=LxERP.t8('Booking group'), value='Y') %]</p>
   </div>
 
   <div class="col list">


### PR DESCRIPTION
Diese Änderung erlaubt, im Artikelbericht auch die Buchungsgruppe auszugeben.

Ein Kunde verwendet dies, um per PDF-Export aus dem Artikelbericht eine Preisliste für seine Kunden zu erzeugen, welche die Umsatzsteuerklasse (7% / 19%) beinhaltet. Zusammen mit der bereits vorhandenen Filterfunktionalität ist dies recht flexibel einsetzbar.

Ergebnis im Bericht:
<img width="174" height="192" alt="image" src="https://github.com/user-attachments/assets/70398dfb-4e77-405c-840d-01f64559e48d" />
