### PR TITLE
Artikelmaske: Bereich CVARs in Basisdaten nur zeigen, wenn Variablen …

### DIFF
--- a/templates/design40_webpages/part/_basic_data.html
+++ b/templates/design40_webpages/part/_basic_data.html
@@ -287,7 +287,7 @@
   </table>
 </div><!-- /.col -->
 
-[% IF CUSTOM_VARIABLES_FIRST_TAB %]
+[% IF CUSTOM_VARIABLES_FIRST_TAB.size %]
 <div class="col">
 <table id="custom_variables_table" class="tbl-list wi-moderate">
   <caption>[% 'Custom Variables' | $T8 %]</caption>


### PR DESCRIPTION
…vorhanden

Wenn keine Variablen für "Im Reiter Basisdaten anzeigen" konfiguriert sind (oder gar keine Waren-CVARs angelegt sind), dann auch den Bereich "Benutzerdefinierte Variablen" dort nicht anzeigen.