### PR TITLE
ZUGFeRD: require für S:D:GenericTranslation, nicht für Manager davon.

### DIFF
--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -502,7 +502,7 @@ sub _exchanged_document {
     $params{xml}->dataElement("ram:LanguageID", uc($1));
   }
 
-  require SL::DB::Manager::GenericTranslation;
+  require SL::DB::GenericTranslation;
   my $std_notes = SL::DB::Manager::GenericTranslation->get_all(
     where => [
       translation_type => 'ZUGFeRD/notes',


### PR DESCRIPTION
Ein Teil von #593 . Hier nur die Fehlerbehebung, ohne Anpassung der Fehlerbehandlung.

Die Manager-Klasse hat keine eigene Modul-Datei.