### PR TITLE
"neue" Belegmasken: erste Zeile der "2. Zeile" über die ganze Breite …

### DIFF
--- a/templates/design40_webpages/delivery_order/tabs/_second_row.html
+++ b/templates/design40_webpages/delivery_order/tabs/_second_row.html
@@ -5,7 +5,7 @@
 [%- USE P %]
 
 <table>
-  <tr><td>
+  <tr><td colspan="100%">
     <b>[%- 'Serial No.' | $T8 %]</b>&nbsp;
     [%- L.input_tag("order.orderitems[].serialnumber", ITEM.serialnumber, size = 15 "data-validate"="trimmed_whitespaces") %]&nbsp;
     <b>[%- 'Project' | $T8 %]</b>&nbsp;

--- a/templates/design40_webpages/delivery_order/tabs/_second_row.html
+++ b/templates/design40_webpages/delivery_order/tabs/_second_row.html
@@ -4,8 +4,9 @@
 [%- USE L %]
 [%- USE P %]
 
+[% SET maxcols = (MYCONFIG.form_cvars_nr_cols || 3) %]
 <table>
-  <tr><td colspan="100%">
+  <tr><td colspan="[% maxcols %]">
     <b>[%- 'Serial No.' | $T8 %]</b>&nbsp;
     [%- L.input_tag("order.orderitems[].serialnumber", ITEM.serialnumber, size = 15 "data-validate"="trimmed_whitespaces") %]&nbsp;
     <b>[%- 'Project' | $T8 %]</b>&nbsp;
@@ -34,7 +35,7 @@
       [% L.hidden_tag('order.orderitems[].custom_variables[].sub_module', var.sub_module) %]
       [% INCLUDE 'common/render_cvar_input.html' var_name='order.orderitems[].custom_variables[].unparsed_value' %]
     </td>
-    [%- IF (n % (MYCONFIG.form_cvars_nr_cols || 3)) == 0 %]
+    [%- IF (n % maxcols) == 0 %]
 
   </tr><tr>
     [%- END %]

--- a/templates/design40_webpages/order/tabs/_second_row.html
+++ b/templates/design40_webpages/order/tabs/_second_row.html
@@ -6,7 +6,7 @@
 
 <table>
   <tr>
-    <td>
+    <td colspan="100%">
       [% IF (TYPE == "sales_order_intake" || TYPE == "sales_order" || TYPE == "purchase_order" || TYPE == "purchase_order_confirmation") %]
         <b>[% 'Serial No.' | $T8 %]</b> [% L.input_tag("order.orderitems[].serialnumber", ITEM.serialnumber, size = 15, "data-validate"="trimmed_whitespaces") %]
       [% END %]

--- a/templates/design40_webpages/order/tabs/_second_row.html
+++ b/templates/design40_webpages/order/tabs/_second_row.html
@@ -4,9 +4,10 @@
 [% USE L %]
 [% USE P %]
 
+[% SET maxcols = (MYCONFIG.form_cvars_nr_cols || 3) %]
 <table>
   <tr>
-    <td colspan="100%">
+    <td colspan="[% maxcols %]">
       [% IF (TYPE == "sales_order_intake" || TYPE == "sales_order" || TYPE == "purchase_order" || TYPE == "purchase_order_confirmation") %]
         <b>[% 'Serial No.' | $T8 %]</b> [% L.input_tag("order.orderitems[].serialnumber", ITEM.serialnumber, size = 15, "data-validate"="trimmed_whitespaces") %]
       [% END %]
@@ -56,7 +57,7 @@
         [% L.hidden_tag('order.orderitems[].custom_variables[].sub_module', var.sub_module) %]
         [% INCLUDE 'common/render_cvar_input.html' var_name='order.orderitems[].custom_variables[].unparsed_value' %]
       </td>
-      [% IF (n % (MYCONFIG.form_cvars_nr_cols || 3)) == 0 %]
+      [% IF (n % maxcols) == 0 %]
         </tr><tr>
       [% END %]
     [% END %]

--- a/templates/design40_webpages/reclamation/tabs/basic_data/_second_row.html
+++ b/templates/design40_webpages/reclamation/tabs/basic_data/_second_row.html
@@ -4,9 +4,10 @@
 [%- USE L %]
 [%- USE P %]
 
+[% SET maxcols = (MYCONFIG.form_cvars_nr_cols || 3) %]
 <table>
   <tr>
-    <td colspan="100%">
+    <td colspan="[% maxcols %]">
       <b>[%- 'Serial No.' | $T8 %]</b>&nbsp;
       [%- L.input_tag("reclamation.reclamation_items[].serialnumber", ITEM.serialnumber, size = 15 "data-validate"="trimmed_whitespaces") %]&nbsp;
     <b>[%- 'Project' | $T8 %]</b>&nbsp;
@@ -43,7 +44,7 @@
       [% L.hidden_tag('reclamation.reclamation_items[].custom_variables[].sub_module', var.sub_module) %]
       [% INCLUDE 'common/render_cvar_input.html' var_name='reclamation.reclamation_items[].custom_variables[].unparsed_value' %]
     </td>
-      [%- IF (n % (MYCONFIG.form_cvars_nr_cols || 3)) == 0 %]
+      [%- IF (n % maxcols) == 0 %]
         </tr><tr>
       [%- END %]
     [%- END %]

--- a/templates/design40_webpages/reclamation/tabs/basic_data/_second_row.html
+++ b/templates/design40_webpages/reclamation/tabs/basic_data/_second_row.html
@@ -6,7 +6,7 @@
 
 <table>
   <tr>
-    <td>
+    <td colspan="100%">
       <b>[%- 'Serial No.' | $T8 %]</b>&nbsp;
       [%- L.input_tag("reclamation.reclamation_items[].serialnumber", ITEM.serialnumber, size = 15 "data-validate"="trimmed_whitespaces") %]&nbsp;
     <b>[%- 'Project' | $T8 %]</b>&nbsp;


### PR DESCRIPTION
…anzeigen.

Falls man benutzerdef. Variable im Beleg hat, werden sonstalle Spalten der ersten zweiten Zeile in der ersten Spalte palziert.