### PR TITLE
zugferd: Lieferzeitpunkt kann auch Leistungsdatum sein

### DIFF
--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -671,7 +671,7 @@ sub _applicable_header_trade_delivery {
   $params{xml}->startTag("ram:ActualDeliverySupplyChainEvent");
 
   $params{xml}->startTag("ram:OccurrenceDateTime");
-  $params{xml}->dataElement("udt:DateTimeString", ($self->deliverydate // $self->transdate)->strftime('%Y%m%d'), format => "102");
+  $params{xml}->dataElement("udt:DateTimeString", ($self->deliverydate // $self->tax_point // $self->transdate)->strftime('%Y%m%d'), format => "102");
   $params{xml}->endTag;
 
   $params{xml}->endTag;

--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -671,7 +671,7 @@ sub _applicable_header_trade_delivery {
   $params{xml}->startTag("ram:ActualDeliverySupplyChainEvent");
 
   $params{xml}->startTag("ram:OccurrenceDateTime");
-  $params{xml}->dataElement("udt:DateTimeString", ($self->deliverydate // $self->tax_point // $self->transdate)->strftime('%Y%m%d'), format => "102");
+  $params{xml}->dataElement("udt:DateTimeString", $self->effective_tax_point->strftime('%Y%m%d'), format => "102");
   $params{xml}->endTag;
 
   $params{xml}->endTag;


### PR DESCRIPTION
Zumindestens sollte das genommen werden, bevor das Rechnungsdatum als Standard gesetzt wird