### PR TITLE
b/m/io.pl: fix: no ZUGFeRD for print preview

### DIFF
--- a/bin/mozilla/io.pl
+++ b/bin/mozilla/io.pl
@@ -1450,7 +1450,7 @@ sub print_form {
     $form->{TEMPLATE_DRIVER_OPTIONS}->{variable_content_types} = $form->get_variable_content_types();
   }
 
-  if ($form->{format} =~ m{pdf}) {
+  if ($form->{format} =~ m{pdf} && !$form->{preview}) {
     _maybe_attach_zugferd_data($form);
   }
 


### PR DESCRIPTION
fixes error for print preview of non-booked invoices:
  Can't call method "name" on an undefined value at /var/www/kivitendo-erp/SL/DB/Helper/ZUGFeRD.pm line 744.
