### PR TITLE
js/ImageUpload: fix: dataType Parameter

### DIFF
--- a/js/kivi.ImageUpload.js
+++ b/js/kivi.ImageUpload.js
@@ -139,7 +139,7 @@ namespace("kivi.ImageUpload", function(ns) {
         object_type: obj_type,
         object_number: number
       },
-      type: "json",
+      dataType: "json",
       success: (json) => {
         if (json.error) {
           $("#object_description").html("");


### PR DESCRIPTION
Da statt POST json übergeben wurde, antwortete der Lighttpd Webserver mit 501 Not Implemented, anstelle den Request an den Controller zu senden.