### PR TITLE
Test: @Support::Files::javascript_files

### DIFF
--- a/t/Support/Files.pm
+++ b/t/Support/Files.pm
@@ -45,6 +45,9 @@ find(sub { push(@files, $File::Find::name) if $_ =~ /\.pm$/;}, 'SL');
 find(sub { push(@files, $File::Find::name) if $_ =~ /\.pl$/;}, qw(bin/mozilla sql/Pg-upgrade2));
 find(sub { push(@files, $File::Find::name) if $_ =~ /\.html$/;}, qw(templates/design40_webpages));
 
+our @javascript_files;
+find(sub { push(@javascript_files, $File::Find::name) if $_ =~ /\.js$/;}, 'js');
+
 sub have_pkg {
     my ($pkg) = @_;
     my ($msg, $vnum, $vstr);


### PR DESCRIPTION
Das behebt eine Warnung bei den Unit-Tests:
"Name "Support::Files::javascript_files" used only once"

Der eigentliche Test "t/flash_migration/deprecated_calls.t" ist allerdings noch als TODO gekennzeichnet - daran ändert dieser commit nichts.

(cherry picked from odyn)