### PR TITLE
TopQuickSerach: hebe Beschränkung maxlength auf

### DIFF
--- a/templates/design40_webpages/menu/header.html
+++ b/templates/design40_webpages/menu/header.html
@@ -26,7 +26,7 @@
     </span>
     <div class="frame-header-quicksearch">
       [% FOREACH search = quick_search.enabled_modules %]
-        <span class='frame-header-quicksearch'><input type="text" id="top-quick-search-[% search.name %]" module="[% search.name %]" placeholder="[% search.description_field %]" maxlength="20" class="quick-search"></span>
+        <span class='frame-header-quicksearch'><input type="text" id="top-quick-search-[% search.name %]" module="[% search.name %]" placeholder="[% search.description_field %]" class="quick-search"></span>
       [% END %]
     </div>
   </div>


### PR DESCRIPTION
Ein typischer Anwendungsfall ist das Kopieren einer Artikelnummer aus einem Beleg in die Schnellsuche.

Wer Strukturierte Artikelnummern aus mehreren Nummernblöcken und Trennzeichen verwendet, überschreitet schnell die 20 Zeichen. Dann werden beim Einfügen der längeren Nummern keine exakten Treffer gefunden, was die Anwender einschränkt, und dies ganz unnötig.