### PR TITLE
fix Erzeugnis fertigen, Verbraucht mit bestbefore auslagern, sonst negative doppelte Lagerposten

### DIFF
--- a/SL/Helper/Inventory.pm
+++ b/SL/Helper/Inventory.pm
@@ -368,6 +368,7 @@ sub produce_assembly {
       qty          => -$allocation->qty,
       trans_type   => $trans_type_out,
       shippingdate => $shippingdate,
+      bestbefore   => $allocation->bestbefore,
       employee     => SL::DB::Manager::Employee->current,
       comment      => t8('Used for assembly #1 #2', $part->partnumber, $part->description),
     );


### PR DESCRIPTION
Bisher wurde das Mindesthaltbarkeitsdatum der im Schritt "Erzeugnis fertigen" aus dem Lager ausgebuchten Artikel nicht berücksichtigt.
Anstelle der um die beim fertigen benötigte Menge verringerten Bestand wurden daher im Lager negative Bestände angezeigt, wenn Erzeugnisse aus Artikel gefertigt wurden, welche selbst mit MHD eingelagert wurden.


Selbst habe ich getestet, dass das so auch bei in der Mandantenkonfig abgeschaltetem MHD funktioniert, um Erzeugnisse zu fertigen.