### PR TITLE
S:C:AccTrans: handle "no data" properly

### DIFF
--- a/SL/Controller/AccTrans.pm
+++ b/SL/Controller/AccTrans.pm
@@ -12,7 +12,7 @@ sub action_list_transactions {
 
   my $transactions = SL::DB::Manager::AccTransaction->get_all(query => [ trans_id => $::form->{trans_id} ], sort_by => 'acc_trans_id ASC');
 
-  return $self->render(\'', { type => 'json' }) unless scalar @{$transactions};
+  return $self->render('acc_trans/no_data', { layout => 0 }) unless scalar @{$transactions};
 
   my $acc_trans_table = $self->_mini_ledger($transactions);
   my $balances_table  = $self->_mini_trial_balance($transactions);

--- a/templates/design40_webpages/acc_trans/no_data.html
+++ b/templates/design40_webpages/acc_trans/no_data.html
@@ -1,0 +1,3 @@
+[% USE T8 %]
+
+<p class="message message_hint">[% 'No data was found.' | $T8 %]</p>


### PR DESCRIPTION
Aus einem Kundenprojekt:

Returning an empty response of type application/json is not a proper error handling.
I booked an invoice with a net amount of 0 and searched a while to find out why the tab "bookings" is empty... This gives a clear hint.