### PR TITLE
Kundenbericht: Sortierung E-Mail Rechnungsempf. / LS berücksichtigen

### DIFF
--- a/SL/CT.pm
+++ b/SL/CT.pm
@@ -74,6 +74,8 @@ sub search {
       "phone"              => "ct.phone",
       "fax"                => "ct.fax",
       "email"              => "ct.email",
+      "invoice_mail"       => "ct.invoice_mail",
+      "delivery_order_mail" => "ct.delivery_order_mail",
       "street"             => "ct.street",
       "taxnumber"          => "ct.taxnumber",
       "business"           => "b.description",


### PR DESCRIPTION
Zuvor hatten die Sortierspalten keinen Effekt:

- E-Mail des Rechnungsempfängers
- E-Mail des Lieferscheinempfängers