### PR TITLE
202510 feat lagerjournal optimierung paginierung

### DIFF
--- a/SL/WH.pm
+++ b/SL/WH.pm
@@ -206,6 +206,12 @@ sub get_warehouse_journal {
   # connect to database
   my $dbh = $form->get_standard_dbh($myconfig);
 
+
+  my $count_only = delete $filter{count_only};
+  if ($count_only) {
+    delete local $form->{l_oe_id};
+  }
+
   # filters
   my (@filter_ary, @filter_vars, $joins, %select_tokens, %select);
 
@@ -390,8 +396,10 @@ sub get_warehouse_journal {
 
   $where_clause = defined($where_clause) ? $where_clause : '';
 
+  my $columns = $count_only ? 'COUNT(*)' : '*';
+
   my $query =
-  qq|SELECT * FROM (
+  qq|SELECT $columns FROM (
 
      SELECT DISTINCT $select{trans}
      FROM inventory i1
@@ -455,6 +463,11 @@ sub get_warehouse_journal {
   }
 
   my $sth = prepare_execute_query($form, $dbh, $query, @all_vars);
+
+  if ($count_only) {
+    $main::lxdebug->leave_sub();
+    return $sth->fetchrow_array();
+  }
 
   my ($h_oe_id, $q_oe_id);
   if ($form->{l_oe_id}) {

--- a/SL/WH.pm
+++ b/SL/WH.pm
@@ -379,10 +379,11 @@ sub get_warehouse_journal {
      };
 
   $form->{l_classification_id}  = 'Y';
-  $form->{l_trans_id}           = 'Y';
   $form->{l_part_type}          = 'Y';
   $form->{l_itime}              = 'Y';
   $form->{l_invoice_id} = $form->{l_oe_id} if $form->{l_oe_id};
+
+  local $form->{l_trans_id}     = 'Y';
 
   # build the select clauses.
   # take all the requested ones from the first hash and overwrite them from the out/in hashes if present.

--- a/bin/mozilla/wh.pl
+++ b/bin/mozilla/wh.pl
@@ -768,6 +768,12 @@ sub generate_journal {
 
   my $allrows        = !!($form->{report_generator_output_format} ne 'HTML') ;
 
+  # get maxcount
+  if (!$allrows && !$form->{maxrows}) {
+    local $filter{count_only} = 1;
+    $form->{maxrows} = WH->get_warehouse_journal(%filter);
+  }
+
   # manual paginating
   my $pages          = {};
   my $page           = $::form->{page} || 1;
@@ -787,7 +793,7 @@ sub generate_journal {
   my @contents  = WH->get_warehouse_journal(%filter);
   $form->{l_trans_id} = $old_l_trans_id;
 
-  # get maxcount
+  # get maxcount if not already got
   if (!$form->{maxrows}) {
     $form->{maxrows} = scalar @contents ;
   }

--- a/bin/mozilla/wh.pl
+++ b/bin/mozilla/wh.pl
@@ -771,9 +771,7 @@ sub generate_journal {
   # get maxcount
   if (!$allrows && !$form->{maxrows}) {
     local $filter{count_only} = 1;
-    my $old_l_trans_id  = $form->{l_trans_id};
-    $form->{maxrows}    = WH->get_warehouse_journal(%filter);
-    $form->{l_trans_id} = $old_l_trans_id;
+    $form->{maxrows} = WH->get_warehouse_journal(%filter);
   }
 
   # manual paginating
@@ -791,9 +789,7 @@ sub generate_journal {
     $last_nr        = $pages->{per_page};
   }
 
-  my $old_l_trans_id = $form->{l_trans_id};
   my @contents  = WH->get_warehouse_journal(%filter);
-  $form->{l_trans_id} = $old_l_trans_id;
 
   # get maxcount if not already got
   if (!$form->{maxrows}) {

--- a/bin/mozilla/wh.pl
+++ b/bin/mozilla/wh.pl
@@ -771,7 +771,9 @@ sub generate_journal {
   # get maxcount
   if (!$allrows && !$form->{maxrows}) {
     local $filter{count_only} = 1;
-    $form->{maxrows} = WH->get_warehouse_journal(%filter);
+    my $old_l_trans_id  = $form->{l_trans_id};
+    $form->{maxrows}    = WH->get_warehouse_journal(%filter);
+    $form->{l_trans_id} = $old_l_trans_id;
   }
 
   # manual paginating


### PR DESCRIPTION
Für die Paginierung wurde die Anzahl der Einträge beim Lagerbuchungsbericht mit der ersten Query ohne Limit und Offset ermittelt. Dabei wurden auch alle benötigten Spalten aller Einträge geholt.
Die Ermittlung der Anzahl für die Paginierung erfolgt nun in einer ersten Abfrage nur mit 'COUNT(*)' . Die eigentliche Abfrage kann dann direkt limitiert ausgeführt werden.
Jetzt gibt es zwar beim ersten Aufruf eine weitere Abfrage, aber dennoch wird der Bericht schneller, vor allem, wenn eine große Anzahl von Lagerbewegungen vorhanden ist.