### PR TITLE
ZUGFeRD-Export: alle Fehler der ZUGFeRD-Generierung fangen.

### DIFF
--- a/bin/mozilla/io.pl
+++ b/bin/mozilla/io.pl
@@ -2373,11 +2373,7 @@ sub _maybe_attach_zugferd_data {
         mime_type    => 'text/xml',
       }
     ];
-  };
-
-  if (my $e = SL::X::ZUGFeRDValidation->caught) {
-    $::form->error($e->message);
-  }
+  } or do { $::form->error($@) };
 }
 
 sub download_factur_x_xml {
@@ -2392,11 +2388,7 @@ sub download_factur_x_xml {
       || !$record->can('create_zugferd_data')
       || !$record->customer->create_zugferd_invoices_for_this_customer;
 
-  my $xml_content = eval { $record->create_zugferd_data };
-
-  if (my $e = SL::X::ZUGFeRDValidation->caught) {
-    $::form->error($e->message);
-  }
+  my $xml_content = eval { $record->create_zugferd_data } or do { $::form->error($@) };
 
   my $attachment_filename = "factur-x_" . $::form->generate_attachment_filename;
   $attachment_filename    =~ s{\.[^.]+$}{.xml};


### PR DESCRIPTION
Weiterführung bzw. Teil von #593 . Hier nur die Anpassung der Fehlerbehandlung.

Ein require im ZUGFeRD-DB-Helper hatt eine nicht vorhandene Manager-Klasse laden wollen. Das gab einen Laufzeitfehler. Das ist inzwischen behoben.
Aber die evals beim Aufruf der entsprechenden Methode in io.pl haben die Fehler verschluckt, da diese nur die Validierungsfehler abgefangen haben, so dass außer einem internal server error kein Hinweis auf den Laufzeitfehler darauf kam.
Hier ein Fix dazu.
