### PR TITLE
Hinweis auf evtl. fehlende Doku-Dateien zum release-management

### DIFF
--- a/doc/release_management.txt
+++ b/doc/release_management.txt
@@ -128,10 +128,12 @@ als freundliche Checkliste zum Ausdrucken und Erweitern.
     Version bis zum erfolgreichen Login der neuen Version zu kriegen.
   - Bekannte Probleme die im testing auftraten dokumentieren.
 
-* doc/kivitendo-Dokumentation.pdf erstellen
+* doc/kivitendo-Dokumentation.pdf und doc/html/* neu erstellen
   - ggf. muss hier noch dobudish installiert werden, s.a. Entwicklerdokumentation ->
     Dokumentation erstellen. Ansonsten reicht dieser Aufruf:
-  $ scripts/build_doc.sh
+    $ scripts/build_doc.sh
+  - prüfen, ob neu entstandene Dateien indoc/ html (neue Kapitel / neue Bilder)
+    noch zum git-Repo hinzugefügt/eingecheckt werden müssen
 
 * scripts/rose_auto_create_model.pl update machen.
 
@@ -211,6 +213,7 @@ als freundliche Checkliste zum Ausdrucken und Erweitern.
 * VERSION auf aktuelle Version setzen
  - Changelog auf Tagesdatum plus Versionssnummer
  - dokumentation.xml Versionsnummer anpassen
+ - Doku neu bauen (s. o.)
  - im Dokument UPGRADE Versionsnummer anpassen
  - bei der Datei VERSION Versionsnummer anpassen
 


### PR DESCRIPTION
Kommen z.B. neue Kapitel oder Bilder zur Doku dazu, enstehen ggf. auch neue Dateien unter doc/html/. Diese müssen dann noch zum git-Repo hinzugefügt bzw. eingecheckt werden.