### PR TITLE
Druckvorlagen mersiha: Leerzeilen Zwischensumme fix

### DIFF
--- a/templates/print/mersiha/invoice.tex
+++ b/templates/print/mersiha/invoice.tex
@@ -147,11 +147,11 @@
       <%sellprice%>\,\currency&%
       <%if optional%>\optional<%else%><%linetotal%>\,\currency<%if p_discount%>\par{\sffamily\scriptsize{(-<%p_discount%>\,\%)}}<%end p_discount%><%end optional%>
       \tabularnewline
-      <%if discount_sub%>
+      <%if discount_sub%>%
         \rlap{\zwischensumme}& & & & &
         <%discount_sub%>\,\currency
         \tabularnewline
-      <%end%>
+      <%end%>%
     <%end number%>%
     }%
     \begin{PricingTotal}%

--- a/templates/print/mersiha/sales_order.tex
+++ b/templates/print/mersiha/sales_order.tex
@@ -102,11 +102,11 @@
       <%sellprice%>\,\currency&%
       <%if optional%>\optional<%else%><%linetotal%>\,\currency<%if p_discount%>\par{\sffamily\scriptsize{(-<%p_discount%>\,\%)}}<%end p_discount%><%end optional%>
       \tabularnewline
-      <%if discount_sub%>
+      <%if discount_sub%>%
         \rlap{\zwischensumme}& & & & &
         <%discount_sub%>\,\currency
         \tabularnewline
-      <%end%>
+      <%end%>%
     <%end number%>%
     }%
     \begin{PricingTotal}%

--- a/templates/print/mersiha/sales_quotation.tex
+++ b/templates/print/mersiha/sales_quotation.tex
@@ -102,11 +102,11 @@
       <%sellprice%>\,\currency&%
       <%if optional%>\optional<%else%><%linetotal%>\,\currency<%if p_discount%>\par{\sffamily\scriptsize{(-<%p_discount%>\,\%)}}<%end p_discount%><%end optional%>
       \tabularnewline
-      <%if discount_sub%>
+      <%if discount_sub%>%
         \rlap{\zwischensumme}& & & & &
         <%discount_sub%>\,\currency
         \tabularnewline
-      <%end%>
+      <%end%>%
     <%end number%>%
     }
     \begin{PricingTotal}


### PR DESCRIPTION
Durch Einfügen von Kommentaren um die if-Verzweigung im Template wird die Ausgabe einer leeren Zeile am Ende der Positionstablle (vor der Zeile mit dem Nettobetrag) vermieden.