### PR TITLE
RG: Tab "Buchungen": xss durch escaping verhindern

### DIFF
--- a/templates/design40_webpages/acc_trans/_mini_ledger.html
+++ b/templates/design40_webpages/acc_trans/_mini_ledger.html
@@ -19,8 +19,8 @@
     [% FOREACH transaction = TRANSACTIONS %]
     <tr>
       <td class="date">[% transaction.transdate.to_kivitendo %]</td>
-      <td class="center">[% transaction.chart.accno %]</td>
-      <td>[% transaction.chart.description %]</td>
+      <td class="center">[% transaction.chart.accno | html %]</td>
+      <td>[% transaction.chart.description | html %]</td>
       <td class="numeric">[% IF transaction.amount < 0 %] [% LxERP.format_amount(transaction.amount * -1, 2) %] [% END %]</td>
       <td class="numeric">[% IF transaction.amount > 0 %] [% LxERP.format_amount(transaction.amount , 2) %] [% END %]</td>
     </tr>

--- a/templates/design40_webpages/acc_trans/_mini_trial_balance.html
+++ b/templates/design40_webpages/acc_trans/_mini_trial_balance.html
@@ -17,8 +17,8 @@
   <tbody>
     [% FOREACH balance = BALANCES %]
     <tr>
-      <td class="numeric-centered">[% balance.accno %]</td>
-      <td>[% balance.description %]</td>
+      <td class="numeric-centered">[% balance.accno | html %]</td>
+      <td>[% balance.description | html %]</td>
       <td class="numeric">[% IF balance.balance < 0 %] [% LxERP.format_amount(balance.balance * -1, 2) %] [% END %]</td>
       <td class="numeric">[% IF balance.balance > 0 %] [% LxERP.format_amount(balance.balance, 2) %] [% END %]</td>
     </tr>


### PR DESCRIPTION
Kontonummern und Kontobeschreibung kommen vom Benutzer und müssen escaped werden, sonst kann darin untergebrachter js-Code ausgeführt werden.