### PR TITLE
DB-Upgrade-Skript: Indizes für Tabellen, die files referenzieren.

### DIFF
--- a/sql/Pg-upgrade2/indices_for_file_id.sql
+++ b/sql/Pg-upgrade2/indices_for_file_id.sql
@@ -1,0 +1,9 @@
+-- @tag: indices_for_file_id
+-- @description: Indizes für Files in referenzierenden Tabellen
+-- @depends: file_full_texts file_version shopimages oe_version
+-- @required_by: add_file_version
+
+CREATE index ON file_full_texts(file_id);
+CREATE index ON file_versions(file_id);
+CREATE index ON oe_version(file_id);
+CREATE index ON shop_images(file_id);


### PR DESCRIPTION
Das required_by-Tag wurde gewählt, um die Indizes vor dem Ausführen des add_file_versions-Skripts auszuführen, falls das noch nicht getan wurde.
Das macht keine Probleme, falls "add_file_versions" schon ausgeführt wurde - dieses Skript wird dann dennoch ausgeführt.

Hintergrund: Bei Kundeninstallationen mit vielen Dateien kann das Skript "add_file_versions" lange laufen und wird durch die Indizes beschleunigt. Vor allem auch in Test-Installationen, bei denen man die physikalischen Dateien weglässt und dann durch das Upgrade-Skript "add_file_versions" alle Einträge gelöscht werden sollen.