### PR TITLE
SMTP Auth: Gebe Fehler-String vom Server zurück

### DIFF
--- a/SL/Mailer/SMTP.pm
+++ b/SL/Mailer/SMTP.pm
@@ -59,7 +59,7 @@ sub init {
   return 1 unless $login;
 
   if (!$self->{smtp}->auth($login, $cfg->{password})) {
-    $self->extended_status('SMTP authentication failed');
+    $self->extended_status('SMTP authentication failed: ' . $self->{smtp}->message());
     die $self->extended_status;
   }
 }


### PR DESCRIPTION
An dieser Stelle wollen wir die Antwort des Servers sehen.
Im Fehlerfall hat diese oft die Form:

Fehler: Die E-Mail wurde aufgrund des folgenden Fehlers nicht verschickt: SMTP authentication failed: 5.7.0 Authentication failed 

Da stehen keine Secrets drin, also sollte das angezeigt werden. Sonst ist das beim Debugging hinderlich.