### PR TITLE
202510 fix warnung bei vorhandener rechnung

### DIFF
--- a/js/kivi.AP.js
+++ b/js/kivi.AP.js
@@ -33,7 +33,8 @@ namespace('kivi.AP', function(ns){
       url: 'controller.pl',
       data: { action: 'SalesPurchase/check_duplicate_invnumber',
               vendor_id    : $('#vendor_id').val(),
-              invnumber    : $('#invnumber').val()
+              invnumber    : $('#invnumber').val(),
+              id           : $('#id').val()
       },
       method: "GET",
       async: false,


### PR DESCRIPTION
Die Warnung bei schon vorhandener Rechnungsnummer bei gleichem Lieferant warnte auch, wenn ein vorhandener Beleg geändert wurde, bei dem Nummer und Lieferant gleich war, also der Beleg selber wurde als Dublette gefunden.

Das wird hiermit verhindert.