### PR TITLE
202509 Flash CSS position (kein Scrollen und Platz für ActionBar)

### DIFF
--- a/SL/Layout/Flash.pm
+++ b/SL/Layout/Flash.pm
@@ -6,7 +6,7 @@ use SL::Presenter::EscapedText qw(escape escape_js);
 use SL::Helper::Flash;
 
 sub pre_content {
-  '<div style="position:relative"><div id="layout_flash_container"></div></div>'
+  '<div id="layout_flash_container"></div>'
 }
 
 sub _escape_br_html_js {

--- a/css/design40/less/messages.less
+++ b/css/design40/less/messages.less
@@ -239,7 +239,7 @@ body > div.login .message{
 
 // Styles for Flash Refactor/new Flash Messages
 #layout_flash_container {
-  position: absolute;
+  position: fixed;
   z-index: @zindex-flash;
   top: 103px; // position below title bar 28px (header) + 32px (menu) + 42.6px (title) (+ 5px padding included in the flash message)
   right: 20px;

--- a/css/design40/less/messages.less
+++ b/css/design40/less/messages.less
@@ -241,7 +241,7 @@ body > div.login .message{
 #layout_flash_container {
   position: fixed;
   z-index: @zindex-flash;
-  top: 103px; // position below title bar 28px (header) + 32px (menu) + 42.6px (title) (+ 5px padding included in the flash message)
+  top: 128px; // position below title bar 28px (header) + 32px (menu) + 42.6px (title) + 25px (one action bar menu entry) (+ 5px padding included in the flash message)
   right: 20px;
   min-width: 30%;
   animation: fadein .5s;


### PR DESCRIPTION
Probleme bisher:

- Flash messages scrollen mit der Seite
behoben durch position: fixed statt position: absolute
- Flash messages verdecken ActionBar
wie in letzter Partnerkonferenz besprochen abgemildert durch größeren vertikalen Abstand

Was ich noch probiert und wieder verworfen habe: z-index property so setzen, dass Menü und ActionBar über den Flash-Messages liegen. Problem: Flash messages sollen Dialoge verdecken und Dialoge sollen Menü und ActionBar verdecken, was die Hierarchie vorgibt. (Dieses generelle Problem im Hinterkopf behalten, wenn ein mini-React für den Ausziffern-Branch gebaut wird.)