### PR TITLE
202605 fix locales script find needed plugins

### DIFF
--- a/scripts/locales.pl
+++ b/scripts/locales.pl
@@ -637,7 +637,7 @@ sub scanhtmlfile {
       $plugins{loaded}->{$1} = 1;
     }
 
-    while ($line =~ m/\[\%[^\w]*(\w+)\.\w+\(/g) {
+    while ($line =~ m/\[\%[^\w]*(\w+)(?:\.\w+)+\(/g) {
       my $plugin = $1;
       $plugins{needed}->{$plugin} = 1 if (first { $_ eq $plugin } qw(HTML LxERP JavaScript JSON L P));
     }

--- a/templates/design40_webpages/csv_import/_form_customers_vendors.html
+++ b/templates/design40_webpages/csv_import/_form_customers_vendors.html
@@ -1,5 +1,6 @@
 [% USE LxERP %]
 [% USE L %]
+[% USE P %]
 
 <tr>
   <th>[% LxERP.t8('Target table') %]:</th>

--- a/templates/design40_webpages/customer_vendor/tabs/additional_billing_addresses.html
+++ b/templates/design40_webpages/customer_vendor/tabs/additional_billing_addresses.html
@@ -1,6 +1,7 @@
 [% USE T8 %]
 [% USE LxERP %]
 [% USE L %]
+[% USE P %]
 
 <div id="additional_billing_addresses">
 <div class="select-item control-panel">

--- a/templates/design40_webpages/customer_vendor/tabs/additional_billing_addresses.html
+++ b/templates/design40_webpages/customer_vendor/tabs/additional_billing_addresses.html
@@ -27,7 +27,7 @@
 </div>
 
 <div class="item">
-  
+
   <table id="additional_billing_address_table" class="tbl-horizontal">
     <caption>[% 'Name and Address' | $T8 %]</caption>
     <tbody>

--- a/templates/design40_webpages/customer_vendor/tabs/shipto.html
+++ b/templates/design40_webpages/customer_vendor/tabs/shipto.html
@@ -1,6 +1,7 @@
 [% USE T8 %]
 [% USE LxERP %]
 [% USE L %]
+[% USE P %]
 
 <div id="shipto">
 <div class="select-item control-panel">

--- a/templates/design40_webpages/disposition_manager/list_parts.html
+++ b/templates/design40_webpages/disposition_manager/list_parts.html
@@ -1,6 +1,7 @@
 [%- USE HTML -%]
 [%- USE LxERP -%]
 [%- USE L -%]
+[%- USE P -%]
 [%- USE T8 -%]
 
 <div class="wrapper">

--- a/templates/design40_webpages/ic/search_update_prices.html
+++ b/templates/design40_webpages/ic/search_update_prices.html
@@ -2,6 +2,7 @@
 [% USE HTML %]
 [% USE LxERP %]
 [% USE L %]
+[% USE P %]
 <h1>[% 'Update prices' | $T8 %]</h1>
 
 <form method="post" action="controller.pl" id="form">


### PR DESCRIPTION
Das locales-Skript sucht auch nach fehlenden Includes (use) in HTML-Templates, fand bisher aber keine Plugins, bei denen der Zugriff auf die Methoden über mehrere Ebenen (Punkte) geht, z.B. P.part.picker. Dieses PR behebt das und fixt gleich ein paar Templates, wo das Plugins fehlten. 