### PR TITLE
S:H:Inventory: check_allocations_for_assembly: Rundungsfehler berücks…

### DIFF
--- a/SL/Helper/Inventory.pm
+++ b/SL/Helper/Inventory.pm
@@ -425,7 +425,7 @@ sub check_allocations_for_assembly {
     $allocations_by_part{ $assembly->parts_id } -= $assembly->qty * $qty;
   }
 
-  return (none { $_ < 0 } values %allocations_by_part) && (!$check_overfulfilment || (none { $_ > 0 } values %allocations_by_part));
+  return (none { $_ < -0.00001 } values %allocations_by_part) && (!$check_overfulfilment || (none { $_ > 0.00001 } values %allocations_by_part));
 }
 
 sub check_stock_out_transfer_requests {


### PR DESCRIPTION
…ichtigen

Beim Fertigen von nicht ganzzahligen Erzeugnissen und nicht ganzzahligen Bestandteilen kann es durch Rundungsfehler dazu kommen, dass die Allokierung minimal von 0 abweicht. Deshalb wird jetzt nicht mehr auf genau größer oder kleiner 0 geprüft, sondern größer/kleiner eines sehr kleinen Werts.

Das ist mit beim Nachvollziehen von #633 aufgefallen.