### PR TITLE
Performance: Liste der Wiedervorlagen nur bei Popup laden

### DIFF
--- a/bin/mozilla/fu.pl
+++ b/bin/mozilla/fu.pl
@@ -108,8 +108,8 @@ sub display_form {
   $params{trans_id}   = $form->{LINKS}->[0]->{trans_id} if (@{ $form->{LINKS} });
 
   $form->{sort}               = 'follow_up_date';
-  $form->{FOLLOW_UPS_DONE}    = FU->follow_ups(%params,     done => 1);
-  $form->{FOLLOW_UPS_PENDING} = FU->follow_ups(%params, not_done => 1);
+  $form->{FOLLOW_UPS_DONE}    = FU->follow_ups(%params,     done => 1) if $::form->{POPUP_MODE};
+  $form->{FOLLOW_UPS_PENDING} = FU->follow_ups(%params, not_done => 1) if $::form->{POPUP_MODE};
 
   setup_fu_display_form_action_bar() unless $::form->{POPUP_MODE};
 


### PR DESCRIPTION
**Behebt:**
Wird die Maske zum Editieren oder Anlegen einer Wiedervorlage über Produktivität->Berichte->Wiedervorlagen aufgerufen, so wurden nicht benötigte Informationen aus der DB geladen. Da in diesem Fall keine einschränkenden Filter gesetzt werden, kann das je nach Anzahl aller Wiedervorlagen in der DB sehr lange dauern.

**Ist für die Praxis ausreichend, weil:**
Die nur konditional geladenen Daten werden im Popup (Beleg öffnen, Actionbar mehr->Wiedervorlage) gefiltert ("Noch nicht erledigte Wiedervorlagen für dieses Dokument" und "Erledigte Wiedervorlagen für dieses Dokument"), wodurch dort die Datenmenge unproblematisch ist.