### PR TITLE
templates Order, DeliveryOrder: SELF.type für Dateien (sonst leerer Tab)

### DIFF
--- a/templates/design40_webpages/delivery_order/form.html
+++ b/templates/design40_webpages/delivery_order/form.html
@@ -28,7 +28,7 @@
 
 <form method="post" action="controller.pl" id="order_form">
   [% L.hidden_tag('callback',             FORM.callback) %]
-  [% L.hidden_tag('type',                 FORM.type) %]
+  [% L.hidden_tag('type',                 SELF.type) %]
   [% L.hidden_tag('id',                   SELF.order.id) %]
   [% L.hidden_tag('converted_from_record_type_ref', SELF.order.converted_from_record_type_ref) %]
   [% L.hidden_tag('converted_from_record_id',       SELF.order.converted_from_record_id) %]
@@ -52,8 +52,8 @@
       <li><a href="#ui-tabs-webdav">[% 'WebDAV' | $T8 %]</a></li>
 [%- END %]
 [%- IF SELF.order.id AND INSTANCE_CONF.get_doc_storage %]
-      <li><a href="controller.pl?action=File/list&file_type=document&object_type=[% HTML.escape(FORM.type) %]&object_id=[% HTML.url(SELF.order.id) %]">[% 'Documents' | $T8 %]</a></li>
-      <li><a href="controller.pl?action=File/list&file_type=attachment&object_type=[% HTML.escape(FORM.type) %]&object_id=[% HTML.url(SELF.order.id) %]">[% 'Attachments' | $T8 %]</a></li>
+      <li><a href="controller.pl?action=File/list&file_type=document&object_type=[% HTML.escape(SELF.type) %]&object_id=[% HTML.url(SELF.order.id) %]">[% 'Documents' | $T8 %]</a></li>
+      <li><a href="controller.pl?action=File/list&file_type=attachment&object_type=[% HTML.escape(SELF.type) %]&object_id=[% HTML.url(SELF.order.id) %]">[% 'Attachments' | $T8 %]</a></li>
 [%- END %]
 [%- IF SELF.order.id %]
       <li><a href="controller.pl?action=RecordLinks/ajax_list&object_model=DeliveryOrder&object_id=[% HTML.url(SELF.order.id) %]">[% 'Linked Records' | $T8 %]</a></li>

--- a/templates/design40_webpages/order/form.html
+++ b/templates/design40_webpages/order/form.html
@@ -23,7 +23,7 @@
       data-transport-cost-reminder-article-id="[% HTML.escape(transport_cost_reminder_article.id) %]"
       data-transport-cost-reminder-article-description="[% HTML.escape(transport_cost_reminder_article.displayable_name) %]">
   [% L.hidden_tag('callback',             FORM.callback) %]
-  [% L.hidden_tag('type',                 FORM.type) %]
+  [% L.hidden_tag('type',                 SELF.type) %]
   [% L.hidden_tag('id',                   SELF.order.id) %]
   [% L.hidden_tag('converted_from_record_type_ref', SELF.order.converted_from_record_type_ref) %]
   [% L.hidden_tag('converted_from_record_id',       SELF.order.converted_from_record_id) %]
@@ -48,8 +48,8 @@
     <li><a href="#ui-tabs-webdav">[% 'WebDAV' | $T8 %]</a></li>
   [% END %]
   [% IF SELF.order.id AND INSTANCE_CONF.get_doc_storage %]
-    <li><a href="controller.pl?action=File/list&file_type=document&object_type=[% HTML.escape(FORM.type) %]&object_id=[% HTML.url(SELF.order.id) %]">[% 'Documents' | $T8 %]</a></li>
-    <li><a href="controller.pl?action=File/list&file_type=attachment&object_type=[% HTML.escape(FORM.type) %]&object_id=[% HTML.url(SELF.order.id) %]">[% 'Attachments' | $T8 %]</a></li>
+    <li><a href="controller.pl?action=File/list&file_type=document&object_type=[% HTML.escape(SELF.type) %]&object_id=[% HTML.url(SELF.order.id) %]">[% 'Documents' | $T8 %]</a></li>
+    <li><a href="controller.pl?action=File/list&file_type=attachment&object_type=[% HTML.escape(SELF.type) %]&object_id=[% HTML.url(SELF.order.id) %]">[% 'Attachments' | $T8 %]</a></li>
   [% END %]
   [% IF SELF.order.id %]
     <li><a href="controller.pl?action=RecordLinks/ajax_list&object_model=Order&object_id=[% HTML.url(SELF.order.id) %]">[% 'Linked Records' | $T8 %]</a></li>

--- a/templates/design40_webpages/reclamation/form.html
+++ b/templates/design40_webpages/reclamation/form.html
@@ -46,8 +46,8 @@
       <li><a href="#ui-tabs-webdav">[% 'WebDAV' | $T8 %]</a></li>
 [%- END %]
 [%- IF SELF.reclamation.id AND INSTANCE_CONF.get_doc_storage %]
-      <li><a href="controller.pl?action=File/list&file_type=document&object_type=[% HTML.escape(FORM.type) %]&object_id=[% HTML.url(SELF.reclamation.id) %]">[% 'Documents' | $T8 %]</a></li>
-      <li><a href="controller.pl?action=File/list&file_type=attachment&object_type=[% HTML.escape(FORM.type) %]&object_id=[% HTML.url(SELF.reclamation.id) %]">[% 'Attachments' | $T8 %]</a></li>
+      <li><a href="controller.pl?action=File/list&file_type=document&object_type=[% HTML.escape(SELF.type) %]&object_id=[% HTML.url(SELF.reclamation.id) %]">[% 'Documents' | $T8 %]</a></li>
+      <li><a href="controller.pl?action=File/list&file_type=attachment&object_type=[% HTML.escape(SELF.type) %]&object_id=[% HTML.url(SELF.reclamation.id) %]">[% 'Attachments' | $T8 %]</a></li>
 [%- END %]
 [%- IF SELF.reclamation.id %]
       <li><a href="controller.pl?action=RecordLinks/ajax_list&object_model=Reclamation&object_id=[% SELF.reclamation.id %]">[% 'Linked Records' | $T8 %]</a></li>

--- a/templates/design40_webpages/reclamation/form.html
+++ b/templates/design40_webpages/reclamation/form.html
@@ -22,7 +22,7 @@
 
 <form method="post" action="controller.pl" id="reclamation_form">
   [% L.hidden_tag('callback',             FORM.callback) %]
-  [% L.hidden_tag('type',                 FORM.type) %]
+  [% L.hidden_tag('type',                 SELF.type) %]
   [% L.hidden_tag('id',                   SELF.reclamation.id) %]
   [% L.hidden_tag('converted_from_record_type_ref', SELF.reclamation.converted_from_record_type_ref) %]
   [% L.hidden_tag('converted_from_record_id',       SELF.reclamation.converted_from_record_id) %]


### PR DESCRIPTION
Bisher wurde für das DMS FORM.type ausgelesen, was zu leeren Tabs führte, weil S:C:File in der Action list fehl schlug mit: No object type
Dies betrifft die Tabs Dokumente und Dateianhänge.

Mit dem Setzen des hidden tag auf SELF.type ist das Eingabefeld freier Preis auf Preisanfragen vor dem Speichern nutzbar, wie es sein soll.

Statt FORM.type wird SELF.type initialisiert.
Vgl. sub init_type in S:C:Order und S:C:DeliveryOrder.