### PR TITLE
202509 fixes Druckvorlagen mersiha

### DIFF
--- a/templates/print/mersiha/bin_list.tex
+++ b/templates/print/mersiha/bin_list.tex
@@ -43,10 +43,10 @@
 \makeatother
 
 \begin{letter}{
-    <%name%>\ifhmode\\\fi
-    <%street%>\ifhmode\\\fi
-    <%zipcode%> <%city%>\ifhmode\\\fi
-    <%country%>
+    <%name%>             \ifhmode\\\fi
+    <%street%>           \ifhmode\\\fi
+    <%zipcode%> <%city%> \ifhmode\\\fi
+    <%country%>          %
   }
 
   \opening{}

--- a/templates/print/mersiha/bin_list.tex
+++ b/templates/print/mersiha/bin_list.tex
@@ -43,7 +43,7 @@
 \makeatother
 
 \begin{letter}{
-    <%name%>             \ifhmode\\\fi
+    <%name%>             \strut\\
     <%street%>           \ifhmode\\\fi
     <%zipcode%> <%city%> \ifhmode\\\fi
     <%country%>          %

--- a/templates/print/mersiha/check.tex
+++ b/templates/print/mersiha/check.tex
@@ -32,12 +32,12 @@
 
 \begin{letter}{
   <%if billing_address_id%> %
-    <%billing_address_name%>    \ifhmode\\\fi
+    <%billing_address_name%>    \strut\\
     <%billing_address_street%>  \ifhmode\\\fi
     <%billing_address_zipcode%> <%billing_address_city%> \ifhmode\\\fi
     <%billing_address_country%> %
   <%else%> %
-    <%name%>                    \ifhmode\\\fi
+    <%name%>                    \strut\\
     <%street%>                  \ifhmode\\\fi
     <%zipcode%> <%city%>        \ifhmode\\\fi
     <%country%>                 %

--- a/templates/print/mersiha/check.tex
+++ b/templates/print/mersiha/check.tex
@@ -30,18 +30,18 @@
 
 \begin{document}
 
-\begin{letter}{%
-  <%if billing_address_id%>%
-    <%billing_address_name%> \strut\\%
-    <%billing_address_street%>\strut\\%
-    <%billing_address_zipcode%> <%billing_address_city%> \strut\\%
-    <%billing_address_country%>\strut\\%
-  <%else%>%
-    <%name%>\strut\\%
-    <%street%>\strut\\%
-    <%zipcode%> <%city%>\strut\\%
-    <%country%>\strut%
-  <%end billing_address_id%>%
+\begin{letter}{
+  <%if billing_address_id%> %
+    <%billing_address_name%>    \ifhmode\\\fi
+    <%billing_address_street%>  \ifhmode\\\fi
+    <%billing_address_zipcode%> <%billing_address_city%> \ifhmode\\\fi
+    <%billing_address_country%> %
+  <%else%> %
+    <%name%>                    \ifhmode\\\fi
+    <%street%>                  \ifhmode\\\fi
+    <%zipcode%> <%city%>        \ifhmode\\\fi
+    <%country%>                 %
+  <%end%> %
   }
 
   \opening{<%company%>}

--- a/templates/print/mersiha/credit_note.tex
+++ b/templates/print/mersiha/credit_note.tex
@@ -18,10 +18,11 @@
 \setkomavar{info0}[\vorgangsbez]    {<%transaction_description%>}
 \setkomavar{info1}[\datum]          {<%invdate%>}
 \setkomavar{info2}[\fuerRechnung]   {<%invnumber_for_credit_note%>}
-\setkomavar{info3}[\kundennummer]   {<%customernumber%>}
-\setkomavar{info4}[\ansprechpartner]{<%employee_name%>}
-\setkomavar{info5}[\textTelefon]    {<%employee_tel%>}
-\setkomavar{info6}[\textEmail]      {<%employee_email%>}
+\setkomavar{info3}[\auftrag{}~\nr]  {<%ordnumber%>}
+\setkomavar{info4}[\kundennummer]   {<%customernumber%>}
+\setkomavar{info5}[\ansprechpartner]{<%employee_name%>}
+\setkomavar{info6}[\textTelefon]    {<%employee_tel%>}
+\setkomavar{info7}[\textEmail]      {<%employee_email%>}
 \setkomavar{fromname}               {<%employee_name%>}
 
 \setkomavar{title}{\gutschrift~\nr~<%invnumber%>}

--- a/templates/print/mersiha/credit_note.tex
+++ b/templates/print/mersiha/credit_note.tex
@@ -54,7 +54,7 @@
 
 \begin{letter}{
   <%if billing_address_id%> %
-    <%billing_address_name%>         \ifhmode\\\fi
+    <%billing_address_name%>         \strut\\
     <%billing_address_department_1%> \ifhmode\\\fi
     <%billing_address_department_2%> \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
@@ -62,7 +62,7 @@
     <%billing_address_zipcode%> <%billing_address_city%> \ifhmode\\\fi
     <%billing_address_country%>      %
   <%else%> %
-    <%name%>                         \ifhmode\\\fi
+    <%name%>                         \strut\\
     <%department_1%>                 \ifhmode\\\fi
     <%department_2%>                 \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi

--- a/templates/print/mersiha/credit_note.tex
+++ b/templates/print/mersiha/credit_note.tex
@@ -52,24 +52,24 @@
 
 \begin{document}
 
-\begin{letter}{%
-  <%if billing_address_id%>%
-    <%billing_address_name%> \strut\\%
-    <%if billing_address_department_1%><%billing_address_department_1%>\\<%end if%>%
-    <%if billing_address_department_2%><%billing_address_department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\%
-    <%billing_address_street%>\strut\\%
-    <%billing_address_zipcode%> <%billing_address_city%> \strut\\%
-    <%billing_address_country%>\strut\\%
-  <%else%>%
-    <%name%>\strut\\%
-    <%if department_1%><%department_1%>\\<%end if%>%
-    <%if department_2%><%department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\%
-    <%street%>\strut\\%
-    <%zipcode%> <%city%>\strut\\%
-    <%country%>\strut%
-  <%end billing_address_id%>%
+\begin{letter}{
+  <%if billing_address_id%> %
+    <%billing_address_name%>         \ifhmode\\\fi
+    <%billing_address_department_1%> \ifhmode\\\fi
+    <%billing_address_department_2%> \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%billing_address_street%>       \ifhmode\\\fi
+    <%billing_address_zipcode%> <%billing_address_city%> \ifhmode\\\fi
+    <%billing_address_country%>      %
+  <%else%> %
+    <%name%>                         \ifhmode\\\fi
+    <%department_1%>                 \ifhmode\\\fi
+    <%department_2%>                 \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%street%>                       \ifhmode\\\fi
+    <%zipcode%> <%city%>             \ifhmode\\\fi
+    <%country%>                      %
+  <%end billing_address_id%> %
   }
 
   % Bei Kontaktperson Anrede nach Geschlecht unterscheiden.

--- a/templates/print/mersiha/credit_note.tex
+++ b/templates/print/mersiha/credit_note.tex
@@ -39,11 +39,12 @@
     \par
     \normalsize
     <%shiptoname%>\par
-    <%if shiptocontact%> <%shiptocontact%><%end if%>\par
     <%shiptodepartment_1%>\par
     <%shiptodepartment_2%>\par
+    <%if shiptocontact%> <%shiptocontact%><%else%><%cp_title%> <%cp_givenname%> <%cp_name%><%end if%>\par
     <%shiptostreet%>\par
-    <%shiptozipcode%> <%shiptocity%>%
+    <%shiptozipcode%> <%shiptocity%>\par
+    <%shiptocountry%>
   }
 \end{lrbox}
 \makeatother

--- a/templates/print/mersiha/deutsch.tex
+++ b/templates/print/mersiha/deutsch.tex
@@ -45,7 +45,7 @@
 \newcommand{\lieferung} {Lieferbedingungen}
 \newcommand{\textTelefon} {Tel.}
 \newcommand{\textEmail} {E-Mail}
-\newcommand{\textFax} {Fax}
+\providecommand{\textFax} {Fax}
 
 % angebot (sales_quotion)
 \newcommand{\angebot} {Angebot}

--- a/templates/print/mersiha/deutsch.tex
+++ b/templates/print/mersiha/deutsch.tex
@@ -141,10 +141,17 @@
 \newcommand{\asNeunzig} {90+}
 
 % zahlungserinnerung (Mahnung)
-\newcommand{\mahnung} {Zahlungserinnerung}
+\newcommand{\mahnung} {Mahnung}
+\newcommand{\zahlungserinnerung} {Zahlungserinnerung}
 \newcommand{\mahnungsformel} {man kann seine Augen nicht überall haben - offensichtlich haben Sie übersehen, die folgenden Rechnungen zu begleichen:}
-\newcommand{\beruecksichtigtBis} {Zahlungseingänge sind nur berücksichtigt bis zum}
+\newcommand{\beruecksichtigtBis} {Zahlungseingänge wurden berücksichtigt bis zum}
 \newcommand{\schonGezahlt} {Sollten Sie zwischenzeitlich bezahlt haben, betrachten Sie diese Zahlungserinnerung bitte als gegenstandslos.}
+\newcommand{\zahlungserinnerungIgnoriert}[1] {leider haben Sie unsere vorangegangene Zahlungserinnerung ignoriert. Das ist bedauerlich, denn dadurch sind uns Kosten entstanden, die wir nun an Sie weitergeben müssen. Damit keine weiteren Kosten für Sie entstehen, begleichen Sie bitte die nachfolgend ausgewiesenen offenen Posten schnellstmöglich, spätestens jedoch bis zum #1.}
+\newcommand{\triftigeGruende} {Sollte es triftige Gründe für die Zahlungsverzögerung geben, setzen Sie sich bitte mit uns in Verbindung, damit wir gemeinsam eine Lösung finden.}
+\newcommand{\faelligAm} {fällig am}
+\newcommand{\gebuehr} {Gebühr}
+\newcommand{\zinsen} {Zinsen}
+\newcommand{\zuZahlen} {zu zahlen}
 
 % zahlungserinnerung_invoice (Rechnung zur Mahnung)
 \newcommand{\mahnungsrechnungsformel} {hiermit stellen wir Ihnen zu o.g. \mahnung \ folgende Posten in Rechnung:}

--- a/templates/print/mersiha/deutsch.tex
+++ b/templates/print/mersiha/deutsch.tex
@@ -96,6 +96,7 @@
 
 % rechnung (invoice)
 \newcommand{\rechnung} {Rechnung}
+\newcommand{\rechnungs} {Rechnungs}
 \newcommand{\rechnungskopie} {Rechnungskopie}
 \newcommand{\rechnungsdatum} {Rechnungsdatum}
 \newcommand{\ihrebestellung} {Ihre Bestellung}
@@ -117,7 +118,7 @@
 
 \newcommand{\textUstid} {USt-IdNr.:}
 \newcommand{\stornorechnung} {Stornorechnung}
-\newcommand{\stornoErstatten}[1] {Hiermit erstatten wir Ihnen zu Rechnung #1 die nachfolgenden Positionen.}
+\newcommand{\stornoErstatten}[1] {hiermit stornieren wir Ihnen die nachfolgenden Positionen von Rechnung #1.}
 
 % anzahlungsrechnung (invoice_for_advance_payment)
 \newcommand{\anzahlungsrechnung} {Anzahlungsrechnung}

--- a/templates/print/mersiha/deutsch.tex
+++ b/templates/print/mersiha/deutsch.tex
@@ -117,6 +117,7 @@
 
 \newcommand{\textUstid} {USt-IdNr.:}
 \newcommand{\stornorechnung} {Stornorechnung}
+\newcommand{\stornoErstatten}[1] {Hiermit erstatten wir Ihnen zu Rechnung #1 die nachfolgenden Positionen.}
 
 % anzahlungsrechnung (invoice_for_advance_payment)
 \newcommand{\anzahlungsrechnung} {Anzahlungsrechnung}

--- a/templates/print/mersiha/deutsch.tex
+++ b/templates/print/mersiha/deutsch.tex
@@ -45,7 +45,7 @@
 \newcommand{\lieferung} {Lieferbedingungen}
 \newcommand{\textTelefon} {Tel.}
 \newcommand{\textEmail} {E-Mail}
-\providecommand{\textFax} {Fax}
+\newcommand{\textFaxNr} {Fax}
 
 % angebot (sales_quotion)
 \newcommand{\angebot} {Angebot}

--- a/templates/print/mersiha/english.tex
+++ b/templates/print/mersiha/english.tex
@@ -116,6 +116,7 @@
 
 \newcommand{\textUstid} {VAT number:}
 \newcommand{\stornorechnung} {Reversal Invoice}
+\newcommand{\stornoErstatten}[1] {Hereby we refund you the following positions in respect to invoice #1.}
 
 % anzahlungsrechnung (invoice_for_advance_payment)
 \newcommand{\anzahlungsrechnung} {Invoice for advance payment}

--- a/templates/print/mersiha/english.tex
+++ b/templates/print/mersiha/english.tex
@@ -44,7 +44,7 @@
 \newcommand{\lieferung} {Delivery terms:}
 \newcommand{\textTelefon} {Tel.:}
 \newcommand{\textEmail} {Email:}
-\newcommand{\textFax} {Fax:}
+\providecommand{\textFax} {Fax:}
 
 % angebot (sales_quotion)
 \newcommand{\angebot} {Quotation}

--- a/templates/print/mersiha/english.tex
+++ b/templates/print/mersiha/english.tex
@@ -140,10 +140,17 @@
 \newcommand{\asNeunzig} {90+}
 
 % zahlungserinnerung (Mahnung)
-\newcommand{\mahnung} {Payment reminder}
+\newcommand{\mahnung} {Dun}
+\newcommand{\zahlungserinnerung} {Payment reminder}
 \newcommand{\mahnungsformel} {our records show that the following invoices are still outstanding:}
 \newcommand{\beruecksichtigtBis} {We have taken into account payments received up until}
 \newcommand{\schonGezahlt} {If you have already paid in the meantime, please ignore this payment reminder.}
+\newcommand{\zahlungserinnerungIgnoriert}[1] {sadly, you have ignored our previous payment reminder. Regrettably, this caused us burdens, which we have to pass on to you. Ta avoid further charges, please settle the following open positions as fast as possible, at the latest until #1.}
+\newcommand{\triftigeGruende} {If there are compelling reasons for the delay in payment, please contant us, so that we can work out a solution together.}
+\newcommand{\faelligAm} {fällig am}
+\newcommand{\gebuehr} {fee}
+\newcommand{\zinsen} {interest}
+\newcommand{\zuZahlen} {outstanding}
 
 % zahlungserinnerung_invoice (Rechnung zur Mahnung)
 \newcommand{\mahnungsrechnungsformel} {for the above-mentioned payment reminder we charge you the following fees:}

--- a/templates/print/mersiha/english.tex
+++ b/templates/print/mersiha/english.tex
@@ -95,6 +95,7 @@
 
 % rechnung (invoice)
 \newcommand{\rechnung} {Invoice}
+\newcommand{\rechnungs} {Invoice}
 \newcommand{\rechnungskopie} {Invoice copy}
 \newcommand{\rechnungsdatum} {Invoice date}
 \newcommand{\ihrebestellung} {Your order}
@@ -116,7 +117,7 @@
 
 \newcommand{\textUstid} {VAT number:}
 \newcommand{\stornorechnung} {Reversal Invoice}
-\newcommand{\stornoErstatten}[1] {Hereby we refund you the following positions in respect to invoice #1.}
+\newcommand{\stornoErstatten}[1] {hereby we refund you the following positions in respect to invoice #1.}
 
 % anzahlungsrechnung (invoice_for_advance_payment)
 \newcommand{\anzahlungsrechnung} {Invoice for advance payment}

--- a/templates/print/mersiha/english.tex
+++ b/templates/print/mersiha/english.tex
@@ -55,7 +55,7 @@
 \newcommand{\angebotagb} {Our general terms and conditions (AGB) apply. We will send them to you on request.}
 \newcommand{\auftragerteilt}{Order confirmed:}
 \newcommand{\angebotortdatum}{We hereby accept this offer.}
-\newcommand{\abweichendeLieferadresse}{alternate delivery address}
+\newcommand{\abweichendeLieferadresse}{alternative delivery address}
 
 % angebotseingang (purchase_quotation_intake)
 \newcommand{\angebotseingang} {Quotation Intake}

--- a/templates/print/mersiha/english.tex
+++ b/templates/print/mersiha/english.tex
@@ -44,7 +44,7 @@
 \newcommand{\lieferung} {Delivery terms:}
 \newcommand{\textTelefon} {Tel.:}
 \newcommand{\textEmail} {Email:}
-\providecommand{\textFax} {Fax:}
+\newcommand{\textFaxNr} {Fax:}
 
 % angebot (sales_quotion)
 \newcommand{\angebot} {Quotation}

--- a/templates/print/mersiha/english.tex
+++ b/templates/print/mersiha/english.tex
@@ -146,7 +146,7 @@
 \newcommand{\mahnungsformel} {our records show that the following invoices are still outstanding:}
 \newcommand{\beruecksichtigtBis} {We have taken into account payments received up until}
 \newcommand{\schonGezahlt} {If you have already paid in the meantime, please ignore this payment reminder.}
-\newcommand{\zahlungserinnerungIgnoriert}[1] {sadly, you have ignored our previous payment reminder. Regrettably, this caused us burdens, which we have to pass on to you. Ta avoid further charges, please settle the following open positions as fast as possible, at the latest until #1.}
+\newcommand{\zahlungserinnerungIgnoriert}[1] {sadly, you have ignored our previous payment reminder. Regrettably, this caused us burdens, which we have to pass on to you. To avoid further charges, please settle the following open positions as fast as possible, at the latest until #1.}
 \newcommand{\triftigeGruende} {If there are compelling reasons for the delay in payment, please contant us, so that we can work out a solution together.}
 \newcommand{\faelligAm} {fällig am}
 \newcommand{\gebuehr} {fee}

--- a/templates/print/mersiha/english.tex
+++ b/templates/print/mersiha/english.tex
@@ -117,7 +117,7 @@
 
 \newcommand{\textUstid} {VAT number:}
 \newcommand{\stornorechnung} {Reversal Invoice}
-\newcommand{\stornoErstatten}[1] {hereby we refund you the following positions in respect to invoice #1.}
+\newcommand{\stornoErstatten}[1] {we hereby refund the following items with respect to invoice #1.}
 
 % anzahlungsrechnung (invoice_for_advance_payment)
 \newcommand{\anzahlungsrechnung} {Invoice for advance payment}
@@ -141,14 +141,14 @@
 \newcommand{\asNeunzig} {90+}
 
 % zahlungserinnerung (Mahnung)
-\newcommand{\mahnung} {Dun}
+\newcommand{\mahnung} {Dunning letter}
 \newcommand{\zahlungserinnerung} {Payment reminder}
 \newcommand{\mahnungsformel} {our records show that the following invoices are still outstanding:}
 \newcommand{\beruecksichtigtBis} {We have taken into account payments received up until}
 \newcommand{\schonGezahlt} {If you have already paid in the meantime, please ignore this payment reminder.}
 \newcommand{\zahlungserinnerungIgnoriert}[1] {sadly, you have ignored our previous payment reminder. Regrettably, this caused us burdens, which we have to pass on to you. To avoid further charges, please settle the following open positions as fast as possible, at the latest until #1.}
-\newcommand{\triftigeGruende} {If there are compelling reasons for the delay in payment, please contant us, so that we can work out a solution together.}
-\newcommand{\faelligAm} {fällig am}
+\newcommand{\triftigeGruende} {If there are compelling reasons for the delay in payment, please contact us, so that we can work out a solution together.}
+\newcommand{\faelligAm} {Due on}
 \newcommand{\gebuehr} {fee}
 \newcommand{\zinsen} {interest}
 \newcommand{\zuZahlen} {outstanding}

--- a/templates/print/mersiha/insettings.tex
+++ b/templates/print/mersiha/insettings.tex
@@ -4,6 +4,7 @@
 % Sprachüberprüfung
 \RequirePackage[english, ngerman]{babel}
 \RequirePackage{xparse}
+\RequirePackage[hidelinks]{hyperref}
 
 \makeatletter
 \ExplSyntaxOn

--- a/templates/print/mersiha/insettings.tex
+++ b/templates/print/mersiha/insettings.tex
@@ -119,7 +119,7 @@
       \strasse               & \homepage           & \textBank             & \bank \\
       \ort                   & \textUstid\ \ustid  & \textIban             & \iban \\
       \textTelefon~\telefon  & \finanzamt          & \textBic              & \bic \\
-      \Ifstr{\fax}{}{}{\textFax~\fax} &        &\textBankleitzahl       & \bankleitzahl
+      \Ifstr{\fax}{}{}{\textFaxNr~\fax} &          &\textBankleitzahl       & \bankleitzahl
     \end{tabular*}
     % Ende des Fußzeileninhaltes.
   \end{lrbox}

--- a/templates/print/mersiha/invoice.tex
+++ b/templates/print/mersiha/invoice.tex
@@ -109,6 +109,12 @@
   }
   \thispagestyle{kivitendo.letter.first}
 
+  <%if template_meta.formname != "storno_invoice"%>
+    \rechnungsformel
+  <%else%>
+    \stornoErstatten{<%invnumber%>}
+  <%end%>
+
   <%if notes%>%
     <%notes%>%
     \vspace{0.5cm}

--- a/templates/print/mersiha/invoice.tex
+++ b/templates/print/mersiha/invoice.tex
@@ -173,7 +173,7 @@
         <%iap_invnumber%> & <%iap_transdate_as_date%> & <%iap_amount%> & <%iap_taxamount%>\\%
       <%end iap_invnumber%>%
     \end{SimpleTabular}%
-    \bfseries\rechnungsbetrag: <%iap_final_amount%> \currency\\%
+    \textbf{\rechnungsbetrag: <%iap_final_amount%> \currency} \\%
   <%end iap_existing%>
   <%end%>%
 

--- a/templates/print/mersiha/invoice.tex
+++ b/templates/print/mersiha/invoice.tex
@@ -72,11 +72,12 @@
       \par
       \normalsize
       <%shiptoname%>\par
-      <%if shiptocontact%> <%shiptocontact%><%end if%>\par
       <%shiptodepartment_1%>\par
       <%shiptodepartment_2%>\par
+      <%if shiptocontact%> <%shiptocontact%><%else%><%cp_title%> <%cp_givenname%> <%cp_name%><%end if%>\par
       <%shiptostreet%>\par
-      <%shiptozipcode%> <%shiptocity%>%
+      <%shiptozipcode%> <%shiptocity%>\par
+      <%shiptocountry%>
     }
   \end{lrbox}
   \makeatother

--- a/templates/print/mersiha/invoice.tex
+++ b/templates/print/mersiha/invoice.tex
@@ -130,7 +130,7 @@
   <%end notes%>%
 
 
-  \begin{PricingTabular*}[pricetotal/colspec = K]
+  \begin{PricingTabular*}[price/colspec = K, pricetotal/colspec = K]
     % eigentliche Tabelle
     \FakeTable{%
     <%foreach number%>%
@@ -143,9 +143,14 @@
       <%if projectnumber%>\ExtraDescription{\projektnummer: <%projectnumber%>}<%end projectnumber%>%
       &%
       <%qty%> <%unit%> &%
-      <%sellprice%>&%
+      <%sellprice%>\,\currency&%
       <%if optional%>\optional<%else%><%linetotal%>\,\currency<%if p_discount%>\par{\sffamily\scriptsize{(-<%p_discount%>\,\%)}}<%end p_discount%><%end optional%>
       \tabularnewline
+      <%if discount_sub%>
+        \rlap{\zwischensumme}& & & & &
+        <%discount_sub%>\,\currency
+        \tabularnewline
+      <%end%>
     <%end number%>%
     }%
     \begin{PricingTotal}%

--- a/templates/print/mersiha/invoice.tex
+++ b/templates/print/mersiha/invoice.tex
@@ -85,24 +85,24 @@
 
 \begin{document}
 
-\begin{letter}{%
-  <%if billing_address_id%>%
-    <%billing_address_name%> \strut\\%
-    <%if billing_address_department_1%><%billing_address_department_1%>\\<%end if%>%
-    <%if billing_address_department_2%><%billing_address_department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\%
-    <%billing_address_street%>\strut\\%
-    <%billing_address_zipcode%> <%billing_address_city%> \strut\\%
-    <%billing_address_country%>\strut\\%
-  <%else%>%
-    <%name%>\strut\\%
-    <%if department_1%><%department_1%>\\<%end if%>%
-    <%if department_2%><%department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\%
-    <%street%>\strut\\%
-    <%zipcode%> <%city%>\strut\\%
-    <%country%>\strut%
-  <%end billing_address_id%>%
+\begin{letter}{
+  <%if billing_address_id%> %
+    <%billing_address_name%>         \ifhmode\\\fi
+    <%billing_address_department_1%> \ifhmode\\\fi
+    <%billing_address_department_2%> \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%billing_address_street%>       \ifhmode\\\fi
+    <%billing_address_zipcode%> <%billing_address_city%> \ifhmode\\\fi
+    <%billing_address_country%>      %
+  <%else%> %
+    <%name%>                         \ifhmode\\\fi
+    <%department_1%>                 \ifhmode\\\fi
+    <%department_2%>                 \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%street%>                       \ifhmode\\\fi
+    <%zipcode%> <%city%>             \ifhmode\\\fi
+    <%country%>                      %
+  <%end%> %
   }
 
   % Bei Kontaktperson Anrede nach Geschlecht unterscheiden.

--- a/templates/print/mersiha/invoice.tex
+++ b/templates/print/mersiha/invoice.tex
@@ -1,5 +1,6 @@
 \documentclass[paper=a4,fontsize=10pt]{scrartcl}
 \usepackage{kiviletter}
+\usepackage{xstring}
 <%if template_meta.formname == "invoice_copy"%>
   \usepackage{transparent}
   \DeclareNewLayer[page,foreground,contents={
@@ -31,6 +32,7 @@
 
 <%if template_meta.formname == "storno_invoice"%>
   \renewcommand{\rechnung}{\stornorechnung}
+
 <%end template_meta.formname == "storno_invoice"%>
 
 % laufende Kopfzeile:
@@ -49,7 +51,14 @@
 \setkomavar{info10}[\textEmail]        {<%employee_email%>}
 \setkomavar{fromname}                  {<%employee_name%>}
 
-\setkomavar{title}{\rechnung~\nr~<%invnumber%>}
+<%if template_meta.formname == "storno_invoice"%>
+  \setkomavar{title}{\rechnungs-<%invnumber%>}
+
+  \setkomavar{info5}[\rechnung~\nr]    {\StrSubstitute{<%invnumber%>}{Storno zu }{}}
+<%else%>
+  \setkomavar{title}{\rechnung~\nr~<%invnumber%>}
+<%end%>
+
 
 <%if shiptoname%>%
   \makeatletter
@@ -109,10 +118,10 @@
   }
   \thispagestyle{kivitendo.letter.first}
 
-  <%if template_meta.formname != "storno_invoice"%>
-    \rechnungsformel
+  <%if template_meta.formname == "storno_invoice"%>
+    \stornoErstatten{\StrSubstitute{<%invnumber%>}{Storno zu }{}}
   <%else%>
-    \stornoErstatten{<%invnumber%>}
+    \rechnungsformel
   <%end%>
 
   <%if notes%>%

--- a/templates/print/mersiha/invoice.tex
+++ b/templates/print/mersiha/invoice.tex
@@ -87,7 +87,7 @@
 
 \begin{letter}{
   <%if billing_address_id%> %
-    <%billing_address_name%>         \ifhmode\\\fi
+    <%billing_address_name%>         \strut\\
     <%billing_address_department_1%> \ifhmode\\\fi
     <%billing_address_department_2%> \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
@@ -95,7 +95,7 @@
     <%billing_address_zipcode%> <%billing_address_city%> \ifhmode\\\fi
     <%billing_address_country%>      %
   <%else%> %
-    <%name%>                         \ifhmode\\\fi
+    <%name%>                         \strut\\
     <%department_1%>                 \ifhmode\\\fi
     <%department_2%>                 \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi

--- a/templates/print/mersiha/invoice.tex
+++ b/templates/print/mersiha/invoice.tex
@@ -52,9 +52,9 @@
 \setkomavar{fromname}                  {<%employee_name%>}
 
 <%if template_meta.formname == "storno_invoice"%>
-  \setkomavar{title}{\rechnungs-<%invnumber%>}
+  \setkomavar{title}{\stornorechnung{} \StrSubstitute{<%invnumber%>}{Storno zu }{}}
 
-  \setkomavar{info5}[\rechnung~\nr]    {\StrSubstitute{<%invnumber%>}{Storno zu }{}}
+  \setkomavar{info5}[\rechnung~\nr]   {\StrSubstitute{<%invnumber%>}{Storno zu }{}}
 <%else%>
   \setkomavar{title}{\rechnung~\nr~<%invnumber%>}
 <%end%>

--- a/templates/print/mersiha/kiviletter.sty
+++ b/templates/print/mersiha/kiviletter.sty
@@ -60,7 +60,7 @@
 \newkomavar[\projektnummer]{projectID}
 \setkomavar*{fromphone}{\textTelefon}
 \setkomavar*{fromemail}{\textEmail}
-\setkomavar*{fromfax}{\textFax}
+\setkomavar*{fromfax}{\textFaxNr}
 \setkomavar*{customer}{\kundennummer}
 
 

--- a/templates/print/mersiha/kivitendo.sty
+++ b/templates/print/mersiha/kivitendo.sty
@@ -1,7 +1,7 @@
 \ProvidesFile{kivitendo.sty}
 \usepackage{colortbl}
 \usepackage{eurosym}
-\usepackage{german}
+\usepackage[ngerman]{babel}
 \usepackage{graphicx}
 \usepackage{ifthen}
 \usepackage{iftex}

--- a/templates/print/mersiha/mahnung.tex
+++ b/templates/print/mersiha/mahnung.tex
@@ -23,7 +23,7 @@
 \setkomavar{info6}[\textEmail]      {<%employee_email%>}
 \setkomavar{fromname}               {<%employee_name%>}
 
-\setkomavar{title}{\zahlungserinnerung<%if dunning_id%>~\nr~<%dunning_id%><%end if%>}
+\setkomavar{title}{\mahnung<%if dunning_id%>~\nr~<%dunning_id%><%end if%>}
 
 \begin{document}
 
@@ -61,23 +61,27 @@
   }
   \thispagestyle{kivitendo.letter.first}
 
-  \mahnungsformel
+  \zahlungserinnerungIgnoriert{<%dunning_date%>}
 
-  \begin{SimpleTabular}[headline=\bfseries\rechnung~\nr & \bfseries\rechnungsdatum & \bfseries\faelligAm & \bfseries\betrag, colspec=X l l r<{\tabcurrency}]
-    % eigentliche Tabelle
+  \begin{SimpleTabular}[
+    headline=\bfseries\rechnung~\nr & \bfseries\rechnungsdatum & \bfseries\faelligAm & \bfseries\betrag & \bfseries\gebuehr & \bfseries\zinsen & \bfseries\zuZahlen,
+    %colspec=rXr<{\tabcurrency}
+    colspec=X l l r<{\tabcurrency} r<{\tabcurrency} r<{\tabcurrency} r<{\tabcurrency}
+  ]
     <%foreach dn_invnumber%>%
-      <%dn_invnumber%> & <%dn_transdate%> & <%dn_duedate%> & <%dn_amount%> \\[0.1cm]
+      <%dn_invnumber%> & <%dn_transdate%> & <%dn_duedate%> & <%dn_amount%> & <%dn_fee%> & <%dn_interest%> & <%dn_linetotal%> \\[0.1cm]
     <%end dn_invnumber%>%
+    \\ \midrule
+    \textbf{\schlussbetrag} & & & <%total_open_amount%> & <%fee%> & <%total_interest%> & \textbf{<%total_amount%>}
   \end{SimpleTabular}
 
 
   \smallskip
 
-  \bitteZahlenBis~<%dunning_duedate%>.
-
-
   \beruecksichtigtBis~<%dunning_date%>.
   \schonGezahlt
+
+  \triftigeGruende
 
   \closing{\gruesse}
 

--- a/templates/print/mersiha/mahnung_invoice.tex
+++ b/templates/print/mersiha/mahnung_invoice.tex
@@ -1,0 +1,1 @@
+zahlungserinnerung_invoice.tex

--- a/templates/print/mersiha/pick_list.tex
+++ b/templates/print/mersiha/pick_list.tex
@@ -34,7 +34,7 @@
   \\\textTelefon : <%shiptophone%>
 <%end shiptophone%>%
 <%if shiptofax%>%
-  \\\textFax : <%shiptofax%>
+  \\\textFaxNr : <%shiptofax%>
 <%end shiptofax%>%
 \\%
 <%shiptoemail%>%

--- a/templates/print/mersiha/proforma.tex
+++ b/templates/print/mersiha/proforma.tex
@@ -56,7 +56,7 @@
 
 \begin{letter}{
   <%if billing_address_id%> %
-    <%billing_address_name%>         \ifhmode\\\fi
+    <%billing_address_name%>         \strut\\
     <%billing_address_department_1%> \ifhmode\\\fi
     <%billing_address_department_2%> \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
@@ -64,7 +64,7 @@
     <%billing_address_zipcode%> <%billing_address_city%> \ifhmode\\\fi
     <%billing_address_country%>      %
   <%else%> %
-    <%name%>                         \ifhmode\\\fi
+    <%name%>                         \strut\\
     <%department_1%>                 \ifhmode\\\fi
     <%department_2%>                 \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi

--- a/templates/print/mersiha/proforma.tex
+++ b/templates/print/mersiha/proforma.tex
@@ -54,24 +54,24 @@
 
 \begin{document}
 
-\begin{letter}{%
-  <%if billing_address_id%>%
-    <%billing_address_name%> \strut\\%
-    <%if billing_address_department_1%><%billing_address_department_1%>\\<%end if%>%
-    <%if billing_address_department_2%><%billing_address_department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\%
-    <%billing_address_street%>\strut\\%
-    <%billing_address_zipcode%> <%billing_address_city%> \strut\\%
-    <%billing_address_country%>\strut\\%
-  <%else%>%
-    <%name%>\strut\\%
-    <%if department_1%><%department_1%>\\<%end if%>%
-    <%if department_2%><%department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\%
-    <%street%>\strut\\%
-    <%zipcode%> <%city%>\strut\\%
-    <%country%>\strut%
-  <%end billing_address_id%>%
+\begin{letter}{
+  <%if billing_address_id%> %
+    <%billing_address_name%>         \ifhmode\\\fi
+    <%billing_address_department_1%> \ifhmode\\\fi
+    <%billing_address_department_2%> \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%billing_address_street%>       \ifhmode\\\fi
+    <%billing_address_zipcode%> <%billing_address_city%> \ifhmode\\\fi
+    <%billing_address_country%>      %
+  <%else%> %
+    <%name%>                         \ifhmode\\\fi
+    <%department_1%>                 \ifhmode\\\fi
+    <%department_2%>                 \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%street%>                       \ifhmode\\\fi
+    <%zipcode%> <%city%>             \ifhmode\\\fi
+    <%country%>                      %
+  <%end%> %
   }
 
   % Bei Kontaktperson Anrede nach Geschlecht unterscheiden.

--- a/templates/print/mersiha/proforma.tex
+++ b/templates/print/mersiha/proforma.tex
@@ -41,11 +41,12 @@
       \par
       \normalsize
       <%shiptoname%>\par
-      <%if shiptocontact%> <%shiptocontact%><%end if%>\par
       <%shiptodepartment_1%>\par
       <%shiptodepartment_2%>\par
+      <%if shiptocontact%> <%shiptocontact%><%else%><%cp_title%> <%cp_givenname%> <%cp_name%><%end if%>\par
       <%shiptostreet%>\par
-      <%shiptozipcode%> <%shiptocity%>%
+      <%shiptozipcode%> <%shiptocity%>\par
+      <%shiptocountry%>
     }
   \end{lrbox}
   \makeatother

--- a/templates/print/mersiha/purchase_order.tex
+++ b/templates/print/mersiha/purchase_order.tex
@@ -53,7 +53,7 @@
 \begin{document}
 
 \begin{letter}{
-    <%name%>              \ifhmode\\\fi
+    <%name%>              \strut\\
     <%department_1%>      \ifhmode\\\fi
     <%department_2%>      \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi

--- a/templates/print/mersiha/purchase_order.tex
+++ b/templates/print/mersiha/purchase_order.tex
@@ -39,11 +39,12 @@
     \par
     \normalsize
     <%shiptoname%>\par
-    <%if shiptocontact%> <%shiptocontact%><%end if%>\par
     <%shiptodepartment_1%>\par
     <%shiptodepartment_2%>\par
+    <%if shiptocontact%> <%shiptocontact%><%else%><%cp_title%> <%cp_givenname%> <%cp_name%><%end if%>\par
     <%shiptostreet%>\par
-    <%shiptozipcode%> <%shiptocity%>%
+    <%shiptozipcode%> <%shiptocity%>\par
+    <%shiptocountry%>
   }
 \end{lrbox}
 \makeatother

--- a/templates/print/mersiha/purchase_order.tex
+++ b/templates/print/mersiha/purchase_order.tex
@@ -53,13 +53,13 @@
 \begin{document}
 
 \begin{letter}{
-    <%name%>\strut\\
-    <%if department_1%><%department_1%>\\<%end if%>%
-    <%if department_2%><%department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\
-    <%street%>\strut\\
-    <%zipcode%> <%city%>\strut\\
-    <%country%> \strut
+    <%name%>              \ifhmode\\\fi
+    <%department_1%>      \ifhmode\\\fi
+    <%department_2%>      \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%street%>            \ifhmode\\\fi
+    <%zipcode%> <%city%>  \ifhmode\\\fi
+    <%country%>           %
   }
 
   % Bei Kontaktperson Anrede nach Geschlecht unterscheiden.

--- a/templates/print/mersiha/purchase_quotation_intake.tex
+++ b/templates/print/mersiha/purchase_quotation_intake.tex
@@ -50,7 +50,7 @@
 \begin{document}
 
 \begin{letter}{
-    <%name%>              \ifhmode\\\fi
+    <%name%>              \strut\\
     <%department_1%>      \ifhmode\\\fi
     <%department_2%>      \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi

--- a/templates/print/mersiha/purchase_quotation_intake.tex
+++ b/templates/print/mersiha/purchase_quotation_intake.tex
@@ -36,11 +36,12 @@
     \par
     \normalsize
     <%shiptoname%>\par
-    <%if shiptocontact%> <%shiptocontact%><%end if%>\par
     <%shiptodepartment_1%>\par
     <%shiptodepartment_2%>\par
+    <%if shiptocontact%> <%shiptocontact%><%else%><%cp_title%> <%cp_givenname%> <%cp_name%><%end if%>\par
     <%shiptostreet%>\par
-    <%shiptozipcode%> <%shiptocity%>%
+    <%shiptozipcode%> <%shiptocity%>\par
+    <%shiptocountry%>
   }
 \end{lrbox}
 \makeatother

--- a/templates/print/mersiha/purchase_quotation_intake.tex
+++ b/templates/print/mersiha/purchase_quotation_intake.tex
@@ -50,13 +50,13 @@
 \begin{document}
 
 \begin{letter}{
-    <%name%>\strut\\
-    <%if department_1%><%department_1%>\\<%end if%>%
-    <%if department_2%><%department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\
-    <%street%>\strut\\
-    <%zipcode%> <%city%>\strut\\
-    <%country%> \strut
+    <%name%>              \ifhmode\\\fi
+    <%department_1%>      \ifhmode\\\fi
+    <%department_2%>      \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%street%>            \ifhmode\\\fi
+    <%zipcode%> <%city%>  \ifhmode\\\fi
+    <%country%>           %
   }
 
   % Bei Kontaktperson Anrede nach Geschlecht unterscheiden.

--- a/templates/print/mersiha/purchase_reclamation.tex
+++ b/templates/print/mersiha/purchase_reclamation.tex
@@ -60,7 +60,7 @@ $( END )$%
 
 \begin{letter}{
   %TODO(Tamino): what name, street, ... ?
-  $( reclamation.customervendor.name )$               \ifhmode\\\fi
+  $( reclamation.customervendor.name )$               \strut\\
   $( reclamation.customervendor.department_1 )$       \ifhmode\\\fi
   $( reclamation.customervendor.department_2 )$       \ifhmode\\\fi
   $( reclamation.contact.cp_givenname )$ $( reclamation.contact.cp_name )$ \ifhmode\\\fi

--- a/templates/print/mersiha/purchase_reclamation.tex
+++ b/templates/print/mersiha/purchase_reclamation.tex
@@ -60,13 +60,13 @@ $( END )$%
 
 \begin{letter}{
   %TODO(Tamino): what name, street, ... ?
-  $( reclamation.customervendor.name )$\strut\\
-  $( IF (reclamation.customervendor.department_1) )$$( reclamation.customervendor.department_1 )$\\$( END )$%
-  $( IF (reclamation.customervendor.department_2) )$$( reclamation.customervendor.department_2 )$\\$( END )$%
-  $( reclamation.contact.cp_givenname )$ $( reclamation.contact.cp_name )$\strut\\
-  $( reclamation.customervendor.street )$\strut\\
-  $( reclamation.customervendor.zipcode )$ $( city )$\strut\\
-  $( reclamation.customervendor.country )$ \strut
+  $( reclamation.customervendor.name )$               \ifhmode\\\fi
+  $( reclamation.customervendor.department_1 )$       \ifhmode\\\fi
+  $( reclamation.customervendor.department_2 )$       \ifhmode\\\fi
+  $( reclamation.contact.cp_givenname )$ $( reclamation.contact.cp_name )$ \ifhmode\\\fi
+  $( reclamation.customervendor.street )$             \ifhmode\\\fi
+  $( reclamation.customervendor.zipcode )$ $( city )$ \ifhmode\\\fi
+  $( reclamation.customervendor.country )$ %
     }
 
     % Bei Kontaktperson Anrede nach Geschlecht unterscheiden.

--- a/templates/print/mersiha/receipt.tex
+++ b/templates/print/mersiha/receipt.tex
@@ -31,10 +31,10 @@
 \begin{document}
 
 \begin{letter}{
-    <%name%>\ifhmode\\\fi
-    <%street%>\ifhmode\\\fi
-    <%zipcode%> <%city%>\ifhmode\\\fi
-    <%country%>%
+    <%name%>              \ifhmode\\\fi
+    <%street%>            \ifhmode\\\fi
+    <%zipcode%> <%city%>  \ifhmode\\\fi
+    <%country%>           %
   }
 
   \opening{<%company%>}

--- a/templates/print/mersiha/receipt.tex
+++ b/templates/print/mersiha/receipt.tex
@@ -31,7 +31,7 @@
 \begin{document}
 
 \begin{letter}{
-    <%name%>              \ifhmode\\\fi
+    <%name%>              \strut\\
     <%street%>            \ifhmode\\\fi
     <%zipcode%> <%city%>  \ifhmode\\\fi
     <%country%>           %

--- a/templates/print/mersiha/sales_delivery_order.tex
+++ b/templates/print/mersiha/sales_delivery_order.tex
@@ -32,7 +32,7 @@
 
 \begin{letter}{
     <%if shiptoname%> % ABWEICHENDE LIEFERADRESSE (Aus Stammdaten oder Beleg)
-      <%shiptoname%>          \ifhmode\\\fi
+      <%shiptoname%>          \strut\\
       <%shiptodepartment_1%>  \ifhmode\\\fi
       <%shiptodepartment_2%>  \ifhmode\\\fi
       <%if shiptocontact%> <%shiptocontact%> <%else%> <%cp_title%> <%cp_givenname%> <%cp_name%> <%end if%> \ifhmode\\\fi
@@ -40,7 +40,7 @@
       <%shiptozipcode%> <%shiptocity%> \ifhmode\\\fi
       <%shiptocountry%>       %
     <%else%> % KEINE ABWEICHENDE LIEFERADRESSE
-      <%name%>                \ifhmode\\\fi
+      <%name%>                \strut\\
       <%department_1%>        \ifhmode\\\fi
       <%department_2%>        \ifhmode\\\fi
       <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi

--- a/templates/print/mersiha/sales_delivery_order.tex
+++ b/templates/print/mersiha/sales_delivery_order.tex
@@ -31,22 +31,23 @@
 \begin{document}
 
 \begin{letter}{
-    \Ifstr{<%shiptoname%>}{}{ % KEINE ABWEICHENDE LIEFERADRESSE
-      <%name%>\strut\\
+    <%if shiptoname%> % ABWEICHENDE LIEFERADRESSE (Aus Stammdaten oder Beleg)
+      <%shiptoname%>\par
+      <%if shiptodepartment_1%><%shiptodepartment_1%>\par<%end if%>
+      <%if shiptodepartment_2%><%shiptodepartment_2%>\par<%end if%>
+      <%if shiptocontact%> <%shiptocontact%><%else%><%cp_title%> <%cp_givenname%> <%cp_name%><%end if%>\par
+      <%shiptostreet%>\par
+      <%shiptozipcode%> <%shiptocity%>\par
+      <%shiptocountry%>
+    <%else%> % KEINE ABWEICHENDE LIEFERADRESSE
+      <%name%>\par
       <%if department_1%><%department_1%>\\<%end if%>%
       <%if department_2%><%department_2%>\\<%end if%>%
-      <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\
-      <%street%>\strut\\
-      <%zipcode%> <%city%>\strut\\
-      <%country%> \strut
-    }{ % ABWEICHENDE LIEFERADRESSE (Aus Stammdaten oder Beleg)
-      <%shiptoname%>\strut\\
-      <%if shiptocontact%> <%shiptocontact%><%end if%>\strut\\
-      <%shiptodepartment_1%>\strut\\
-      <%shiptodepartment_2%>\strut\\
-      <%shiptostreet%>\strut\\
-      <%shiptozipcode%> <%shiptocity%>\strut
-    } % ende ifthenelse LIEFERADRESSE
+      <%cp_title%> <%cp_givenname%> <%cp_name%>\par
+      <%street%>\par
+      <%zipcode%> <%city%>\par
+      <%country%>
+    <%end%> %
   }
 
   \opening{}

--- a/templates/print/mersiha/sales_delivery_order.tex
+++ b/templates/print/mersiha/sales_delivery_order.tex
@@ -32,21 +32,21 @@
 
 \begin{letter}{
     <%if shiptoname%> % ABWEICHENDE LIEFERADRESSE (Aus Stammdaten oder Beleg)
-      <%shiptoname%>\par
-      <%if shiptodepartment_1%><%shiptodepartment_1%>\par<%end if%>
-      <%if shiptodepartment_2%><%shiptodepartment_2%>\par<%end if%>
-      <%if shiptocontact%> <%shiptocontact%><%else%><%cp_title%> <%cp_givenname%> <%cp_name%><%end if%>\par
-      <%shiptostreet%>\par
-      <%shiptozipcode%> <%shiptocity%>\par
-      <%shiptocountry%>
+      <%shiptoname%>          \ifhmode\\\fi
+      <%shiptodepartment_1%>  \ifhmode\\\fi
+      <%shiptodepartment_2%>  \ifhmode\\\fi
+      <%if shiptocontact%> <%shiptocontact%> <%else%> <%cp_title%> <%cp_givenname%> <%cp_name%> <%end if%> \ifhmode\\\fi
+      <%shiptostreet%>        \ifhmode\\\fi
+      <%shiptozipcode%> <%shiptocity%> \ifhmode\\\fi
+      <%shiptocountry%>       %
     <%else%> % KEINE ABWEICHENDE LIEFERADRESSE
-      <%name%>\par
-      <%if department_1%><%department_1%>\\<%end if%>%
-      <%if department_2%><%department_2%>\\<%end if%>%
-      <%cp_title%> <%cp_givenname%> <%cp_name%>\par
-      <%street%>\par
-      <%zipcode%> <%city%>\par
-      <%country%>
+      <%name%>                \ifhmode\\\fi
+      <%department_1%>        \ifhmode\\\fi
+      <%department_2%>        \ifhmode\\\fi
+      <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+      <%street%>              \ifhmode\\\fi
+      <%zipcode%> <%city%>    \ifhmode\\\fi
+      <%country%>             %
     <%end%> %
   }
 

--- a/templates/print/mersiha/sales_order.tex
+++ b/templates/print/mersiha/sales_order.tex
@@ -46,11 +46,12 @@
     \par
     \normalsize
     <%shiptoname%>\par
-    <%if shiptocontact%> <%shiptocontact%><%end if%>\par
     <%shiptodepartment_1%>\par
     <%shiptodepartment_2%>\par
+    <%if shiptocontact%> <%shiptocontact%><%else%><%cp_title%> <%cp_givenname%> <%cp_name%><%end if%>\par
     <%shiptostreet%>\par
-    <%shiptozipcode%> <%shiptocity%>%
+    <%shiptozipcode%> <%shiptocity%>\par
+    <%shiptocountry%>
   }
 \end{lrbox}
 \makeatother

--- a/templates/print/mersiha/sales_order.tex
+++ b/templates/print/mersiha/sales_order.tex
@@ -60,7 +60,7 @@
 \begin{document}
 
 \begin{letter}{
-    <%name%>              \ifhmode\\\fi
+    <%name%>              \strut\\
     <%department_1%>      \ifhmode\\\fi
     <%department_2%>      \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi

--- a/templates/print/mersiha/sales_order.tex
+++ b/templates/print/mersiha/sales_order.tex
@@ -84,7 +84,7 @@
 
   \auftragsformel
 
-  \begin{PricingTabular*}[pricetotal/colspec = K]
+  \begin{PricingTabular*}[price/colspec = K, pricetotal/colspec = K]
     % eigentliche Tabelle
     \FakeTable{
     <%foreach number%>%
@@ -98,9 +98,14 @@
       <%if projectnumber%>\ExtraDescription{\projektnummer: <%projectnumber%>}<%end projectnumber%>%
       &%
       <%qty%> <%unit%> &%
-      <%sellprice%>&%
+      <%sellprice%>\,\currency&%
       <%if optional%>\optional<%else%><%linetotal%>\,\currency<%if p_discount%>\par{\sffamily\scriptsize{(-<%p_discount%>\,\%)}}<%end p_discount%><%end optional%>
       \tabularnewline
+      <%if discount_sub%>
+        \rlap{\zwischensumme}& & & & &
+        <%discount_sub%>\,\currency
+        \tabularnewline
+      <%end%>
     <%end number%>%
     }%
     \begin{PricingTotal}%

--- a/templates/print/mersiha/sales_order.tex
+++ b/templates/print/mersiha/sales_order.tex
@@ -60,13 +60,13 @@
 \begin{document}
 
 \begin{letter}{
-    <%name%>\strut\\
-    <%if department_1%><%department_1%>\\<%end if%>%
-    <%if department_2%><%department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\
-    <%street%>\strut\\
-    <%zipcode%> <%city%>\strut\\
-    <%country%> \strut
+    <%name%>              \ifhmode\\\fi
+    <%department_1%>      \ifhmode\\\fi
+    <%department_2%>      \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%street%>            \ifhmode\\\fi
+    <%zipcode%> <%city%>  \ifhmode\\\fi
+    <%country%>           %
   }
 
   % Bei Kontaktperson Anrede nach Geschlecht unterscheiden.

--- a/templates/print/mersiha/sales_quotation.tex
+++ b/templates/print/mersiha/sales_quotation.tex
@@ -98,9 +98,14 @@
       <%if projectnumber%>\ExtraDescription{\projektnummer: <%projectnumber%>}<%end projectnumber%>%
       &%
       <%qty%> <%unit%> &%
-      <%sellprice%>&%
+      <%sellprice%>\,\currency&%
       <%if optional%>\optional<%else%><%linetotal%>\,\currency<%if p_discount%>\par{\sffamily\scriptsize{(-<%p_discount%>\,\%)}}<%end p_discount%><%end optional%>
       \tabularnewline
+      <%if discount_sub%>
+        \rlap{\zwischensumme}& & & & &
+        <%discount_sub%>\,\currency
+        \tabularnewline
+      <%end%>
     <%end number%>%
     }
     \begin{PricingTotal}

--- a/templates/print/mersiha/sales_quotation.tex
+++ b/templates/print/mersiha/sales_quotation.tex
@@ -46,11 +46,12 @@
       \par
       \normalsize
       <%shiptoname%>\par
-      <%if shiptocontact%> <%shiptocontact%><%end if%>\par
       <%shiptodepartment_1%>\par
       <%shiptodepartment_2%>\par
+      <%if shiptocontact%> <%shiptocontact%><%else%><%cp_title%> <%cp_givenname%> <%cp_name%><%end if%>\par
       <%shiptostreet%>\par
-      <%shiptozipcode%> <%shiptocity%>%
+      <%shiptozipcode%> <%shiptocity%>\par
+      <%shiptocountry%>
     }
   \end{lrbox}
   \makeatother

--- a/templates/print/mersiha/sales_quotation.tex
+++ b/templates/print/mersiha/sales_quotation.tex
@@ -59,7 +59,7 @@
 
 
 \begin{letter}{
-    <%name%>              \ifhmode\\\fi
+    <%name%>              \strut\\
     <%department_1%>      \ifhmode\\\fi
     <%department_2%>      \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi

--- a/templates/print/mersiha/sales_quotation.tex
+++ b/templates/print/mersiha/sales_quotation.tex
@@ -59,13 +59,13 @@
 
 
 \begin{letter}{
-    <%name%>\strut\\
-    <%if department_1%><%department_1%>\\<%end if%>%
-    <%if department_2%><%department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\
-    <%street%>\strut\\
-    <%zipcode%> <%city%>\strut\\
-    <%country%> \strut
+    <%name%>              \ifhmode\\\fi
+    <%department_1%>      \ifhmode\\\fi
+    <%department_2%>      \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%street%>            \ifhmode\\\fi
+    <%zipcode%> <%city%>  \ifhmode\\\fi
+    <%country%>           %
   }
 
   % Bei Kontaktperson Anrede nach Geschlecht unterscheiden.

--- a/templates/print/mersiha/sales_quotation.tex
+++ b/templates/print/mersiha/sales_quotation.tex
@@ -85,7 +85,7 @@
   \angebotsformel
 
 
-  \begin{PricingTabular*}[pricetotal/colspec = K]
+  \begin{PricingTabular*}[price/colspec = K, pricetotal/colspec = K]
     % eigentliche Tabelle
     \FakeTable{
     <%foreach number%>%

--- a/templates/print/mersiha/sales_reclamation.tex
+++ b/templates/print/mersiha/sales_reclamation.tex
@@ -59,7 +59,7 @@ $( END )$%
 
 \begin{letter}{
   %TODO(Tamino): what name, street, ... ?
-  $( reclamation.customervendor.name )$         \ifhmode\\\fi
+  $( reclamation.customervendor.name )$         \strut\\
   $( reclamation.customervendor.department_1 )$ \ifhmode\\\fi
   $( reclamation.customervendor.department_2 )$ \ifhmode\\\fi
   $( reclamation.contact.cp_givenname )$ $( reclamation.contact.cp_name )$ \ifhmode\\\fi

--- a/templates/print/mersiha/sales_reclamation.tex
+++ b/templates/print/mersiha/sales_reclamation.tex
@@ -59,13 +59,13 @@ $( END )$%
 
 \begin{letter}{
   %TODO(Tamino): what name, street, ... ?
-  $( reclamation.customervendor.name )$\strut\\
-  $( IF (reclamation.customervendor.department_1) )$$( reclamation.customervendor.department_1 )$\\$( END )$%
-  $( IF (reclamation.customervendor.department_2) )$$( reclamation.customervendor.department_2 )$\\$( END )$%
-  $( reclamation.contact.cp_givenname )$ $( reclamation.contact.cp_name )$\strut\\
-  $( reclamation.customervendor.street )$\strut\\
-  $( reclamation.customervendor.zipcode )$ $( city )$\strut\\
-  $( reclamation.customervendor.country )$ \strut
+  $( reclamation.customervendor.name )$         \ifhmode\\\fi
+  $( reclamation.customervendor.department_1 )$ \ifhmode\\\fi
+  $( reclamation.customervendor.department_2 )$ \ifhmode\\\fi
+  $( reclamation.contact.cp_givenname )$ $( reclamation.contact.cp_name )$ \ifhmode\\\fi
+  $( reclamation.customervendor.street )$       \ifhmode\\\fi
+  $( reclamation.customervendor.zipcode )$ $( city )$ \ifhmode\\\fi
+  $( reclamation.customervendor.country )$      %
     }
 
     % Bei Kontaktperson Anrede nach Geschlecht unterscheiden.

--- a/templates/print/mersiha/supplier_delivery_order.tex
+++ b/templates/print/mersiha/supplier_delivery_order.tex
@@ -39,21 +39,22 @@
 <%if shiptoname%>%
 \makeatletter
 \begin{lrbox}\shippingAddressBox
-	\parbox{\useplength{toaddrwidth}}{
-		\backaddr@format{\scriptsize\usekomafont{backaddress}%
-			\strut\abweichendeLieferadresse
-		}
-		\par\smallskip
-		\setlength{\parskip}{\z@}
-		\par
-		\normalsize
-		<%shiptoname%>\par
-		<%if shiptocontact%> <%shiptocontact%><%end if%>\par
-		<%shiptodepartment_1%>\par
-		<%shiptodepartment_2%>\par
-		<%shiptostreet%>\par
-		<%shiptozipcode%> <%shiptocity%>%
-	}
+  \parbox{\useplength{toaddrwidth}}{
+    \backaddr@format{\scriptsize\usekomafont{backaddress}%
+      \strut\abweichendeLieferadresse
+    }
+    \par\smallskip
+    \setlength{\parskip}{\z@}
+    \par
+    \normalsize
+    <%shiptoname%>\par
+    <%shiptodepartment_1%>\par
+    <%shiptodepartment_2%>\par
+    <%if shiptocontact%> <%shiptocontact%><%else%><%cp_title%> <%cp_givenname%> <%cp_name%><%end if%>\par
+    <%shiptostreet%>\par
+    <%shiptozipcode%> <%shiptocity%>\par
+    <%shiptocountry%>
+  }
 \end{lrbox}
 \makeatother
 <%end shiptoname%>%

--- a/templates/print/mersiha/supplier_delivery_order.tex
+++ b/templates/print/mersiha/supplier_delivery_order.tex
@@ -64,13 +64,13 @@
 
 
 \begin{letter}{
-    <%name%>\strut\\
-    <%if department_1%><%department_1%>\\<%end if%>%
-    <%if department_2%><%department_2%>\\<%end if%>%
-    <%cp_title%> <%cp_givenname%> <%cp_name%>\strut\\
-    <%street%>\strut\\
-    <%zipcode%> <%city%>\strut\\
-    <%country%> \strut
+    <%name%>              \ifhmode\\\fi
+    <%department_1%>      \ifhmode\\\fi
+    <%department_2%>      \ifhmode\\\fi
+    <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi
+    <%street%>            \ifhmode\\\fi
+    <%zipcode%> <%city%>  \ifhmode\\\fi
+    <%country%>           %
   }
 
 

--- a/templates/print/mersiha/supplier_delivery_order.tex
+++ b/templates/print/mersiha/supplier_delivery_order.tex
@@ -64,7 +64,7 @@
 
 
 \begin{letter}{
-    <%name%>              \ifhmode\\\fi
+    <%name%>              \strut\\
     <%department_1%>      \ifhmode\\\fi
     <%department_2%>      \ifhmode\\\fi
     <%cp_title%> <%cp_givenname%> <%cp_name%> \ifhmode\\\fi

--- a/templates/print/mersiha/zahlungserinnerung.tex
+++ b/templates/print/mersiha/zahlungserinnerung.tex
@@ -23,7 +23,7 @@
 \setkomavar{info6}[\textEmail]      {<%employee_email%>}
 \setkomavar{fromname}               {<%employee_name%>}
 
-\setkomavar{title}{\mahnung<%if dunning_id%>~\nr~<%dunning_id%><%end if%>%}
+\setkomavar{title}{\mahnung<%if dunning_id%>~\nr~<%dunning_id%><%end if%>}
 
 \begin{document}
 

--- a/templates/print/mersiha/zahlungserinnerung.tex
+++ b/templates/print/mersiha/zahlungserinnerung.tex
@@ -13,7 +13,7 @@
 
 
 % laufende Kopfzeile:
-\ourhead{\kundennummer}{<%customernumber%>}{\mahnung}{<%dunning_id%>}{<%dunning%>}
+\ourhead{\kundennummer}{<%customernumber%>}{\zahlungserinnerung}{<%dunning_id%>}{<%dunning%>}
 
 \setkomavar{info0}[\vorgangsbez]    {<%transaction_description%>}
 \setkomavar{info1}[\datum]          {<%dunning_date%>}


### PR DESCRIPTION
Verbesserungen aus einem Kundenprojekt:
- Fehler beim Pflichtenheft-drucken behoben
- Fehler beim Zahlungerrinerung drucken behoben
- Druckvorlage für Mahnungen angelegt
- Storno-Rechnungen haben nun Titel "Rechnungs-Storno zu..." statt "Rechnung Storno zu..."
- Seitenzahlen in ZUGFeRD-Rechnungen werden nicht mehr rot umrandet