### PR TITLE
Auth-DB-Upgrade-Skript für 4.0.0: Beschreibung gefixt

### DIFF
--- a/sql/Pg-upgrade2-auth/release_4_0_0.sql
+++ b/sql/Pg-upgrade2-auth/release_4_0_0.sql
@@ -1,3 +1,3 @@
 -- @tag: release_4_0_0
--- @description: Abhängigkeitsscript für Release 3.9.2
+-- @description: Abhängigkeitsscript für Release 4.0.0
 -- @depends: release_3_9_2


### PR DESCRIPTION
Ändert technisch nichts, aber die falsche Beschreibung könnte Admins verwirren.