### PR TITLE
alle hochgeladenen dokumente des reiters dokument im SEPA Doc Downl.

### DIFF
--- a/SL/SEPA.pm
+++ b/SL/SEPA.pm
@@ -557,16 +557,18 @@ sub send_concatinated_sepa_pdfs {
     # File::get_all and converting to scalar is a tiny bit stupid, see Form.pm,
     # but there is no get_latest_version (but sorts objects by itime!)
     # check if already resynced
-    my ( $file_object ) = SL::File->get_all(object_id   => $item->{ap_id} ? $item->{ap_id} : $item->{ar_id},
-                                            object_type => $item->{ap_id} ? 'purchase_invoice' : 'invoice',
-                                            file_type   => 'document',
-                                           );
-    next if     (ref $file_object ne 'SL::File::Object');
-    next unless $file_object->mime_type eq 'application/pdf';
+    my @file_objects = SL::File->get_all(object_id   => $item->{ap_id} ? $item->{ap_id} : $item->{ar_id},
+                                         object_type => $item->{ap_id} ? 'purchase_invoice' : 'invoice',
+                                         file_type   => 'document',
+                                        );
+    foreach my $file_object (@file_objects) {
+      next if     (ref $file_object ne 'SL::File::Object');
+      next unless $file_object->mime_type eq 'application/pdf';
 
-    my $file = $file_object->get_file;
-    die "No file" unless -e $file;
-    push @files, $file;
+      my $file = $file_object->get_file;
+      die "No file" unless -e $file;
+      push @files, $file;
+    }
   }
 
   my @cmd = (

--- a/SL/SEPA.pm
+++ b/SL/SEPA.pm
@@ -554,8 +554,6 @@ sub send_concatinated_sepa_pdfs {
   foreach my $item (@{$items}) {
 
     # check if there is already a file for the invoice
-    # File::get_all and converting to scalar is a tiny bit stupid, see Form.pm,
-    # but there is no get_latest_version (but sorts objects by itime!)
     # check if already resynced
     my @file_objects = SL::File->get_all(object_id   => $item->{ap_id} ? $item->{ap_id} : $item->{ar_id},
                                          object_type => $item->{ap_id} ? 'purchase_invoice' : 'invoice',

--- a/SL/SEPA.pm
+++ b/SL/SEPA.pm
@@ -834,8 +834,6 @@ sub send_concatinated_sepa_pdfs {
   foreach my $item (@{ $params{arap_ids} }) {
 
     # check if there is already a file for the invoice
-    # File::get_all and converting to scalar is a tiny bit stupid, see Form.pm,
-    # but there is no get_latest_version (but sorts objects by itime!)
     # check if already resynced
     my @file_objects = SL::File->get_all(object_id   => $item->{ap_id} ? $item->{ap_id} : $item->{ar_id},
                                          object_type => $item->{ap_id} ? 'purchase_invoice' : 'invoice',

--- a/SL/SEPA.pm
+++ b/SL/SEPA.pm
@@ -835,16 +835,15 @@ sub send_concatinated_sepa_pdfs {
 
     # check if there is already a file for the invoice
     # check if already resynced
-    my @file_objects = SL::File->get_all(object_id   => $item->{ap_id} ? $item->{ap_id} : $item->{ar_id},
+    my @file_objects = grep { ref($_) eq 'SL::File::Object' }
+                       SL::File->get_all(object_id   => $item->{ap_id} ? $item->{ap_id} : $item->{ar_id},
                                          object_type => $item->{ap_id} ? 'purchase_invoice' : 'invoice',
                                          file_type   => 'document',
+                                         mime_type   => 'application/pdf',
                                         );
     foreach my $file_object (@file_objects) {
-      next if     (ref $file_object ne 'SL::File::Object');
-      next unless $file_object->mime_type eq 'application/pdf';
-
       my $file = $file_object->get_file;
-      die "No file" unless -e $file;
+      $::form->error(t8('Document file not found: #1', $file)) unless -e $file;
       push @files, $file;
     }
   }

--- a/locale/de/all
+++ b/locale/de/all
@@ -1358,6 +1358,7 @@ $self->{texts} = {
   'Document Project (number)'   => 'Projektnummer des Belegs',
   'Document Project Description' => 'Projektbeschreibung des Belegs',
   'Document Project Number'     => 'Projektnummer des Belegs',
+  'Document file not found: #1' => 'Dokumentendatei nicht gefunden: #1',
   'Document generating failed. Please check Templates an LateX !' => 'Das Dokument konnte nicht erzeugt werden. Bitte Vorlagen und LateX prüfen!',
   'Documentation'               => 'Dokumentation',
   'Documentation (in German)'   => 'Dokumentation',

--- a/locale/en/all
+++ b/locale/en/all
@@ -1358,6 +1358,7 @@ $self->{texts} = {
   'Document Project (number)'   => '',
   'Document Project Description' => '',
   'Document Project Number'     => '',
+  'Document file not found: #1' => '',
   'Document generating failed. Please check Templates an LateX !' => '',
   'Documentation'               => '',
   'Documentation (in German)'   => '',


### PR DESCRIPTION
s.o.
Es macht mehr Sinn dem Anwender alle Dokumente im Reiter Dokumente anzeigen zu lassen, um eine bessere QS des SEPA XML Lauf zu haben.

Manuell getestet: 2 Dokumente, 1 Dokument, kein Dokument