### PR TITLE
20260520 fix datex export rounding

### DIFF
--- a/SL/DATEV.pm
+++ b/SL/DATEV.pm
@@ -809,7 +809,7 @@ sub generate_datev_data {
 
         } else {
           # emulate PTC rounding behaviour: first round taxes in isolation, then add up and round the entire sum
-          # makes a difference in the very rare case where tax ends on .0044444449 and tax + netmount ends on 0.00500001
+          # makes a difference in the very rare case where tax ends on .0044444449 and tax + netamount ends on 0.00500001
           # see "rounding error test" in t/datev/invoices.t
           my $unrounded_tax         = $trans->[$j]->{'amount'} * ($tax_rate) * -1 + $rounding_error;
           my $rounded_tax           = $form->round_amount($unrounded_tax, 2);

--- a/SL/DATEV.pm
+++ b/SL/DATEV.pm
@@ -808,10 +808,17 @@ sub generate_datev_data {
           $absumsatz               += -1 * $new_trans{'amount'};
 
         } else {
-          my $unrounded             = $trans->[$j]->{'amount'} * (1 + $tax_rate) * -1 + $rounding_error;
-          my $rounded               = $form->round_amount($unrounded, 2);
+          # emulate PTC rounding behaviour: first round taxes in isolation, then add up and round the entire sum
+          # makes a difference in the very rare case where tax ends on .0044444449 and tax + netmount ends on 0.00500001
+          # see "rounding error test" in t/datev/invoices.t
+          my $unrounded_tax         = $trans->[$j]->{'amount'} * ($tax_rate) * -1 + $rounding_error;
+          my $rounded_tax           = $form->round_amount($unrounded_tax, 2);
+          $rounding_error           = $unrounded_tax - $rounded_tax;
 
+          my $unrounded             = $trans->[$j]->{'amount'} * -1 + $rounding_error + $rounded_tax;
+          my $rounded               = $form->round_amount($unrounded, 2);
           $rounding_error           = $unrounded - $rounded;
+
           $new_trans{'amount'}      = $rounded;
           $new_trans{'umsatz'}      = abs($rounded) * $ml;
           $trans->[$j]->{'umsatz'}  = $new_trans{umsatz};

--- a/SL/Helper/Number.pm
+++ b/SL/Helper/Number.pm
@@ -72,7 +72,7 @@ sub _round_number {
   # before the decimal sign as well using integer arithmetic again.
 
   my $int_amount = int(abs $amount);
-  my $str_places = max(min(10, 16 - length("$int_amount") - $places), $places);
+  my $str_places = max(min(10, 15 - length("$int_amount") - $places), $places);
   my $amount_str = sprintf '%.*f', $places + $str_places, abs($amount);
 
   return $amount unless $amount_str =~ m{^(\d+)\.(\d+)$};

--- a/t/datev/invoices.t
+++ b/t/datev/invoices.t
@@ -350,6 +350,48 @@ $::form->{gldatefrom} = DateTime->new(year => 2017, month => 5, day => 1)->to_ki
 $datev->generate_datev_data(from_to => $datev->fromto);
 cmp_deeply $datev->generate_datev_lines, [], "no bookings for January made after May 1st: ok";
 
+
+
+### rounding error test
+#
+# 3 units of 2790.00 each
+# 25% discount
+# 19% tax
+#
+# expected
+# => amount     7470.23
+# => net_amount 6577.50
+# => tax_amount 1192.73
+#
+# this is the rare case where order of operations matters:
+# 2790 * 3 * 0.75 * 0.19   = 1192.724999999999909   # tax
+# 2790 * 3 * 0.75          = 6277.500000000000000   # netamount
+# 2790 * 3 * 0.75 * 1.19   = 7470.224999999999454   # amount
+# tax + netamount          = 7470.225000000000364   # amount
+#
+# when calculated directly and rounded on 12th digit, there will be a cent difference
+my $invoice_rounding_test = create_sales_invoice(
+  invnumber    => "sales invoice rounding test",
+  customer     => $customer,
+  itime        => DateTime->now,
+  gldate       => DateTime->now,
+  intnotes     => 'booked in March',
+  taxincluded  => 0,
+  transdate    => $date,
+  invoiceitems => [ create_invoice_item(part => $part1, qty => 3, sellprice => 2790, discount => 0.25) ]
+);
+my $datev = SL::DATEV->new(
+  exporttype => SL::DATEV::DATEV_ET_BUCHUNGEN,
+  format     => SL::DATEV::DATEV_FORMAT_KNE,
+  trans_id   => $invoice_rounding_test->id,
+);
+$datev->generate_datev_data;
+#diag(Data::Dumper::Dumper($datev));
+
+cmp_ok $datev->{DATEV}[0][0]{umsatz}, '==', 7470.23, "amount is rounded correctly";
+cmp_ok $datev->{DATEV}[0][1]{umsatz}, '==', 7470.23, "amount is rounded correctly";
+
+
 done_testing();
 clear_up();
 

--- a/t/datev/invoices.t
+++ b/t/datev/invoices.t
@@ -380,7 +380,7 @@ my $invoice_rounding_test = create_sales_invoice(
   transdate    => $date,
   invoiceitems => [ create_invoice_item(part => $part1, qty => 3, sellprice => 2790, discount => 0.25) ]
 );
-my $datev = SL::DATEV->new(
+$datev = SL::DATEV->new(
   exporttype => SL::DATEV::DATEV_ET_BUCHUNGEN,
   format     => SL::DATEV::DATEV_FORMAT_KNE,
   trans_id   => $invoice_rounding_test->id,

--- a/t/datev/invoices.t
+++ b/t/datev/invoices.t
@@ -360,7 +360,7 @@ cmp_deeply $datev->generate_datev_lines, [], "no bookings for January made after
 #
 # expected
 # => amount     7470.23
-# => net_amount 6577.50
+# => net_amount 6277.50
 # => tax_amount 1192.73
 #
 # this is the rare case where order of operations matters:

--- a/t/db_helper/price_tax_calculator.t
+++ b/t/db_helper/price_tax_calculator.t
@@ -652,6 +652,32 @@ sub test_default_order_two_items_19_one_optional() {
   }, "${title}: calculated data");
 }
 
+sub test_rounding_error_invoice_one_item_19_tax_not_included {
+  reset_state();
+
+  my $item          = new_item(qty => 3, sellprice => 2790, discount => 0.25);
+
+  my $invoice = new_invoice(
+    taxincluded  => 0,
+    items => [ $item ],
+  );
+
+  my $taxkey = $item->part->get_taxkey(date => $transdate, is_sales => 1, taxzone => $invoice->taxzone_id);
+
+  # sellprice 2790 * qty 3 * discount 0.75 = 6277.5
+  # 19%(6277.5) = 1192.725 rounded = 1192.73
+  # total rounded = 7470.23
+
+  my $title = 'rounding error invoice, one item, 19% tax not included';
+  my %data  = $invoice->calculate_prices_and_taxes;
+
+  # ... should not be calculated for the record sum
+  is($invoice->netamount,       6277.5,             "${title}: netamount");
+  is($invoice->amount,          7470.23,             "${title}: amount");
+  # diag explain $invoice->items->[0];
+  # diag explain \%data;
+}
+
 
 Support::TestSetup::login();
 
@@ -665,6 +691,7 @@ test_default_invoice_one_item_19_tax_not_included_rounding_discount();
 test_default_invoice_one_item_19_tax_not_included_rounding_discount_huge_qty();
 test_default_invoice_one_item_19_tax_not_included_rounding_discount_big_qty_low_sellprice();
 test_default_order_two_items_19_one_optional();
+test_rounding_error_invoice_one_item_19_tax_not_included();
 
 clear_up();
 done_testing();

--- a/t/helper/number.t
+++ b/t/helper/number.t
@@ -136,11 +136,11 @@ is(_round_total('8.2345'),'8.23');
 is(_round_total('8.2350'),'8.24');
 
 # known edge case: happens with 3x 2790, 25% discount, 19% tax
-# tax works out to .2249999999
+# gross amount works out to about 7470.2249999999; separately computed tax to about 1192.7249999999
 {
   my $test = "edge case: 3x2790, 25% discount, 19% tax";
 
-  # literal rounds correcty
+  # literal rounds correctly
   is(_round_total('7470.225'),7470.23, "$test - literal");
 
   # amount computed directly

--- a/t/helper/number.t
+++ b/t/helper/number.t
@@ -1,4 +1,4 @@
-use Test::More tests => 173;
+use Test::More tests => 180;
 
 use lib 't';
 
@@ -134,3 +134,28 @@ is(_round_total('2.342'),'2.34');
 is(_round_total('1.2345'),'1.23');
 is(_round_total('8.2345'),'8.23');
 is(_round_total('8.2350'),'8.24');
+
+# known edge case: happens with 3x 2790, 25% discount, 19% tax
+# tax works out to .2249999999
+{
+  my $test = "edge case: 3x2790, 25% discount, 19% tax";
+
+  # literal rounds correcty
+  is(_round_total('7470.225'),7470.23, "$test - literal");
+
+  # amount computed directly
+  my $netamount = 6277.5;
+  my $amount = $netamount * 1.19;
+  is(_round_total($amount), 7470.23, "$test - amount direct total");
+  is(_round_number($amount, 2), 7470.23, "$test - amount direct number");
+
+  # tax computed separately
+  my $tax = $netamount * 0.19;
+  is(_round_total($tax), 1192.73, "$test - tax total");
+  is(_round_number($tax, 2), 1192.73, "$test - tax number");
+
+  # amount added from tax and netamount
+  $amount = $netamount + $tax;
+  is(_round_total($amount), 7470.23, "$test - amount computed total");
+  is(_round_number($amount, 2), 7470.23, "$test - amount computed number");
+}


### PR DESCRIPTION
Das hier ist ein Fix für einen sehr speziellen Bug im DATEV Export den Jan gefunden hatte.

Bei einer Rechnungsposition mit 3 Einheiten à 2790€ und mit 25% Rabatt kommt die Rechnung auf ein Netto von 6577,50€.
Die 19% Steuer davon sind intern genau 1192.724999999999909 und werden korrekt auf 1192,73 aufgerundet.

Wo dann aber DATEV Export und PTC sich unterscheiden ist, dass der DATEV Export direkt das Brutto als `1.19 * netamount` berechnet, was dann `7470.224999999999454` ist, und damit genau eine Valenzstelle zu früh auf 4 endet und abgerundet wird auf 22 Cent. Der PTC berechnet stattdessen tax + netamount, was dann 7470.225000000000364 ist und aufgerundet wird auf 23 Cent.

Dieser PR enthält 2 Fixes dazu:

1. Der DATEV Export emuliert jetzt das PTC verhalten und rundet zuerst die Steuer, addiert die auf das Netto, und rundet dann nochmal.
2. Die Valenzgrenze für SL::Helper::Number::round_amount war vorher 16 signifikante Ziffern, das hier reduziert das auf 15.

Beide alleine würden den Bug fixen, aber zusammen sollte das jetzt stabil sein gegen ähnliche Probleme mit 5-stelligen Rechnungswerten.