### PR TITLE
S:D:Invoice->dunnings lieferte Fehlermeldung, durch with_objects

### DIFF
--- a/SL/DB/Invoice.pm
+++ b/SL/DB/Invoice.pm
@@ -67,7 +67,6 @@ __PACKAGE__->meta->add_relationship(
     type         => 'one to many',
     class        => 'SL::DB::Dunning',
     column_map   => { id => 'trans_id' },
-    manager_args => { with_objects => [ 'dunnings' ] }
   },
 );
 


### PR DESCRIPTION
Ist noch nicht aufgefallen:


In der Konsole:
```

my $inv = SL::DB::Manager::Invoice->find_by(id => 14687);
re.pl(main):040:0>  $inv->dunnings
Runtime error: 'Could not load SL::DB::Dunning objects with key trans_id = '14687' - Invalid with_objects or require_objects argument: no foreign key or relationship named 'dunnings' found in Rose::DB::Object::Manager at /usr/share/perl5/Rose/DB/Object/Manager.pm line 904.
```
