### PR TITLE
Debitorenbuchung: HTML: Input-Tag in table nicht ausserhalb von tr/td

### DIFF
--- a/bin/mozilla/gl.pl
+++ b/bin/mozilla/gl.pl
@@ -994,7 +994,13 @@ sub display_rows {
 |;
   }
 
+  print qq|  <tr class="hidden">
+   <td>
+  |;
   $form->hide_form(qw(rowcount selectaccno));
+  print qq|   </td>
+  </tr>
+  |;
 
   $main::lxdebug->leave_sub();
 


### PR DESCRIPTION
Auch wenn das hier noch html im Perl-Code ist, dennoch ein kleiner Fix.