### PR TITLE
CSVImport Aufträge: richtige Fehlermeldung, wenn Kunde/Lieferant nich…

### DIFF
--- a/SL/Controller/CsvImport/Order.pm
+++ b/SL/Controller/CsvImport/Order.pm
@@ -391,11 +391,9 @@ sub handle_type {
     # if no type is present - set to sales order or purchase
     # order depending on customer/vendor
 
-    $entry->{object}->record_type(
-      $entry->{object}->customer_id ? SALES_ORDER_TYPE :
-      $entry->{object}->vendor_id   ? PURCHASE_ORDER_TYPE
-                                    : undef
-    );
+    $entry->{object}->record_type($entry->{object}->customer_id
+                                  ? SALES_ORDER_TYPE
+                                  : PURCHASE_ORDER_TYPE);
   }
 
   $entry->{info_data}->{record_type} = $::locale->text($entry->{object}->record_type);

--- a/t/controllers/csvimport/orders.t
+++ b/t/controllers/csvimport/orders.t
@@ -162,6 +162,31 @@ $entry = $entries->[12];
 is $entry->{object}->record_type, PURCHASE_ORDER_CONFIRMATION_TYPE, '"purchase_order_confirmation" as explicitly given record type works';
 
 #####
+# test error handling if no customer or vendor ist given/found
+#####
+$file = \<<EOL;
+datatype;customer;vendor
+datatype;description;qty
+Order;;
+OrderItem;TestPart1;
+Order;CustomerUnknown;
+OrderItem;TestPart2;10
+Order;;VendorUnknown
+OrderItem;TestPart2;20
+EOL
+
+$entries = do_import($file);
+
+$entry = $entries->[0];
+is $entry->{errors}->[0], 'Error: Customer/vendor missing', 'show correct error if customer/vendor missing';
+
+$entry = $entries->[2];
+is $entry->{errors}->[0], 'Error: Customer/vendor not found', 'show correct error if customer not found';
+
+$entry = $entries->[4];
+is $entry->{errors}->[0], 'Error: Customer/vendor not found', 'show correct error if vendor not found';
+
+#####
 $entries = undef;
 clear_up;
 


### PR DESCRIPTION
…t gefunden

Vorher wurde irgendwo eine Ausname geworfen, da der record_type nicht ermittelt werden konnte und es gab keinen Hinweis darauf, dass Kunde oder Lieferant nicht gefunden wurde.