### PR TITLE
S:C:Reclamation: Fix: Zeilenwerter per js Aktualisieren -> keine Marge

### DIFF
--- a/js/kivi.Reclamation.js
+++ b/js/kivi.Reclamation.js
@@ -413,15 +413,6 @@ namespace('kivi.Reclamation', function(ns) {
   ns.redisplay_line_values = function(is_sales, data) {
     $('.row_entry').each(function(idx, elt) {
       $(elt).find('[name="linetotal"]').html(data[idx][0]);
-      if (is_sales && $(elt).find('[name="second_row"]').data('loaded') == 1) {
-        var mt = data[idx][1];
-        var mp = data[idx][2];
-        var h  = '<span';
-        if (mt[0] === '-') h += ' class="plus0"';
-        h += '>' + mt + '&nbsp;&nbsp;' + mp + '%';
-        h += '</span>';
-        $(elt).find('[name="linemargin"]').html(h);
-      }
     });
   };
 


### PR DESCRIPTION
Reklamations-Positionen haben keine Marge und deshalb fehlen die Daten im Array, dass für die Aktualisierung verwendet wird.

Der Zugriff darauf ergab dann eine js-Fehler.