### PR TITLE
templates: amcvar/search_include fix Ausrichtung per Div

### DIFF
--- a/templates/design40_webpages/amcvar/search_include.html
+++ b/templates/design40_webpages/amcvar/search_include.html
@@ -9,8 +9,10 @@
       [% SET start_new_row = '0' %]
     [% END %]
     <td id="[% HTML.escape(include_prefix) %]cvartd_[% HTML.escape(var.name) %]">
-      <input type="checkbox" name="[% HTML.escape(include_prefix) %]cvar_[% HTML.escape(var.name) %]" id="[% HTML.escape(include_prefix) %]cvar_[% HTML.escape(var.name) %]" value="[% HTML.escape(include_value) %]"[% IF var.included_by_default %] checked[% END %]>
-      <label for="[% HTML.escape(include_prefix) %]cvar_[% HTML.escape(var.name) %]">[% HTML.escape(var.description) %]</label>
+      <div>
+        <input type="checkbox" name="[% HTML.escape(include_prefix) %]cvar_[% HTML.escape(var.name) %]" id="[% HTML.escape(include_prefix) %]cvar_[% HTML.escape(var.name) %]" value="[% HTML.escape(include_value) %]"[% IF var.included_by_default %] checked[% END %]>
+        <label for="[% HTML.escape(include_prefix) %]cvar_[% HTML.escape(var.name) %]">[% HTML.escape(var.description) %]</label>
+      </div>
     </td>
 
     [% UNLESS loop.count % 4 %][% SET start_new_row = '1' %]


### PR DESCRIPTION
Zuvor waren die Checkboxes und ihre Labels nicht zwangsweise auf derselben Zeile. Beobachtet in
ct.pl?action=search_contact