### PR TITLE
Unit-Test datev/encoding: check_text wird nicht exportiert

### DIFF
--- a/t/datev/encoding.t
+++ b/t/datev/encoding.t
@@ -3,8 +3,7 @@ use Test::More;
 
 use lib 't';
 
-use_ok 'Support::TestSetup';
-use SL::DATEV::CSV qw(check_text);
+use_ok 'SL::DATEV::CSV';
 use Support::TestSetup;
 
 use utf8;


### PR DESCRIPTION
Die Methode check_text gibt es gar nicht in SL::DATEV::CSV.

Ab Perl 5.40 wird da eine Warnung ausgespuckt:
"Attempt to call undefined import method with arguments ("check_text") via package "SL::DATEV::CSV""

Ausserdem use_ok für SL::DATEV::CSV und nicht für Support::TestSetup, was auch zweimal eingebunden wurde.