### PR TITLE
Artikelbericht Design 4.0 CSS div .wrapper hinzugefügt

### DIFF
--- a/bin/mozilla/ct.pl
+++ b/bin/mozilla/ct.pl
@@ -300,7 +300,7 @@ sub list_names {
 
   my $report = SL::ReportGenerator->new(\%myconfig, $form);
 
-  $report->set_options('top_info_text'         => join("\n", @options),
+  $report->set_options('raw_top_info_text'     => $form->parse_html_template('ct/list_names_top', { options => \@options }),
                        'raw_bottom_info_text'  => $form->parse_html_template('ct/list_names_bottom'),
                        'output_format'         => 'HTML',
                        'title'                 => $form->{title},

--- a/templates/design40_webpages/ct/list_names_bottom.html
+++ b/templates/design40_webpages/ct/list_names_bottom.html
@@ -5,3 +5,5 @@
   <input name="callback" type="hidden" value="[% HTML.escape(callback) %]">
   <input name="db" type="hidden" value="[% HTML.escape(db) %]">
 </form>
+
+</div><!-- wrapper -->

--- a/templates/design40_webpages/ct/list_names_top.html
+++ b/templates/design40_webpages/ct/list_names_top.html
@@ -1,0 +1,6 @@
+[% USE HTML %]
+[% USE T8 %]
+[% USE L %]
+
+<div class="wrapper">
+[% 'Options' | $T8 %]: [% FOREACH o = options %][% HTML.escape(o) %]<br>[% END %]

--- a/templates/design40_webpages/ic/generate_report_bottom.html
+++ b/templates/design40_webpages/ic/generate_report_bottom.html
@@ -50,6 +50,7 @@
 </table>
 
 </div>
+</div><!-- wrapper -->
 
 <form method="post" action="controller.pl" id="new_form">
  <input name="callback" type="hidden" value="[% HTML.escape(callback) %]">

--- a/templates/design40_webpages/ic/generate_report_top.html
+++ b/templates/design40_webpages/ic/generate_report_top.html
@@ -2,4 +2,5 @@
 [% USE T8 %]
 [% USE L %]
 
+<div class="wrapper">
 [% 'Options' | $T8 %]: [% options.join(', ') %]


### PR DESCRIPTION
Ohne diese Änderung sah es so aus:
<img width="461" height="189" alt="image" src="https://github.com/user-attachments/assets/7b13664c-d295-47c0-8ff7-5bff33b78cd5" />

Mit dieser Änderung stimmt der Seitenabstand:
<img width="456" height="228" alt="image" src="https://github.com/user-attachments/assets/647ce127-5b91-4e13-b101-7fe14bc1adcd" />

Ebenso betroffen von diesem Problem war der Kunden-Bericht. Hier habe ich darauf geachtet, die bisherige Formatierung mit Zeilenumbrüchen für die Optionen beizubehalten:
<img width="247" height="142" alt="image" src="https://github.com/user-attachments/assets/a056aa87-1d06-4995-ba92-eadb781d46ac" />
