### PR TITLE
fix Lieferschein Auslagern mit MHD (Typo bestbefore)

### DIFF
--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1741,7 +1741,7 @@ sub make_item {
 
       # assign attributes
       $obj->$_($line->{$_}) for qw(bin_id warehouse_id chargenumber qty unit);
-      $obj->bestbefore_as_date($line->{bestfbefore})
+      $obj->bestbefore_as_date($line->{bestbefore})
         if $line->{bestbefore} && $::instance_conf->get_show_bestbefore;
       push @save, $obj if $obj->qty;
     }


### PR DESCRIPTION
Aufgrund eines Schreibfehlers einer Variablen wurde bei in der Mandantenkonfig angeschalteten Mindesthaltbarkeitsdaten das Auslagern von Lieferscheinen nicht erlaubt.