### PR TITLE
Lieferschein: Fix SQL-Fehler Volltextsuche

### DIFF
--- a/SL/DO.pm
+++ b/SL/DO.pm
@@ -220,7 +220,6 @@ sub transactions {
                              dord.cusordnumber
                              dord.oreqnumber
                              dord.vendor_confirmation_number
-                             oe.ordnumber
                             );
     my $tmp_where = '';
     $tmp_where .= join ' OR ', map {"$_ ILIKE ?"} @fulltext_fields;


### PR DESCRIPTION
oe ist nicht gejoint. Und die Auftragsnummer ist schon in der Abfrage als dord.ordnumber.

Wenn für EK-Lieferscheine Volltexte auch in Lieferantenauftragsbestätigsnummern gesucht werden sollen, muss das hier noch angepasst werden. Dazu müssen die Nummern über die record links geholt werden.