### PR TITLE
202604 fix html part controller

### DIFF
--- a/SL/Presenter/Part.pm
+++ b/SL/Presenter/Part.pm
@@ -39,7 +39,7 @@ sub part_picker {
   my ($name, $value, %params) = @_;
 
   $value = SL::DB::Manager::Part->find_by(id => $value) if $value && !ref $value;
-  my $id = $params{id} || name_to_id($name);
+  my $id = delete($params{id}) || name_to_id($name);
 
   my @classes = $params{class} ? ($params{class}) : ();
   push @classes, 'part_autocomplete';

--- a/templates/design40_webpages/part/_assembly.html
+++ b/templates/design40_webpages/part/_assembly.html
@@ -75,7 +75,7 @@
       [% END %]
       <td align="right">[% 'Margepercent' | $T8 %]:</td>
       <td></td>
-      <td id="items_sum_diff"      class="numeric">
+      <td id="items_sum_diff_percent" class="numeric">
       [% IF items_sellprice_sum > 0 %]
         [%- LxERP.format_amount(100 - items_lastcost_sum / items_sellprice_sum * 100,      2, 0) %]
       [% END %]

--- a/templates/design40_webpages/part/_assembly.html
+++ b/templates/design40_webpages/part/_assembly.html
@@ -83,7 +83,6 @@
       <td colspan="3"></td>
     </tr>
     <tr>
-    <tr>
       [% IF SELF.orphaned || AUTH.assert('assembly_edit', 1) %]
       <td colspan="9"></td>
       [% ELSE %]

--- a/templates/design40_webpages/part/_assembly_row.html
+++ b/templates/design40_webpages/part/_assembly_row.html
@@ -14,7 +14,7 @@
     [% L.button_tag("kivi.Part.delete_item_row(this)", LxERP.t8("X"), class="wi-verytiny") %] [% # , confirm=LxERP.t8("Are you sure?")) %]
   </td>
   <td class="numeric">
-    <div id="position" class="numeric">[% HTML.escape(position) or HTML.escape(ITEM.position) %]</div>
+    <div name="position" class="numeric">[% HTML.escape(position) or HTML.escape(ITEM.position) %]</div>
   </td>
   <td class="center"[% UNLESS orphaned || AUTH.assert('assembly_edit', 1) %] style="display:none"[% END %]>
     <img src="image/updown.png" alt="[% LxERP.t8('reorder item') %]" class="dragdrop">

--- a/templates/design40_webpages/part/_assortment_row.html
+++ b/templates/design40_webpages/part/_assortment_row.html
@@ -14,7 +14,7 @@
     [% L.button_tag("kivi.Part.delete_item_row(this)", LxERP.t8("✖"), class="wi-verytiny neutral delete-item") %] [% # , confirm=LxERP.t8("Are you sure?")) %]
   </td>
   <td class="center">
-    <div id="position">
+    <div name="position">
       [% HTML.escape(position) or HTML.escape(ITEM.position) %]
     </div>
   </td>

--- a/templates/design40_webpages/part/_basic_data.html
+++ b/templates/design40_webpages/part/_basic_data.html
@@ -100,7 +100,7 @@
 </div><!-- /.col -->
 
 <div class="col">
-  <table id="ic5" class="tbl-horizontal">
+  <table id="ic4" class="tbl-horizontal">
     <caption>[% 'Prices' | $T8 %]</caption>
     <colgroup> <col class="wi-mediumsmall"><col class="wi-mediumsmall"> </colgroup>
     <tbody>

--- a/templates/design40_webpages/part/_businessmodels.html
+++ b/templates/design40_webpages/part/_businessmodels.html
@@ -38,7 +38,7 @@
       <td></td>
       <td></td>
       <td></td>
-      <th class="right"><span class="label">[% 'Business' | $T8 %]</th>
+      <th class="right"><span class="label">[% 'Business' | $T8 %]</span></th>
       <td>[% P.select_tag('add_businessmodel', SELF.all_businesses, title_key="description", with_empty=1, class="wi-mediumsmall", onchange='kivi.Part.add_businessmodel_row()') %]</td>
       <td>[% L.button_tag('kivi.Part.add_businessmodel_row()', LxERP.t8('Add')) %]</td>
       <td></td>


### PR DESCRIPTION
Kleine Fixes in HTML-Templates.

Und eine Apassung im Part-Picker-Code, damit keine doppelten DOM-Ids vergeben werden