### PR TITLE
S:Form: generate email body, even if salutation_general is unset

### DIFF
--- a/SL/Form.pm
+++ b/SL/Form.pm
@@ -1281,8 +1281,6 @@ sub generate_email_body {
     $body  = GenericTranslations->get(translation_type => "salutation_general", language_id => $self->{language_id});
   }
 
-  return undef unless $body;
-
   $body .= GenericTranslations->get(translation_type => "salutation_punctuation_mark", language_id => $self->{language_id});
   $body  = '<p>' . $::locale->quote_special_chars('HTML', $body) . '</p>';
 


### PR DESCRIPTION
Aus einem Kundenprojekt:

The previous behaviour was to return undef, which was not checked at the call-site. This left the user with no preset email text, whatsoever, providing no hint which setting is missing.

Now, we just leave out the greeting if none is set, which gives the user a higher chance to spot the missing translation.

I looked into reordering the settings (greetings first, then preset email texts later, but the sorting in the template makes this not easy, so we do without.