### PR TITLE
fix: templates: Datumssuche Preisanfragen und BWA Comboboxes Layout

### DIFF
--- a/templates/design40_webpages/oe/search.html
+++ b/templates/design40_webpages/oe/search.html
@@ -86,7 +86,7 @@
      </tr>
      [%- END %]
     <tr>
-      <th>[% IF type == 'purchase_order_confirmation' %][% 'Confirmation Date' | $T8 %][% ELSIF is_order %][% 'Order Date' | $T8 %][% ELSE %][% 'Quotation Date' | $T8 %][% END %] [% 'From' | $T8 %]</th>
+      <th>[% IF type == 'purchase_order_confirmation' %][% 'Confirmation Date' | $T8 %][% ELSIF is_order %][% 'Order Date' | $T8 %][% ELSIF type == 'request_quotation' %][% 'RFQ Date' | $T8 %][% ELSE %][% 'Quotation Date' | $T8 %][% END %] [% 'From' | $T8 %]</th>
       <td>[% L.date_tag('transdatefrom','', class='wi-date') %] [% 'Bis' | $T8 %] [% L.date_tag('transdateto','', class='wi-date') %]</td>
     </tr>
     <tr>

--- a/templates/design40_webpages/rp/report.html
+++ b/templates/design40_webpages/rp/report.html
@@ -27,73 +27,26 @@
     <td><input name="duetyp" type="radio" value="13" checked onchange='set_from_to(this.value, year.value)'>[% 'Yearly' | $T8 %]</td>
     <td>
       <table>
-        <tr>
-          <td><input name="duetyp" type="radio" value="A" onchange='set_from_to(this.value, year.value)'></td>
-          <td>1. [% 'Quarter' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="B" onchange='set_from_to(this.value, year.value)'></td>
-          <td>2. [% 'Quarter' | $T8 %]</td></tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="C" onchange='set_from_to(this.value, year.value)'></td>
-          <td>3. [% 'Quarter' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="D" onchange='set_from_to(this.value, year.value)'></td>
-          <td>4. [% 'Quarter' | $T8 %]</td>
-        </tr>
+        [% SET cnt = 1 %]
+        [% FOREACH x = ["A", "B", "C", "D"] %]
+          <tr>
+            <td><input name="duetyp" type="radio" value="[% x %]" onchange='set_from_to(this.value, year.value)'></td>
+            <td>[% cnt %]. [% 'Quarter' | $T8 %]</td>
+          </tr>
+        [% SET cnt = cnt + 1 %]
+        [% END %]
       </table>
     </td>
     <td>
       <table>
-        <tr>
-          <td><input name="duetyp" type="radio" value="1" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'January' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="2" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'February' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="3" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'March' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="4" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'April' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="5" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'May' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="6" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'June' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="7" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'July' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="8" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'August' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="9" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'September' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="10" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'October' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="11" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'November' | $T8 %]</td>
-        </tr>
-        <tr>
-          <td><input name="duetyp" type="radio" value="12" onchange='set_from_to(this.value, year.value)'></td>
-          <td>[% 'December' | $T8 %]</td>
-        </tr>
+        [% SET cnt = 1 %]
+        [% FOREACH x = [ LxERP.t8('January'), LxERP.t8('February'), LxERP.t8('March'), LxERP.t8('April'), LxERP.t8('May'), LxERP.t8('June'), LxERP.t8('July'), LxERP.t8('August'), LxERP.t8('September'), LxERP.t8('October'), LxERP.t8('November'), LxERP.t8('December') ] %]
+          <tr>
+            <td><input name="duetyp" type="radio" value="[% cnt %]" onchange='set_from_to(this.value, year.value)'></td>
+            <td>[% x %]</td>
+          </tr>
+        [% SET cnt = cnt + 1 %]
+        [% END %]
       </table>
     </td>
   </tr>

--- a/templates/design40_webpages/rp/report.html
+++ b/templates/design40_webpages/rp/report.html
@@ -24,14 +24,17 @@
   </tr>
   <tr>
     <th></th>
-    <td><input name="duetyp" type="radio" value="13" checked onchange='set_from_to(this.value, year.value)'>[% 'Yearly' | $T8 %]</td>
+    <td>
+      <input id="duetyp13" name="duetyp" type="radio" value="13" checked onchange='set_from_to(this.value, year.value)'>
+      <label for="duetyp13">[% 'Yearly' | $T8 %]</label>
+    </td>
     <td>
       <table>
         [% SET cnt = 1 %]
         [% FOREACH x = ["A", "B", "C", "D"] %]
           <tr>
-            <td><input name="duetyp" type="radio" value="[% x %]" onchange='set_from_to(this.value, year.value)'></td>
-            <td>[% cnt %]. [% 'Quarter' | $T8 %]</td>
+            <td><input id="duetyp[% x %]" name="duetyp" type="radio" value="[% x %]" onchange='set_from_to(this.value, year.value)'></td>
+            <td><label for="duetyp[% x %]">[% cnt %].&nbsp;[% 'Quarter' | $T8 %]</label></td>
           </tr>
         [% SET cnt = cnt + 1 %]
         [% END %]
@@ -42,8 +45,8 @@
         [% SET cnt = 1 %]
         [% FOREACH x = [ LxERP.t8('January'), LxERP.t8('February'), LxERP.t8('March'), LxERP.t8('April'), LxERP.t8('May'), LxERP.t8('June'), LxERP.t8('July'), LxERP.t8('August'), LxERP.t8('September'), LxERP.t8('October'), LxERP.t8('November'), LxERP.t8('December') ] %]
           <tr>
-            <td><input name="duetyp" type="radio" value="[% cnt %]" onchange='set_from_to(this.value, year.value)'></td>
-            <td>[% x %]</td>
+            <td><input id="duetyp[% cnt %]" name="duetyp" type="radio" value="[% cnt %]" onchange='set_from_to(this.value, year.value)'></td>
+            <td><label for="duetyp[% cnt %]">[% x %]</label></td>
           </tr>
         [% SET cnt = cnt + 1 %]
         [% END %]

--- a/templates/design40_webpages/rp/report.html
+++ b/templates/design40_webpages/rp/report.html
@@ -26,24 +26,75 @@
     <th></th>
     <td><input name="duetyp" type="radio" value="13" checked onchange='set_from_to(this.value, year.value)'>[% 'Yearly' | $T8 %]</td>
     <td>
-      <input name="duetyp" type="radio" value="A" onchange='set_from_to(this.value, year.value)'>[% 'Quarter' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="B" onchange='set_from_to(this.value, year.value)'>2. [% 'Quarter' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="C" onchange='set_from_to(this.value, year.value)'>3. [% 'Quarter' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="D" onchange='set_from_to(this.value, year.value)'>4. [% 'Quarter' | $T8 %]<br>
+      <table>
+        <tr>
+          <td><input name="duetyp" type="radio" value="A" onchange='set_from_to(this.value, year.value)'></td>
+          <td>1. [% 'Quarter' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="B" onchange='set_from_to(this.value, year.value)'></td>
+          <td>2. [% 'Quarter' | $T8 %]</td></tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="C" onchange='set_from_to(this.value, year.value)'></td>
+          <td>3. [% 'Quarter' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="D" onchange='set_from_to(this.value, year.value)'></td>
+          <td>4. [% 'Quarter' | $T8 %]</td>
+        </tr>
+      </table>
     </td>
     <td>
-      <input name="duetyp" type="radio" value="1" onchange='set_from_to(this.value, year.value)'>[% 'January' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="2" onchange='set_from_to(this.value, year.value)'>[% 'February' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="3" onchange='set_from_to(this.value, year.value)'>[% 'March' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="4" onchange='set_from_to(this.value, year.value)'>[% 'April' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="5" onchange='set_from_to(this.value, year.value)'>[% 'May' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="6" onchange='set_from_to(this.value, year.value)'>[% 'June' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="7" onchange='set_from_to(this.value, year.value)'>[% 'July' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="8" onchange='set_from_to(this.value, year.value)'>[% 'August' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="9" onchange='set_from_to(this.value, year.value)'>[% 'September' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="10" onchange='set_from_to(this.value, year.value)'>[% 'October' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="11" onchange='set_from_to(this.value, year.value)'>[% 'November' | $T8 %]<br>
-      <input name="duetyp" type="radio" value="12" onchange='set_from_to(this.value, year.value)'>[% 'December' | $T8 %]<br>
+      <table>
+        <tr>
+          <td><input name="duetyp" type="radio" value="1" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'January' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="2" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'February' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="3" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'March' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="4" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'April' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="5" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'May' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="6" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'June' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="7" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'July' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="8" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'August' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="9" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'September' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="10" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'October' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="11" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'November' | $T8 %]</td>
+        </tr>
+        <tr>
+          <td><input name="duetyp" type="radio" value="12" onchange='set_from_to(this.value, year.value)'></td>
+          <td>[% 'December' | $T8 %]</td>
+        </tr>
+      </table>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
Verbesserungen an den Templates:

- Bisher falsche Übersetzung des Datums-Feldes bei Suche nach Preisanfragen korrigiert.
- In der BWA verrutschen die Labels an den Comboboxes nicht mehr, da diese nun in einer Tablle gepackt sind.