### PR TITLE
B 202604 Workflow Auftrag → Lieferschein → Rechnung: abweichende Rechnungsadresse beibehalten

### DIFF
--- a/templates/design40_webpages/delivery_order/tabs/basic_data.html
+++ b/templates/design40_webpages/delivery_order/tabs/basic_data.html
@@ -59,7 +59,6 @@
       <tr>
         <th>[% 'Shipping Address' | $T8 %]</th>
         <td>
-          [% L.hidden_tag('order.billing_address_id', SELF.order.billing_address_id) %]
           <span id='shipto_selection' [%- IF !SELF.order.${SELF.cv}.shipto.size %]style='display:none'[%- END %]>
             [% shiptos = [ { shipto_id => "", displayable_id => LxERP.t8("No/individual shipping address") } ] ;
                FOREACH s = SELF.order.${SELF.cv}.shipto ;
@@ -321,6 +320,7 @@
 
 </div><!-- /#row_table_scroll_id /.wrapper -->
 
+[% L.hidden_tag('order.billing_address_id', SELF.order.billing_address_id) %]
 [% L.hidden_tag('order.currency_id', SELF.order.currency_id) %]
 [% L.hidden_tag('order.taxzone_id', SELF.order.taxzone_id) %]
 [% L.hidden_tag('order.taxincluded', SELF.order.taxincluded) %]

--- a/templates/design40_webpages/delivery_order/tabs/basic_data.html
+++ b/templates/design40_webpages/delivery_order/tabs/basic_data.html
@@ -59,6 +59,7 @@
       <tr>
         <th>[% 'Shipping Address' | $T8 %]</th>
         <td>
+          [% L.hidden_tag('order.billing_address_id', SELF.order.billing_address_id) %]
           <span id='shipto_selection' [%- IF !SELF.order.${SELF.cv}.shipto.size %]style='display:none'[%- END %]>
             [% shiptos = [ { shipto_id => "", displayable_id => LxERP.t8("No/individual shipping address") } ] ;
                FOREACH s = SELF.order.${SELF.cv}.shipto ;


### PR DESCRIPTION

Ohne das hidden_tag wurde die billing_address_id beim Speichern eines Lieferscheins mit NULL überschrieben.
Dies hatte zur Folge, dass im Workflow

      Auftrag ----> Lieferschein ----> Rechnung

Eine im Auftrag eingestellte abweichende Rechnungsadresse nicht in die Rechnung übernommen wurde.
(In Lieferscheinen werden abweichende Rechnungsadressen grundsätzlich nicht angezeigt - DB seitig werden sie aber durchgereicht.)

