### PR TITLE
202512 fix partly inventory perpetual

### DIFF
--- a/SL/DB/Invoice.pm
+++ b/SL/DB/Invoice.pm
@@ -552,7 +552,7 @@ sub _post_create_assemblyitem_entries {
     push @new_items, $item;
     $item_idx++;
 
-    foreach my $assembly_item (@{ $assembly_entries->[$item_idx] || [ ] }) {
+    foreach my $assembly_item (@{ $assembly_entries->[$item_idx - 1] || [ ] }) {
       push @new_items, SL::DB::InvoiceItem->new(parts_id     => $assembly_item->{part}->id,
                                                 description  => $assembly_item->{part}->description,
                                                 unit         => $assembly_item->{part}->unit,

--- a/SL/DB/Invoice.pm
+++ b/SL/DB/Invoice.pm
@@ -553,7 +553,7 @@ sub _post_create_assemblyitem_entries {
     $item_idx++;
 
     foreach my $assembly_item (@{ $assembly_entries->[$item_idx] || [ ] }) {
-      push @new_items, SL::DB::InvoiceItem->new(parts_id     => $assembly_item->{part},
+      push @new_items, SL::DB::InvoiceItem->new(parts_id     => $assembly_item->{part}->id,
                                                 description  => $assembly_item->{part}->description,
                                                 unit         => $assembly_item->{part}->unit,
                                                 qty          => $assembly_item->{qty},

--- a/SL/DB/Invoice.pm
+++ b/SL/DB/Invoice.pm
@@ -542,17 +542,15 @@ sub recalculate_amounts {
 sub _post_create_assemblyitem_entries {
   my ($self, $assembly_entries) = @_;
 
-  my $items = $self->items_sorted;
+  my @items = grep { !$_->assemblyitem } @{ $self->items_sorted };
   my @new_items;
 
-  my $item_idx = 0;
-  foreach my $item (@{ $items }) {
-    next if $item->assemblyitem;
+  foreach my $item_idx (0 .. scalar(@items)-1) {
+    my $item = $items[$item_idx];
 
     push @new_items, $item;
-    $item_idx++;
 
-    foreach my $assembly_item (@{ $assembly_entries->[$item_idx - 1] || [ ] }) {
+    foreach my $assembly_item (@{ $assembly_entries->[$item_idx] || [ ] }) {
       push @new_items, SL::DB::InvoiceItem->new(parts_id     => $assembly_item->{part}->id,
                                                 description  => $assembly_item->{part}->description,
                                                 unit         => $assembly_item->{part}->unit,

--- a/SL/DB/Invoice.pm
+++ b/SL/DB/Invoice.pm
@@ -542,7 +542,7 @@ sub recalculate_amounts {
 sub _post_create_assemblyitem_entries {
   my ($self, $assembly_entries) = @_;
 
-  my $items = $self->invoiceitems;
+  my $items = $self->items_sorted;
   my @new_items;
 
   my $item_idx = 0;


### PR DESCRIPTION
Ich glaube, dass die Bestandsmethode schon länger nicht mehr funktioniert. Zumindest das Buchen via SL::DB::Invoice->post ist kaputt (gewesen) und auch der Code in IS.pl funktioniert nicht mehr so wie er soll.

Dieser PR fixt das (vermutlich) für SL::DB::Invoice->post.
