### PR TITLE
F 202603 part displayablenameprefs onhand hinzugefügt

### DIFF
--- a/SL/DB/Part.pm
+++ b/SL/DB/Part.pm
@@ -24,6 +24,7 @@ use SL::DB::Helper::DisplayableNamePreferences (
   options => [ {name => 'partnumber',  title => t8('Part Number')     },
                {name => 'description', title => t8('Description')    },
                {name => 'notes',       title => t8('Notes')},
+               {name => 'onhand',      title => t8('Onhand'),     sub => sub { $::form->format_amount(\%::myconfig, $_[0]->onhand) } },
                {name => 'partsgroup',  title => t8('Partsgroup'), sub => sub { $_[0]->partsgroup && $_[0]->partsgroup->partsgroup } },
                {name => 'ean',         title => t8('EAN')            }, ],
 );

--- a/SL/DB/Part.pm
+++ b/SL/DB/Part.pm
@@ -24,7 +24,7 @@ use SL::DB::Helper::DisplayableNamePreferences (
   options => [ {name => 'partnumber',  title => t8('Part Number')     },
                {name => 'description', title => t8('Description')    },
                {name => 'notes',       title => t8('Notes')},
-               {name => 'onhand',      title => t8('Onhand'),     sub => sub { $::form->format_amount(\%::myconfig, $_[0]->onhand) } },
+               {name => 'onhand',      title => t8('Onhand'),     sub => sub { $_[0]->onhand_as_number } },
                {name => 'partsgroup',  title => t8('Partsgroup'), sub => sub { $_[0]->partsgroup && $_[0]->partsgroup->partsgroup } },
                {name => 'ean',         title => t8('EAN')            }, ],
 );


### PR DESCRIPTION
Macht im Picker nichts kaputt und ein Kunde benötigt die Anzeige des Bestandes in der Schnellsuche.

Das ist ohnehin nur dann aktiv, wenn man es z.B. in den Nutzereinstellungen -> Anzeigeoptionen als <%onhand%> einstellt.