### PR TITLE
fix: Erzeugnis fertigen mit fraktionaler Menge (Komma nicht ignorieren)

### DIFF
--- a/bin/mozilla/wh.pl
+++ b/bin/mozilla/wh.pl
@@ -544,7 +544,8 @@ sub create_assembly_chargenumbers {
 
   setup_wh_create_assembly_chargenumbers_action_bar();
 
-  my $hidden_vars = { map { $_ => $form->{$_} } qw(parts_id warehouse_id bin_id bestbefore chargenumber qty unit comment) };
+  my $hidden_vars = { map { $_ => $form->{$_} } qw(parts_id warehouse_id bin_id bestbefore chargenumber unit comment) };
+  $hidden_vars->{$_} = $form->format_amount(\%main::myconfig, $form->{$_}) for qw(qty);
 
   $form->{title} = $::locale->text('Select Chargenumbers');
   $form->header;


### PR DESCRIPTION
Zuvor passierte folgendes:
Beim Erzeugnis fertigen mit Menge 1,5 wurde in der Auswahl mehrdeutiger Lagerbestände (Chargennummer / MHD) zunächst 1,5 angezeigt, nach dem ersten Klick auf Erneuern jedoch 15. Dies liegt daran, dass im Form der formatierte Zahlenwert für die Menge durchgereicht wird. Dieser Commit setzt das konsequent um.