### PR TITLE
PartPicker: Backspace und Klick neben das Feld löscht Eingabe

### DIFF
--- a/js/autocomplete_chart.js
+++ b/js/autocomplete_chart.js
@@ -7,16 +7,18 @@ namespace('kivi', function(k){
       return $real.data("chart_picker");
 
     var KEY = {
-      ESCAPE: 27,
-      ENTER:  13,
-      TAB:    9,
-      LEFT:   37,
-      RIGHT:  39,
-      PAGE_UP: 33,
+      BACKSPACE: 8,
+      ESCAPE:    27,
+      ENTER:     13,
+      TAB:       9,
+      LEFT:      37,
+      RIGHT:     39,
+      PAGE_UP:   33,
       PAGE_DOWN: 34,
       SHIFT:     16,
       CTRL:      17,
       ALT:       18,
+      DELETE:    46,
     };
     var CLASSES = {
       PICKED:       'chartpicker-picked',
@@ -221,6 +223,13 @@ namespace('kivi', function(k){
      *  event.which does not contain tab events in keypressed in firefox but will report 0
      *  chrome does not fire keypressed at all on tab or escape
      */
+    $dummy.keyup(function(event){
+      // if string is empty assume they want to delete
+      if ((event.which == KEY.BACKSPACE || event.which == KEY.DELETE) && $dummy.val() === '') {
+        set_item({});
+      }
+    });
+
     $dummy.keydown(function(event){
       if (event.which == KEY.ENTER || event.which == KEY.TAB) {
         // if string is empty assume they want to delete
@@ -249,6 +258,14 @@ namespace('kivi', function(k){
     $dummy.on('paste', function(){
       setTimeout(function() {
         handle_changed_text();
+      }, 1);
+    });
+
+    $dummy.on('cut', function(){
+      setTimeout(function() {
+        if ($dummy.val() === '') {
+          set_item({});
+        }
       }, 1);
     });
 

--- a/js/autocomplete_project.js
+++ b/js/autocomplete_project.js
@@ -7,16 +7,18 @@ namespace('kivi', function(k){
       return $real.data("project_picker");
 
     var KEY = {
-      ESCAPE: 27,
-      ENTER:  13,
-      TAB:    9,
-      LEFT:   37,
-      RIGHT:  39,
-      PAGE_UP: 33,
+      BACKSPACE: 8,
+      ESCAPE:    27,
+      ENTER:     13,
+      TAB:       9,
+      LEFT:      37,
+      RIGHT:     39,
+      PAGE_UP:   33,
       PAGE_DOWN: 34,
       SHIFT:     16,
       CTRL:      17,
       ALT:       18,
+      DELETE:    46,
     };
     var CLASSES = {
       PICKED:       'projectpicker-picked',
@@ -221,6 +223,13 @@ namespace('kivi', function(k){
      *  event.which does not contain tab events in keypressed in firefox but will report 0
      *  chrome does not fire keypressed at all on tab or escape
      */
+    $dummy.keyup(function(event){
+      // if string is empty assume they want to delete
+      if ((event.which == KEY.BACKSPACE || event.which == KEY.DELETE) && $dummy.val() === '') {
+        set_item({});
+      }
+    });
+
     $dummy.keydown(function(event){
       if (event.which == KEY.ENTER || event.which == KEY.TAB) {
         // if string is empty assume they want to delete
@@ -248,6 +257,14 @@ namespace('kivi', function(k){
     $dummy.on('paste', function(){
       setTimeout(function() {
         handle_changed_text();
+      }, 1);
+    });
+
+    $dummy.on('cut', function(){
+      setTimeout(function() {
+        if ($dummy.val() === '') {
+          set_item({});
+        }
       }, 1);
     });
 

--- a/js/kivi.CustomerVendor.js
+++ b/js/kivi.CustomerVendor.js
@@ -387,12 +387,12 @@ namespace('kivi.CustomerVendor', function(ns) {
         // if string is empty assume they want to delete
         if (self.$dummy.val() === '') {
           self.set_item({});
-          return true;
+          return;
         } else if (self.state == self.STATES.PICKED) {
           if (self.o.action.commit_one) {
             self.run_action(self.o.action.commit_one);
           }
-          return true;
+          return;
         }
         if (event.which == KEY.TAB) {
           event.preventDefault();
@@ -405,7 +405,7 @@ namespace('kivi.CustomerVendor', function(ns) {
             match_one:  self.o.action.commit_one,
             match_many: self.o.action.commit_many
           });
-          return false;
+          return;
         }
       } else if (event.which == KEY.DOWN && !self.autocomplete_open) {
         var old_options = self.$dummy.autocomplete('option');
@@ -446,7 +446,7 @@ namespace('kivi.CustomerVendor', function(ns) {
         }
       });
       this.$dummy.keyup  (function(event){ self.handle_keyup  (event); });
-      this.$dummy.keydown(function(event){ self.handle_keydown(event) });
+      this.$dummy.keydown(function(event){ self.handle_keydown(event); });
       this.$dummy.on('paste', function(){
         setTimeout(function() {
           self.handle_changed_text();

--- a/js/kivi.CustomerVendor.js
+++ b/js/kivi.CustomerVendor.js
@@ -250,6 +250,7 @@ namespace('kivi.CustomerVendor', function(ns) {
   };
 
   var KEY = {
+    BACKSPACE: 8,
     TAB:       9,
     ENTER:     13,
     SHIFT:     16,
@@ -262,6 +263,7 @@ namespace('kivi.CustomerVendor', function(ns) {
     UP:        38,
     RIGHT:     39,
     DOWN:      40,
+    DELETE:    46,
   };
 
   ns.Picker = function($real, options) {
@@ -372,6 +374,13 @@ namespace('kivi.CustomerVendor', function(ns) {
         }
       });
     },
+    handle_keyup: function(event) {
+      var self = this;
+      // if string is empty assume they want to delete
+      if ((event.which == KEY.BACKSPACE || event.which == KEY.DELETE) && self.$dummy.val() === '') {
+        self.set_item({});
+      }
+    },
     handle_keydown: function(event) {
       var self = this;
       if (event.which == KEY.ENTER || event.which == KEY.TAB) {
@@ -436,10 +445,18 @@ namespace('kivi.CustomerVendor', function(ns) {
           self.autocomplete_open = false;
         }
       });
+      this.$dummy.keyup  (function(event){ self.handle_keyup  (event); });
       this.$dummy.keydown(function(event){ self.handle_keydown(event) });
       this.$dummy.on('paste', function(){
         setTimeout(function() {
           self.handle_changed_text();
+        }, 1);
+      });
+      this.$dummy.on('cut', function(){
+        setTimeout(function() {
+          if (self.$dummy.val() === '') {
+            self.set_item({});
+          }
         }, 1);
       });
       this.$dummy.blur(function(){

--- a/js/kivi.Part.js
+++ b/js/kivi.Part.js
@@ -620,6 +620,13 @@ namespace('kivi.Part', function(ns) {
           self.handle_changed_text();
         }, 1);
       });
+      this.$dummy.on('cut', function(){
+        setTimeout(function() {
+          if (self.$dummy.val() === '') {
+            self.set_item({});
+          }
+        }, 1);
+      });
       this.$dummy.blur(function(){
         window.clearTimeout(self.timer);
         self.timer = window.setTimeout(function() { self.annotate_state(); }, 100);

--- a/js/kivi.Part.js
+++ b/js/kivi.Part.js
@@ -332,6 +332,7 @@ namespace('kivi.Part', function(ns) {
   };
 
   var KEY = {
+    BACKSPACE: 8,
     TAB:       9,
     ENTER:     13,
     SHIFT:     16,
@@ -501,6 +502,14 @@ namespace('kivi.Part', function(ns) {
      *  event.which does not contain tab events in keypressed in firefox but will report 0
      *  chrome does not fire keypressed at all on tab or escape
      */
+    handle_keyup: function(event) {
+      var self = this;
+      // if string is empty assume they want to delete
+      if (event.which == KEY.BACKSPACE && self.$dummy.val() === '') {
+        self.set_item({});
+        return true;
+      }
+    },
     handle_keydown: function(event) {
       var self = this;
       if (event.which == KEY.ENTER || event.which == KEY.TAB) {
@@ -604,6 +613,7 @@ namespace('kivi.Part', function(ns) {
           self.autocomplete_open = false;
         }
       });
+      this.$dummy.keyup  (function(event){ self.handle_keyup  (event); });
       this.$dummy.keydown(function(event){ self.handle_keydown(event); });
       this.$dummy.on('paste', function(){
         setTimeout(function() {

--- a/js/kivi.Part.js
+++ b/js/kivi.Part.js
@@ -507,7 +507,6 @@ namespace('kivi.Part', function(ns) {
       // if string is empty assume they want to delete
       if (event.which == KEY.BACKSPACE && self.$dummy.val() === '') {
         self.set_item({});
-        return true;
       }
     },
     handle_keydown: function(event) {
@@ -518,12 +517,12 @@ namespace('kivi.Part', function(ns) {
         // if string is empty assume they want to delete
         if (self.$dummy.val() === '') {
           self.set_item({});
-          return true;
+          return;
         } else if (self.state == self.STATES.PICKED) {
           if (self.o.action.commit_one) {
             self.run_action(self.o.action.commit_one);
           }
-          return true;
+          return;
         }
         if (event.which == KEY.TAB) {
           event.preventDefault();
@@ -536,7 +535,7 @@ namespace('kivi.Part', function(ns) {
             match_one:  self.o.action.commit_one,
             match_many: self.o.action.commit_many
           });
-          return false;
+          return;
         }
       } else if (event.which == KEY.DOWN && !self.autocomplete_open) {
         var old_options = self.$dummy.autocomplete('option');

--- a/js/kivi.Part.js
+++ b/js/kivi.Part.js
@@ -345,6 +345,7 @@ namespace('kivi.Part', function(ns) {
     UP:        38,
     RIGHT:     39,
     DOWN:      40,
+    DELETE:    46,
   };
 
   ns.Picker = function($real, options) {
@@ -505,7 +506,7 @@ namespace('kivi.Part', function(ns) {
     handle_keyup: function(event) {
       var self = this;
       // if string is empty assume they want to delete
-      if (event.which == KEY.BACKSPACE && self.$dummy.val() === '') {
+      if ((event.which == KEY.BACKSPACE || event.which == KEY.DELETE) && self.$dummy.val() === '') {
         self.set_item({});
       }
     },


### PR DESCRIPTION
Bisher wurde der PartPicker nur geleert, wenn man nach dem Entfernen des Inhaltes mit Backspace mit Enter oder Tab aus dem Feld herausnavigiert.

Das lag daran, dass im onKeydown Event der aktualisierte Wert des Feldes noch nicht zur Verfügung steht. Im inKeyup Event hingegen ist dies der Fall.

Wenn wir uns einig sind, dass die Lösung so korrekt ist, gibt es noch drei weitere Fundstellen:
```git grep -l dummy.keydown
js/autocomplete_chart.js
js/autocomplete_project.js
js/kivi.CustomerVendor.js
js/kivi.Part.js
```