### PR TITLE
Positionsnummern mit Kapitelbildung: letzte Position innerhalb der Zwischensumme berücksichtigen

### DIFF
--- a/SL/IS.pm
+++ b/SL/IS.pm
@@ -367,7 +367,7 @@ sub invoice_details {
       $form->{nodiscount_total} += $nodiscount_linetotal;
       $form->{discount_total}   += $discount;
 
-      if ($subtotal_active) {
+      if ($subtotal_active || $subtotal_turn_off) {
         $discount_subtotal   += $linetotal;
         $nodiscount_subtotal += $nodiscount_linetotal;
       }

--- a/SL/OE.pm
+++ b/SL/OE.pm
@@ -1160,7 +1160,7 @@ sub order_details {
       $form->{nodiscount_total} += $nodiscount_linetotal;
       $form->{discount_total}   += $discount;
 
-      if ($subtotal_active) {
+      if ($subtotal_active || $subtotal_turn_off) {
         $discount_subtotal   += $linetotal;
         $nodiscount_subtotal += $nodiscount_linetotal;
       }


### PR DESCRIPTION
## Problem
Die Berechnung der Zwischensumme berücksichtigte nicht die letzte Pos. innerhalb der Zwischensumme, wie bereits von @wernerhahn in Issue #681 festgestellt:
<img width="1296" height="378" alt="grafik" src="https://github.com/user-attachments/assets/6ac35661-12ba-46fc-8f44-ab7148e9f0e9" />

## Verbesserung

Mit dieser Änderung funktioniert es richtig:
<img width="1302" height="374" alt="grafik" src="https://github.com/user-attachments/assets/4e50a006-ff3f-43e1-acea-9f37ae3f1431" />

