### PR TITLE
Lieferscheinbericht: Spalte Versandort zur Anzeige auswählbar

### DIFF
--- a/SL/DO.pm
+++ b/SL/DO.pm
@@ -309,6 +309,7 @@ SQL
     "name"                    => "ct.name",
     "employee"                => "e.name",
     "salesman"                => "sm.name",
+    "shippingpoint"           => "dord.shippingpoint",
     "shipvia"                 => "dord.shipvia",
     "transaction_description" => "dord.transaction_description",
     "department"              => "lower(dep.description)",

--- a/bin/mozilla/do.pl
+++ b/bin/mozilla/do.pl
@@ -160,7 +160,7 @@ sub orders {
     customernumber          vendor_confirmation_number
     cusordnumber
     name                    employee  salesman
-    shipvia                 globalprojectnumber
+    shippingpoint shipvia   globalprojectnumber
     transaction_description department
     open                    delivered
     insertdate              items
@@ -196,6 +196,7 @@ sub orders {
     'name'                    => { 'text' => $form->{vc} eq 'customer' ? $locale->text('Customer') : $locale->text('Vendor'), },
     'employee'                => { 'text' => $locale->text('Employee'), },
     'salesman'                => { 'text' => $locale->text('Salesman'), },
+    'shippingpoint'           => { 'text' => $locale->text('Shipping Point'), },
     'shipvia'                 => { 'text' => $locale->text('Ship via'), },
     'globalprojectnumber'     => { 'text' => $locale->text('Project Number'), },
     'transaction_description' => { 'text' => $locale->text('Transaction description'), },
@@ -208,7 +209,7 @@ sub orders {
     'order_confirmation_number'  => { 'text' => $locale->text('Order Confirmation Number'), },
   );
 
-  foreach my $name (qw(id transdate reqdate donumber ordnumber name employee salesman shipvia transaction_description department insertdate vendor_confirmation_number)) {
+  foreach my $name (qw(id transdate reqdate donumber ordnumber name employee salesman shippingpoint shipvia transaction_description department insertdate vendor_confirmation_number)) {
     my $sortdir                 = $form->{sort} eq $name ? 1 - $form->{sortdir} : $form->{sortdir};
     $column_defs{$name}->{link} = $href . "&sort=$name&sortdir=$sortdir";
   }

--- a/templates/design40_webpages/do/search.html
+++ b/templates/design40_webpages/do/search.html
@@ -258,6 +258,9 @@
       <input name="l_shipvia" id="l_shipvia" type="checkbox" value="Y">
       <label for="l_shipvia">[% 'Ship via' | $T8 %]</label>
     </div>
+    <div>
+      [% L.checkbox_tag('l_shippingpoint', label => LxERP.t8('Shipping Point')) %]
+    </div>
   </div>
 </div><!-- /.form-addition /.wrapper -->
 


### PR DESCRIPTION
Konkret in einem Kundenprojekt so benötigt;
Bringt diesen Bericht etwas näher an den Auftrags- und den Rechnungsbericht.