### PR TITLE
Wiedervorlagen zeige Link zur Referenz

### DIFF
--- a/bin/mozilla/fu.pl
+++ b/bin/mozilla/fu.pl
@@ -178,6 +178,8 @@ sub finish {
 
     FU->finish('id' => $form->{id});
 
+    return edit() unless ($form->{POPUP_MODE});
+
   } else {
     foreach my $i (1..$form->{rowcount}) {
       next unless ($form->{"selected_$i"} && $form->{"follow_up_id_$i"});
@@ -523,13 +525,19 @@ sub setup_fu_display_form_action_bar {
       action => [
         t8('Finish'),
         submit   => [ '#form', { action => "finish" } ],
-        disabled => !$::form->{id} ? t8('The object has not been saved yet.') : undef,
+        disabled => !$::form->{id} ? t8('The object has not been saved yet.') :
+                    $::form->{done_at} ? t8('Done') : undef,
       ],
       action => [
         t8('Delete'),
         submit   => [ '#form', { action => "delete" } ],
         disabled => !$::form->{id} ? t8('The object has not been saved yet.') : undef,
         confirm  => t8('Do you really want to delete this object?'),
+      ],
+      'separator',
+      action => [
+        t8('Back'),
+        link => $::form->{callback} || 'fu.pl?action=search',
       ],
     );
   }

--- a/templates/design40_webpages/fu/add_edit.html
+++ b/templates/design40_webpages/fu/add_edit.html
@@ -35,7 +35,7 @@
       [% FOREACH row = LINKS %]
         <tr>
           <th>[% 'Reference' | $T8 %]</th>
-          <td>[% P.link_tag(row.url, row.title, target="_blank") %]</td>
+          <td>[% P.link_tag(row.url, HTML.escape(row.title), target="_blank") %]</td>
         </tr>
       [% END %]
       <tr>


### PR DESCRIPTION
Beim Anlegen, Editieren und Abschließen von Wiedervorlagen:
zeige den Links zur Referenz (falls vorhanden), damit die Anwender diese aufrufen können.

zur Diskussion: Ist es besser, die Wiedervorlage beim Abschließen wieder anzuzeigen, anstatt zurück zur Suche zu springen? Der zweite Commit bewirkt genau dies und bietet einen neuen Zurück-Button in der Action Bar an.