### PR TITLE
tests: t/fx/aptransactions.t: nicht von Debug-Ausgabe verwirren lassen

### DIFF
--- a/t/fxtransaction/ap_transactions.t
+++ b/t/fxtransaction/ap_transactions.t
@@ -256,6 +256,7 @@ init_db();
 
     local *STDOUT = $out_fh;
     local *STDERR = $err_fh;
+    local $LXDebug::global_level = LXDebug::NONE();
     my $bt_controller = SL::Controller::BankTransaction->new;
     @result = $bt_controller->action_save_invoices;
   };


### PR DESCRIPTION
Der Test prüft, ob stderr leer ist, aber wenn der Debug-Level auf DEBUG2 steht, dann gibt es immer einer Debug-Meldung, die auf stderr landet. Deshalb wird vor dem Ausführen der entsprechenden zu Routine der Debug-Level lokal auf NONE gesetzt.