### PR TITLE
Debitorenbuchungen Dokument genauso wie Anhänge eingebunden

### DIFF
--- a/templates/design40_webpages/ar/form_header.html
+++ b/templates/design40_webpages/ar/form_header.html
@@ -42,7 +42,7 @@
   [% END %]
   [% IF id %]
     [% IF INSTANCE_CONF.get_doc_storage %]
-      <li><a href="#ui-tabs-docs">[% 'Documents' | $T8 %]</a></li>
+      <li><a href="controller.pl?action=File/list&file_type=document&object_type=invoice&object_id=[% HTML.url(id) %]">[% 'Documents' | $T8 %]</a></li>
       <li><a href="controller.pl?action=File/list&file_type=attachment&object_type=invoice&object_id=[% HTML.url(id) %]">[% 'Attachments' | $T8 %]</a></li>
     [% END %]
     [% IF AUTH.assert('record_links', 1) %]
@@ -51,10 +51,6 @@
       <li><a href="[% 'controller.pl?action=AccTrans/list_transactions&trans_id=' _ HTML.url(id) | html %]">[% LxERP.t8('Transactions') %]</a></li>
   [% END %]
 </ul>
-
-[% IF id AND INSTANCE_CONF.get_doc_storage %]
-  <div id="ui-tabs-docs"></div>
-[% END %]
 
 <div id="ui-tabs-basic-data">
 


### PR DESCRIPTION
Den Reiter Debitorenbuchungen gab es schon war aber immer leer.
Hab den genauso eingebunden wie die Anhänge.