### PR TITLE
"neue" Belege: zweite Zeile: CVars-Warengruppenfilter berücksichtigen

### DIFF
--- a/templates/design40_webpages/delivery_order/tabs/_second_row.html
+++ b/templates/design40_webpages/delivery_order/tabs/_second_row.html
@@ -23,7 +23,18 @@
   <tr>
     [%- SET n = 0 %]
     [%- FOREACH var = ITEM.cvars_by_config %]
-    [%- NEXT UNLESS (var.config.processed_flags.editable && ITEM.part.cvar_by_name(var.config.name).is_valid) %]
+      [%- NEXT UNLESS (var.config.processed_flags.editable && ITEM.part.cvar_by_name(var.config.name).is_valid) %]
+      [%-
+        IF (var.config.processed_flags.partsgroup_filter);
+          SET show = 0;
+          FOREACH pg = var.config.partsgroups;
+            IF (ITEM.part.partsgroup.id == pg.id); show = 1; LAST; END;
+          END;
+        ELSE;
+          show = 1;
+        END;
+        NEXT IF (!show);
+      %]
     [%- SET n = n + 1 %]
     <th>
       [% var.config.description %]

--- a/templates/design40_webpages/order/tabs/_second_row.html
+++ b/templates/design40_webpages/order/tabs/_second_row.html
@@ -48,6 +48,17 @@
     [% SET n = 0 %]
     [% FOREACH var = ITEM.cvars_by_config %]
       [% NEXT UNLESS (var.config.processed_flags.editable && ITEM.part.cvar_by_name(var.config.name).is_valid) %]
+      [%-
+        IF (var.config.processed_flags.partsgroup_filter);
+          SET show = 0;
+          FOREACH pg = var.config.partsgroups;
+            IF (ITEM.part.partsgroup.id == pg.id); show = 1; LAST; END;
+          END;
+        ELSE;
+          show = 1;
+        END;
+        NEXT IF (!show);
+      %]
       [% SET n = n + 1 %]
       <td>
         <b>[% var.config.description %]</b>

--- a/templates/design40_webpages/reclamation/tabs/basic_data/_second_row.html
+++ b/templates/design40_webpages/reclamation/tabs/basic_data/_second_row.html
@@ -33,6 +33,17 @@
     [%- SET n = 0 %]
     [%- FOREACH var = ITEM.cvars_by_config %]
       [%- NEXT UNLESS (var.config.processed_flags.editable && ITEM.part.cvar_by_name(var.config.name).is_valid) %]
+      [%-
+        IF (var.config.processed_flags.partsgroup_filter);
+          SET show = 0;
+          FOREACH pg = var.config.partsgroups;
+            IF (ITEM.part.partsgroup.id == pg.id); show = 1; LAST; END;
+          END;
+        ELSE;
+          show = 1;
+        END;
+        NEXT IF (!show);
+      %]
       [%- SET n = n + 1 %]
     <th>
       [% var.config.description %]


### PR DESCRIPTION
Benutzerdef. Variablen bei Artikeln haben einen Filter nach Warengruppen. Benutzerdef. Variablen sollen dann nur für Artikel angezeigt werden, die zu der entsprechenden Warengruppe gehören.
Dieser Filter wurde aber im neuen Auftrags-Controller und allen nach dessen Vorbild entstandenen Controllern nicht eingebaut.

Das wird hier nun im Template-Code erledigt.