### PR TITLE
20250827 fix zugferd require and errors

### DIFF
--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -502,7 +502,7 @@ sub _exchanged_document {
     $params{xml}->dataElement("ram:LanguageID", uc($1));
   }
 
-  require SL::DB::Manager::GenericTranslation;
+  require SL::DB::GenericTranslation;
   my $std_notes = SL::DB::Manager::GenericTranslation->get_all(
     where => [
       translation_type => 'ZUGFeRD/notes',

--- a/bin/mozilla/io.pl
+++ b/bin/mozilla/io.pl
@@ -2359,7 +2359,7 @@ sub _maybe_attach_zugferd_data {
         mime_type    => 'text/xml',
       }
     ];
-  };
+  } or do { $::form->error($@) };
 
   if (my $e = SL::X::ZUGFeRDValidation->caught) {
     $::form->error($e->message);
@@ -2378,7 +2378,7 @@ sub download_factur_x_xml {
       || !$record->can('create_zugferd_data')
       || !$record->customer->create_zugferd_invoices_for_this_customer;
 
-  my $xml_content = eval { $record->create_zugferd_data };
+  my $xml_content = eval { $record->create_zugferd_data } or do { $::form->error($@) };
 
   if (my $e = SL::X::ZUGFeRDValidation->caught) {
     $::form->error($e->message);

--- a/bin/mozilla/io.pl
+++ b/bin/mozilla/io.pl
@@ -2360,10 +2360,6 @@ sub _maybe_attach_zugferd_data {
       }
     ];
   } or do { $::form->error($@) };
-
-  if (my $e = SL::X::ZUGFeRDValidation->caught) {
-    $::form->error($e->message);
-  }
 }
 
 sub download_factur_x_xml {
@@ -2379,10 +2375,6 @@ sub download_factur_x_xml {
       || !$record->customer->create_zugferd_invoices_for_this_customer;
 
   my $xml_content = eval { $record->create_zugferd_data } or do { $::form->error($@) };
-
-  if (my $e = SL::X::ZUGFeRDValidation->caught) {
-    $::form->error($e->message);
-  }
 
   my $attachment_filename = "factur-x_" . $::form->generate_attachment_filename;
   $attachment_filename    =~ s{\.[^.]+$}{.xml};


### PR DESCRIPTION
Ein require im ZUGFeRD-DB-Helper hat eine nicht vorhandene Manager-Klasse laden wollen.
Zudem haben die evals beim Aufruf der entsprechenden Methode in io.pl die Fehler verschluckt, so dass außer einem internal server error kein Hinweis darauf kam.
Hier ein Fix dazu.
