### PR TITLE
Einkaufslieferschein: Liefertermin reqdate ist das aktuelle Datum

### DIFF
--- a/SL/DB/DeliveryOrder/TypeData.pm
+++ b/SL/DB/DeliveryOrder/TypeData.pm
@@ -83,7 +83,7 @@ my %type_data = (
     },
     defaults => {
       reqdate => sub {
-        DateTime->today_local->next_workday(extra_days => 1);
+        DateTime->today_local;
       },
     },
     part_classification_query => [ "used_for_purchase" => 1 ],


### PR DESCRIPTION
Einkaufslieferscheine werden i.d.R. bei Erhalt der Ware erfasst. Es ergibt daher keinen Sinn, dabei den Liefertermin auf den nächsten Werktag zu setzen.