### PR TITLE
S:C:Reconciliation: Erlaube Abgleich nur bei Summe 0,00

### DIFF
--- a/SL/Controller/Reconciliation.pm
+++ b/SL/Controller/Reconciliation.pm
@@ -281,7 +281,7 @@ sub _get_proposals {
     #add proposal if something in acc_trans was found
     #otherwise try to find another entry in acc_trans and add it
     # for linked_records we allow a slight difference / imprecision, for acc_trans search we don't
-    if (scalar @{ $proposal->{BB} } and abs($check_sum) <= 0.01 ) {
+    if (scalar @{ $proposal->{BB} } and abs($check_sum) < 0.005 ) {
       push @proposals, $proposal;
     } elsif (!scalar @{ $proposal->{BB} }) {
       # use account_number and iban for matching remote account number


### PR DESCRIPTION
Zuvor war der Bankabgleich auch möglich, wenn die Banktransaktion und die Summe der Buchungsbeträge sich nicht aufgehoben haben.

Hierbei werden die auf 2 Dezimalstellen gerundeten Werte berücksichtigt, weshalb auf 0.005 (wird zu 0.01 aufgerundet) geprüft werden muss.