### PR TITLE
202509 feat vendor and ap id in parts price history rebased

### DIFF
--- a/SL/Controller/PartsPriceHistory.pm
+++ b/SL/Controller/PartsPriceHistory.pm
@@ -75,10 +75,10 @@ sub column_defs {
     listprice    => { text => $::locale->text('List Price'),   sub => sub { $_[0]->listprice_as_number }},
     sellprice    => { text => $::locale->text('Sell Price'),   sub => sub { $_[0]->sellprice_as_number }},
     price_factor => { text => $::locale->text('Price Factor'), sub => sub { $_[0]->price_factor_as_number }},
-    vendor_id    => { text => $::locale->text('Vendor'),
+    vendor       => { text => $::locale->text('Vendor'),
                            sub => sub { $_[0]->vendor_id ? SL::DB::Manager::Vendor->find_by(id => $_[0]->vendor_id)->name                   : undef },
                       obj_link => sub { my $id = $_[0]->vendor_id; return $id ? "controller.pl?action=CustomerVendor/edit&id=$id&db=vendor" : undef }},
-    ap_id        => { text => $::locale->text('Purchase Invoice'),
+    ap           => { text => $::locale->text('Purchase Invoice'),
                            sub => sub { $_[0]->ap_id ? SL::DB::Manager::PurchaseInvoice->find_by(id => $_[0]->ap_id)->invnumber : undef },
                       obj_link => sub { my $id = $_[0]->ap_id; return $id ? "ir.pl?action=edit&id=$id"                          : undef }},
   };
@@ -93,7 +93,7 @@ sub prepare_report {
 
   my $title       = $::locale->text('Price history for master data');
 
-  my @columns     = qw(valid_from lastcost listprice sellprice price_factor vendor_id ap_id);
+  my @columns     = qw(valid_from lastcost listprice sellprice price_factor vendor ap);
 
   my $column_defs = $self->column_defs;
 

--- a/SL/Controller/PartsPriceHistory.pm
+++ b/SL/Controller/PartsPriceHistory.pm
@@ -55,6 +55,7 @@ sub setup_for_list {
     parse_filter($self->{filter}),
     sort_by => $self->set_sort_params(%params),
     page    => $params{page},
+    with_objects => ['vendor', 'ap'],
   );
 
   return \%args;

--- a/SL/Controller/PartsPriceHistory.pm
+++ b/SL/Controller/PartsPriceHistory.pm
@@ -75,6 +75,12 @@ sub column_defs {
     listprice    => { text => $::locale->text('List Price'),   sub => sub { $_[0]->listprice_as_number }},
     sellprice    => { text => $::locale->text('Sell Price'),   sub => sub { $_[0]->sellprice_as_number }},
     price_factor => { text => $::locale->text('Price Factor'), sub => sub { $_[0]->price_factor_as_number }},
+    vendor_id    => { text => $::locale->text('Vendor'),
+                           sub => sub { $_[0]->vendor_id ? SL::DB::Manager::Vendor->find_by(id => $_[0]->vendor_id)->name                   : undef },
+                      obj_link => sub { my $id = $_[0]->vendor_id; return $id ? "controller.pl?action=CustomerVendor/edit&id=$id&db=vendor" : undef }},
+    ap_id        => { text => $::locale->text('Purchase Invoice'),
+                           sub => sub { $_[0]->ap_id ? SL::DB::Manager::PurchaseInvoice->find_by(id => $_[0]->ap_id)->invnumber : undef },
+                      obj_link => sub { my $id = $_[0]->ap_id; return $id ? "ir.pl?action=edit&id=$id"                          : undef }},
   };
 }
 
@@ -87,7 +93,7 @@ sub prepare_report {
 
   my $title       = $::locale->text('Price history for master data');
 
-  my @columns     = qw(valid_from lastcost listprice sellprice price_factor);
+  my @columns     = qw(valid_from lastcost listprice sellprice price_factor vendor_id ap_id);
 
   my $column_defs = $self->column_defs;
 

--- a/SL/Controller/PartsPriceHistory.pm
+++ b/SL/Controller/PartsPriceHistory.pm
@@ -7,6 +7,8 @@ use Clone qw(clone);
 use SL::DB::PartsPriceHistory;
 use SL::Controller::Helper::ParseFilter;
 use SL::Controller::Helper::ReportGenerator;
+use SL::Presenter::CustomerVendor qw();
+use SL::Presenter::Invoice qw();
 
 sub action_list {
   my ($self) = @_;
@@ -76,11 +78,9 @@ sub column_defs {
     sellprice    => { text => $::locale->text('Sell Price'),   sub => sub { $_[0]->sellprice_as_number }},
     price_factor => { text => $::locale->text('Price Factor'), sub => sub { $_[0]->price_factor_as_number }},
     vendor       => { text => $::locale->text('Vendor'),
-                           sub => sub { $_[0]->vendor_id ? SL::DB::Manager::Vendor->find_by(id => $_[0]->vendor_id)->name                   : undef },
-                      obj_link => sub { my $id = $_[0]->vendor_id; return $id ? "controller.pl?action=CustomerVendor/edit&id=$id&db=vendor" : undef }},
+                      raw_data => sub { $_[0]->vendor ? SL::Presenter::CustomerVendor::vendor($_[0]->vendor, display => 'table-cell') : undef }},
     ap           => { text => $::locale->text('Purchase Invoice'),
-                           sub => sub { $_[0]->ap_id ? SL::DB::Manager::PurchaseInvoice->find_by(id => $_[0]->ap_id)->invnumber : undef },
-                      obj_link => sub { my $id = $_[0]->ap_id; return $id ? "ir.pl?action=edit&id=$id"                          : undef }},
+                      raw_data => sub { $_[0]->ap ? SL::Presenter::Invoice::purchase_invoice($_[0]->ap, display => 'table-cell') : undef }},
   };
 }
 

--- a/SL/DB/Manager/PartsPriceHistory.pm
+++ b/SL/DB/Manager/PartsPriceHistory.pm
@@ -16,6 +16,8 @@ sub _sort_spec {
     default  => [ 'valid_from', 0 ],
     columns  => {
       SIMPLE => 'ALL',
+      vendor => ['lower(vendor.name)'],
+      ap     => ['lower(ap.invnumber)', 'ap.transdate'],
     },
   );
 }

--- a/SL/DB/MetaSetup/PartsPriceHistory.pm
+++ b/SL/DB/MetaSetup/PartsPriceHistory.pm
@@ -9,6 +9,7 @@ use parent qw(SL::DB::Object);
 __PACKAGE__->meta->table('parts_price_history');
 
 __PACKAGE__->meta->columns(
+  ap_id        => { type => 'integer' },
   id           => { type => 'serial', not_null => 1 },
   lastcost     => { type => 'numeric', precision => 15, scale => 5 },
   listprice    => { type => 'numeric', precision => 15, scale => 5 },
@@ -16,14 +17,25 @@ __PACKAGE__->meta->columns(
   price_factor => { type => 'numeric', default => 1, precision => 15, scale => 5 },
   sellprice    => { type => 'numeric', precision => 15, scale => 5 },
   valid_from   => { type => 'timestamp', not_null => 1 },
+  vendor_id    => { type => 'integer' },
 );
 
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 __PACKAGE__->meta->foreign_keys(
+  ap => {
+    class       => 'SL::DB::PurchaseInvoice',
+    key_columns => { ap_id => 'id' },
+  },
+
   part => {
     class       => 'SL::DB::Part',
     key_columns => { part_id => 'id' },
+  },
+
+  vendor => {
+    class       => 'SL::DB::Vendor',
+    key_columns => { vendor_id => 'id' },
   },
 );
 

--- a/SL/DB/Part.pm
+++ b/SL/DB/Part.pm
@@ -93,6 +93,11 @@ __PACKAGE__->meta->add_relationships(
     class        => 'SL::DB::PurchaseBasketItem',
     column_map   => { id => 'part_id' },
   },
+  price_histories  => {
+    type         => 'one to many',
+    class        => 'SL::DB::PartsPriceHistory',
+    column_map   => { id => 'part_id' },
+  },
 );
 
 __PACKAGE__->meta->initialize;

--- a/SL/DB/PurchaseInvoice.pm
+++ b/SL/DB/PurchaseInvoice.pm
@@ -10,6 +10,7 @@ use SL::DB::MetaSetup::PurchaseInvoice;
 use SL::DB::Manager::PurchaseInvoice;
 use SL::DB::Helper::AttrHTML;
 use SL::DB::Helper::AttrSorted;
+use SL::DB::Helper::FlattenToForm;
 use SL::DB::Helper::LinkedRecords;
 use SL::DB::Helper::Payment qw(:ALL);
 use SL::DB::Helper::RecordLink qw(RECORD_ID RECORD_TYPE_REF RECORD_ITEM_ID RECORD_ITEM_TYPE_REF);
@@ -19,7 +20,7 @@ use SL::Locale::String qw(t8);
 use Rose::DB::Object::Helpers qw(has_loaded_related forget_related as_tree strip);
 
 # The calculator hasn't been adjusted for purchase invoices yet.
-# use SL::DB::Helper::PriceTaxCalculator;
+use SL::DB::Helper::PriceTaxCalculator;
 
 __PACKAGE__->meta->add_relationship(
   invoiceitems   => {

--- a/doc/changelog
+++ b/doc/changelog
@@ -29,6 +29,10 @@ Kleinere neue Features und Detailverbesserungen:
 - Lieferplan um das Feld Status u. Vorgangsbezeichnung des Auftrags und Mikrofilm
   erweitert und nach Vorgangsbezeichnis filterbar gemacht.
 
+- Preishistorie in den Stammdaten um die Felder Lieferant und Rechnung
+  erweitert, falls die Preisaktualisierung über eine Einkaufsrechnung
+  passiert ist.
+
 Bugfixes (Tracker: https://www.kivitendo.de/redmine) / Github-Issues /
 Änderungshistorie laut Github  (https://github.com/kivitendo/kivitendo-erp/):
 

--- a/sql/Pg-upgrade2/parts_price_history_add_vendor_ap_info.sql
+++ b/sql/Pg-upgrade2/parts_price_history_add_vendor_ap_info.sql
@@ -1,0 +1,9 @@
+-- @tag: parts_price_history_add_vendor_ap_info
+-- @description: Lieferanten und Beleginfo für Preishistorie hinzufügen (falls bekannt)
+-- @depends: parts_price_history_add_price_factor
+
+ALTER TABLE parts_price_history ADD COLUMN vendor_id INTEGER;
+ALTER TABLE parts_price_history ADD COLUMN ap_id INTEGER;
+
+ALTER TABLE parts_price_history ADD FOREIGN KEY (vendor_id) REFERENCES vendor(id);
+ALTER TABLE parts_price_history ADD FOREIGN KEY (ap_id) REFERENCES ap(id);

--- a/t/Support/Integration.pm
+++ b/t/Support/Integration.pm
@@ -26,10 +26,10 @@ sub make_request {
     };
 
     open(my $out_fh, '>', \$out) or die;
-    open(my $err_fh, '>', \$err) or die;
+    #open(my $err_fh, '>', \$err) or die;
 
     local *STDOUT = $out_fh;
-    local *STDERR = $err_fh;
+    #local *STDERR = $err_fh;
 
     local $::form = Form->new;
     $::form->{$_} = $form_vars{$_} for keys %form_vars;

--- a/t/ir/post_invoice.t
+++ b/t/ir/post_invoice.t
@@ -1,0 +1,118 @@
+use Test::More;
+
+use strict;
+
+use lib 't';
+use utf8;
+
+use Support::TestSetup;
+use Support::Integration;
+
+use SL::DB::InvoiceItem;
+use SL::DB::Part;
+use SL::DB::PartsPriceHistory;
+use SL::DB::PurchaseInvoice;
+use SL::DB::Vendor;
+use SL::DBUtils qw(selectall_hashref_query);
+use SL::Dev::ALL qw(:ALL);
+
+use_ok 'SL::IR';
+
+Support::TestSetup::login();
+Support::Integration::setup();
+
+#####
+my $part1 = new_part(
+  sellprice => 10,
+  lastcost  => 20,
+)->save;
+my $part2 = new_part(
+  sellprice => 100,
+  lastcost  => 200,
+)->save;
+
+my $description = "simple purchase invoice 1";
+my $vendor      = new_vendor->save;
+my $currency    = 'EUR';
+my %form;
+
+# make new invoice
+my ($out, $err, @ret) = make_request('ir', 'add', type => 'invoice');
+is $ret[0], 1, "new purchase invoice";
+%form = form_from_html($out);
+
+# set invnumber and currency
+$form{invnumber} = $description;
+$form{currency}  = $currency;
+
+# set parts (part one is on pos 1 and 3 (!))
+$form{partnumber_1}  = $part1->partnumber;
+$form{sellprice_1} = 25;
+
+# update
+($out, $err, @ret) = make_request('ir', 'update', %form);
+is $ret[0], 1, "update purchase invoice with part one";
+%form = form_from_html($out);
+
+$form{partnumber_2}  = $part2->partnumber;
+$form{sellprice_2} = 250;
+
+# update
+($out, $err, @ret) = make_request('ir', 'update', %form);
+is $ret[0], 1, "update purchase invoice with part two";
+%form = form_from_html($out);
+
+$form{partnumber_3}  = $part1->partnumber;
+$form{sellprice_3} = 31;
+
+# update
+($out, $err, @ret) = make_request('ir', 'update', %form);
+is $ret[0], 1, "update purchase invoice with three";
+%form = form_from_html($out);
+
+($out, $err, @ret) = make_request('ir', 'post', %form);
+is $ret[0], 1, "posting '$description' does not generate error";
+warn $err if $err;
+
+ok $out =~ /ir\.pl\?action=edit&id=(\d+)/, "posting '$description' returns redirect to id";
+my $id = $1;
+
+######
+my $query = 'SELECT * FROM parts_price_history ORDER BY valid_from DESC, id DESC;';
+my $ref   = selectall_hashref_query($::form, $part1->db->dbh, $query);
+
+# check if vendor and ap is set on the right price updates
+is $ref->[0]->{part_id},   $part1->id,  "last price update: right part";
+is $ref->[0]->{lastcost}, '31.00000',   "last price update: right lastcost";
+is $ref->[0]->{vendor_id}, $vendor->id, "last price update: vendor is set";
+is $ref->[0]->{ap_id},     $id,         "last price update: ap is set ($id)";
+
+is $ref->[1]->{part_id},   $part2->id,  "second last price update: right part";
+is $ref->[1]->{lastcost}, '250.00000',  "second last price update: right lastcost";
+is $ref->[1]->{vendor_id}, $vendor->id, "second last price update: vendor is set";
+is $ref->[1]->{ap_id},     $id,         "second last price update: ap is set ($id)";
+
+is $ref->[2]->{part_id},   $part1->id,  "third last price update: right part";
+is $ref->[2]->{lastcost}, '25.00000',   "third last price update: right lastcost";
+is $ref->[2]->{vendor_id}, $vendor->id, "third last price update: vendor is set";
+is $ref->[2]->{ap_id},     $id,         "third last price update: ap is set ($id)";
+
+#####
+
+# clear_up
+SL::DB::Manager::PartsPriceHistory->delete_all(all => 1);
+SL::DB::Manager::InvoiceItem->delete_all(all => 1);
+SL::DB::Manager::PurchaseInvoice->delete_all(all => 1);
+SL::DB::Manager::Part->delete_all(all => 1);
+SL::DB::Manager::Vendor->delete_all(all => 1);
+
+done_testing();
+
+1;
+
+#####
+# vim: ft=perl
+# set emacs to perl mode
+# Local Variables:
+# mode: perl
+# End:


### PR DESCRIPTION
Dies ist eine neue Version von #607  
(Informationen über Lieferant und Einkaufsrechnung in der Preishistorie mit speichern und in der Preisinformation in den Stammdaten mit Anzeigen.

Ein Feature aus Jans großem 202502 ceos lager optimierung usability UI berichte pr2 ( https://github.com/kivitendo/kivitendo-erp/pull/584 ), den ich nochmal überarbeite und einige Dinge in einen separaten PR tue (wie das hier).)

Ich habe die Punkte, die Sven zum PR #607 genannt hat berücksichtigt.

- rebased auf aktuellen master
- commits, die andere fixen, zusammengefasst
- DB-Upgrade-Skripte, die Spalten hinzufügen und wieder entfernen,  gemerget
- Test für das Speichern des Lieferanten und Rechnungs-Id in der Preis-Historie
- Zugriff auf Preishistorie nicht über Relation/Proxy last_price_update vom Part, da dieses gecached wird
