### PR TITLE
202603 templates: Wiedervorlangen Layout optimiert

### DIFF
--- a/bin/mozilla/fu.pl
+++ b/bin/mozilla/fu.pl
@@ -51,6 +51,7 @@ sub add {
 
   if (0 < scalar @{ $form->{LINKS} }) {
     $link_details = FU->link_details(%{ $form->{LINKS}->[0] });
+    $form->{LINKS}->[0]{$_} = $link_details->{$_} for keys %$link_details;
   }
 
   if ($link_details && $link_details->{title}) {

--- a/doc/changelog
+++ b/doc/changelog
@@ -25,6 +25,8 @@ Mittelgroße neue Features:
 
 Kleinere neue Features und Detailverbesserungen:
 
+- Anordnung der Elemente in der Maske für Wiedervorlagen verbessert
+
 - Suche nach und Anzeige von Kundenartikelnummer und Kunde im Artikelbericht
   analog zur Suche nach Lieferantenartikelnummer und Lieferant ermöglicht.
 

--- a/templates/design40_webpages/fu/add_edit.html
+++ b/templates/design40_webpages/fu/add_edit.html
@@ -2,6 +2,7 @@
 [% USE L %]
 [% USE HTML %]
 [% USE LxERP %]
+[% USE P %]
 <h1>[% title %]</h1>
 
 <script type="text/javascript">
@@ -82,6 +83,12 @@
 <div class="wrapper">
   <table class="tbl-horizontal">
     <tbody>
+      [% FOREACH row = LINKS %]
+        <tr>
+          <th>[% 'Reference' | $T8 %]</th>
+          <td>[% P.link_tag(row.url, row.title, target="_blank") %]</td>
+        </tr>
+      [% END %]
       <tr>
         <th>[% 'Follow-Up Date' | $T8 %]</th>
         <td>[% L.date_tag('follow_up_date', follow_up_date, class="wi-date") %]</td>

--- a/templates/design40_webpages/fu/add_edit.html
+++ b/templates/design40_webpages/fu/add_edit.html
@@ -29,8 +29,9 @@
 [% END %]
 
 <div class="wrapper">
+  <h3>[% 'Follow-Up for user' | $T8 %]</h3>
+  <div class="col">
   <table class="tbl-list">
-    <caption>[% 'Follow-Up for user' | $T8 %]</caption>
     <thead>
       <tr>
         <th>[% L.checkbox_tag('checkall_checkboxes', label='', id='checkall', checkall="[data-checkall=1]") %]</th>
@@ -51,6 +52,9 @@
       [% END %]
     </tbody>
   </table>
+  </div>
+
+  <div class="col">
   <table class="tbl-list">
     <thead>
       <tr>
@@ -72,6 +76,7 @@
       [% END %]
     </tbody>
   </table>
+  </div>
 </div>
 
 <div class="wrapper">

--- a/templates/design40_webpages/fu/add_edit.html
+++ b/templates/design40_webpages/fu/add_edit.html
@@ -30,6 +30,32 @@
 [% END %]
 
 <div class="wrapper">
+  <table class="tbl-horizontal">
+    <tbody>
+      [% FOREACH row = LINKS %]
+        <tr>
+          <th>[% 'Reference' | $T8 %]</th>
+          <td>[% P.link_tag(row.url, row.title, target="_blank") %]</td>
+        </tr>
+      [% END %]
+      <tr>
+        <th>[% 'Follow-Up Date' | $T8 %]</th>
+        <td>[% L.date_tag('follow_up_date', follow_up_date, class="wi-date") %]</td>
+      </tr>
+      <tr>
+        <th>[% 'Subject' | $T8 %]</th>
+        <td><input type="text" name="subject" value="[% HTML.escape(subject) %]" class="wi-wider"></td>
+      </tr>
+      <tr>
+        <th>[% 'Body' | $T8 %]</th>
+        <td><textarea class="wi-wider" rows="10" name="body">[% HTML.escape(body) %]</textarea></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+
+<div class="wrapper">
   <h3>[% 'Follow-Up for user' | $T8 %]</h3>
   <div class="col">
   <table class="tbl-list">
@@ -78,31 +104,6 @@
     </tbody>
   </table>
   </div>
-</div>
-
-<div class="wrapper">
-  <table class="tbl-horizontal">
-    <tbody>
-      [% FOREACH row = LINKS %]
-        <tr>
-          <th>[% 'Reference' | $T8 %]</th>
-          <td>[% P.link_tag(row.url, row.title, target="_blank") %]</td>
-        </tr>
-      [% END %]
-      <tr>
-        <th>[% 'Follow-Up Date' | $T8 %]</th>
-        <td>[% L.date_tag('follow_up_date', follow_up_date, class="wi-date") %]</td>
-      </tr>
-      <tr>
-        <th>[% 'Subject' | $T8 %]</th>
-        <td><input type="text" name="subject" value="[% HTML.escape(subject) %]" class="wi-wider"></td>
-      </tr>
-      <tr>
-        <th>[% 'Body' | $T8 %]</th>
-        <td><textarea class="wi-wider" rows="10" name="body">[% HTML.escape(body) %]</textarea></td>
-      </tr>
-    </tbody>
-  </table>
 </div>
 
 [% IF POPUP_MODE %]


### PR DESCRIPTION
Anwender wünschen, dass beim Anlegen und Editieren von Wiedervorlagen das Layout so beschaffen ist, dass Bildschirmplatz rational genutzt wird und die Übersichtlichkeit gegeben ist. Dies ist hier umgesetzt.

Man bedenke: Der Texteditor hat immer dieselbe initiale Größe und ist mitunter das Erste, was mit Inhalt befüllt wird.
Das einblenden der Belegreferenz als Link (öffnet in neuem Fenster) dient als Gedächtnisstütze beim Schreiben.

Die Benutzer- und Gruppenliste sollten unten und vor allem nebeneinander platziert werden. Je nach Mandantendatenbank kann diese sehr lang sein.