### PR TITLE
S:C:CsvImport: Fehler beim Parsen der Importdatei wieder anzeigen.

### DIFF
--- a/SL/Controller/CsvImport.pm
+++ b/SL/Controller/CsvImport.pm
@@ -105,16 +105,18 @@ sub action_result {
   my $profile = SL::DB::Manager::CsvImportProfile->find_by(id => $data->{profile_id});
   $self->profile($profile);
 
+  my $error_msg;
   if ($data->{errors} and my $first_error =  $data->{errors}->[0]) {
     if ('ARRAY' eq ref $first_error) {
-      flash('error', $::locale->text('There was an error parsing the csv file: #1 in line #2.', $first_error->[2], $first_error->[4]));
+      $error_msg = $::locale->text('There was an error parsing the csv file: #1 in line #2.', $first_error->[2], $first_error->[4]);
     } else {
-      flash('error', $::locale->text('There was an error parsing the csv file: #1', $first_error));
+      $error_msg = $::locale->text('There was an error parsing the csv file: #1', $first_error);
     }
   }
 
-  if ($data->{progress}{finished} || $data->{errors}) {
-    $self->render('csv_import/_deferred_report', { layout => 0 });
+  if ($data->{progress}{finished} || $error_msg) {
+    $self->render('csv_import/_deferred_report', { layout => 0 }, error => $error_msg);
+
   } else {
     if (!$self->task_server->is_running) {
       $self->task_server->start;

--- a/templates/design40_webpages/csv_import/_deferred_report.html
+++ b/templates/design40_webpages/csv_import/_deferred_report.html
@@ -1,3 +1,5 @@
+[% USE P %]
+
 <div id='csv_import_report'></div>
 
 <script type='text/javascript'>
@@ -18,6 +20,9 @@
   }
 
   $(document).ready(function(){
+    [%- IF error %]
+      kivi.display_flash('error', '[% P.escape_js(error) %]');
+    [%- END %]
     [%- IF SELF.background_job.data_as_hash.report_id %]
       get_report('#csv_import_report', 'controller.pl', { action: 'CsvImport/report', 'no_layout': 1, 'id': [% SELF.background_job.data_as_hash.report_id %] });
     [%- END %]


### PR DESCRIPTION
Das ging mit der Flash-Umstellung kaputt (und war vorher auch schon komisch). Da der Inhalt des Reports per js eingefügt wird, wird der Flash-Inhalt nicht gerendert. Früher ging das so halbwegs, da in dem eingefügten Template-Code das "common/flash.html" inkludiert war. Dann wurde der Fehler oben innerhalb des eingefügten divs gerendert. Das klappt nicht mehr.

Nun wird ein Fehler direkt per js (kivi.display_flash) angezeigt.