### PR TITLE
FIX: KeepassXC login autofill

### DIFF
--- a/templates/design40_webpages/login_screen/user_login.html
+++ b/templates/design40_webpages/login_screen/user_login.html
@@ -35,7 +35,7 @@
       <tbody>
         <tr>
           <th>[% 'Login Name' | $T8 %]</th>
-          <td>[% L.input_tag('{AUTH}login', FORM.$auth_login, id='auth_login', class='initial_focus wi-normal') %]</td>
+          <td>[% L.input_tag('{AUTH}login', FORM.$auth_login, id='username', class='initial_focus wi-normal') %]</td>
         </tr>
         <tr>
           <th>[% 'Password' | $T8 %]</th>

--- a/templates/mobile_webpages/login_screen/user_login.html
+++ b/templates/mobile_webpages/login_screen/user_login.html
@@ -29,7 +29,7 @@
 
     <form method="post" name="loginscreen" action="controller.pl" target="_top" class="col s12">
       <div class="row">
-       [% P.M.input_tag('{AUTH}login', FORM.$auth_login, id='auth_login', class='initial_focus validate col s12', label=LxERP.t8('Login Name')) %]
+       [% P.M.input_tag('{AUTH}login', FORM.$auth_login, id='username', class='initial_focus validate col s12', label=LxERP.t8('Login Name')) %]
       </div>
       <div class="row">
         [% P.M.input_tag('{AUTH}password', '', type='password', id='auth_password', class='validate col s12', label=LxERP.t8('Password')) %]


### PR DESCRIPTION
Problem: KeepassXC thinks the username field on the login page is a TOTP token field because of the id containing 'auth' and maybe also the name containing 'AUTH'. This breaks the autofill functionality.

Fix: Renaming id to 'username' seems to be sufficient to fix this. The previous id 'auth_login' seems not to be used anywhere, so this should not break anything.

Fixes: #780

---
See also: https://github.com/copilot/share/407f02ae-0804-8c95-b100-28024405011b