### PR TITLE
Hintergrund-Jobs: Environment-Variablen der Aufrufenden URL übergeben.

### DIFF
--- a/SL/BackgroundJob/Test.pm
+++ b/SL/BackgroundJob/Test.pm
@@ -11,6 +11,7 @@ sub run {
   my $data            = $db_obj->data_as_hash;
 
   $::lxdebug->message(0, "Test job ID " . $db_obj->id . " is being executed on node " . SL::System::TaskServer::node_id() . ".");
+  $::lxdebug->dump   (0, "Test job ID " . $db_obj->id . ": data ", $data);
 
   die "Oh cruel world: " . $data->{exception} if $data->{exception};
 

--- a/SL/Controller/BackgroundJob.pm
+++ b/SL/Controller/BackgroundJob.pm
@@ -9,6 +9,7 @@ use SL::Controller::Helper::GetModels;
 use SL::DB::BackgroundJob;
 use SL::Helper::Flash;
 use SL::JSON;
+use SL::YAML;
 use SL::Locale::String;
 use SL::System::TaskServer;
 
@@ -165,6 +166,11 @@ sub create_or_update {
   my $params = delete($::form->{background_job}) || { };
 
   $self->background_job->assign_attributes(%{ $params });
+
+  my $data = $self->background_job->data_as_hash;
+  $data->{HTTP_ORIGIN} = $ENV{HTTP_ORIGIN};
+  $data->{REQUEST_URI} = $ENV{REQUEST_URI};
+  $self->background_job->data(SL::YAML::Dump($data));
 
   my @errors = $self->background_job->validate;
 


### PR DESCRIPTION
Dazu HTTP_ORIGIN und REQUEST_URI zu data-Attribut des Jobs hinzufügen.

Hintergrund: Wenn ein Hintergrund-Job z.B. E-Mails mit Links zu Ressourcen in kivi verschicken will, dann braucht er die URL. Wird der Hintergrund-Job aber über die Konsole oder über einen System-Dienst gestartet, können die Umgebungsvariablen des Web-Servers nicht ausgelesen werden.

Deshalb werden diese hier beim Speichern des Jobs als Daten übergeben, so dass der Code des Hintergrund-Jobs diese nutzen kann.

Evtl. wäre es besser dafür eigene Felder in der Tabelle background_jobs anzulegen. Auch für die Information über den Benutzer und evtl. der session-id. Diese verwendet der CSV-Import schon, wäre aber evtl. für andere Hintergrund-Jobs auch sinnvoll.
