### PR TITLE
S:C:Order|DeliveryOrder|Reclamation: Als neu speichern: zu löschende …

### DIFF
--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -255,6 +255,11 @@ sub action_save_as_new {
     )->token;
   }
 
+  # item_ids_to_delete contains item ids from the saved order
+  # if items where removed before the save_as_new-action was called.
+  # So clear it before saving the new order object.
+  $self->item_ids_to_delete([]);
+
   # save
   $self->action_save();
 }

--- a/SL/Controller/Order.pm
+++ b/SL/Controller/Order.pm
@@ -318,6 +318,11 @@ sub action_save_as_new {
     $::form->{form_validity_token} = SL::DB::ValidityToken->create(scope => SL::DB::ValidityToken::SCOPE_ORDER_SAVE())->token;
   }
 
+  # item_ids_to_delete contains item ids from the saved order
+  # if items where removed before the save_as_new-action was called.
+  # So clear it before saving the new order object.
+  $self->item_ids_to_delete([]);
+
   # save
   $self->action_save();
 }

--- a/SL/Controller/Reclamation.pm
+++ b/SL/Controller/Reclamation.pm
@@ -250,6 +250,11 @@ sub action_save_as_new {
     $::form->{form_validity_token} = SL::DB::ValidityToken->create(scope => SL::DB::ValidityToken::SCOPE_RECLAMATION_SAVE())->token;
   }
 
+  # item_ids_to_delete contains item ids from the saved order
+  # if items where removed before the save_as_new-action was called.
+  # So clear it before saving the new order object.
+  $self->item_ids_to_delete([]);
+
   # save
   $self->action_save();
 }


### PR DESCRIPTION
…Pos. reseten

Das behebt einen Bug, wo beim "als neu speichern" im alten Beleg entfernte Positonen aus diesem gelöscht werden, obwohl die nur nicht in den neuen Beleg übernommen werden sollten.

Diese Controller merken sich die zu löschenden Positionen vor dem Speichern, da diese nicht mehr in die items gelangen, wenn das Objekt aufgebaut wird, aber beim Speichern noch in der Datenbank blieben, wenn diese nicht extra entfernt werden.

Dies darf aber beim "als neu speichern" nicht passieren, da diese ids zum Vorgänger-Beleg (dem alten Beleg) gehören.