### PR TITLE
fehlende Seitentitel ergänzt

### DIFF
--- a/SL/Controller/DispositionManager.pm
+++ b/SL/Controller/DispositionManager.pm
@@ -79,10 +79,11 @@ sub prepare_report {
 
   map { $column_defs{$_}->{visible} = 1 } @visible;
 
+  $::form->{title} = $title;
   $report->set_options(
     controller_class     => 'DispositionManager',
     output_format        => 'HTML',
-    title                => t8($title),
+    title                => $title,
     allow_pdf_export     => 0,
     allow_csv_export     => 0,
     allow_chart_export   => 0,

--- a/SL/Controller/ListTransactions.pm
+++ b/SL/Controller/ListTransactions.pm
@@ -194,6 +194,7 @@ sub set_title {
   my ($self) = @_;
   my $account = first { $_->{accno} eq $::form->{accno} } @{ $self->accounts_list };
   $self->title(escape(join(" ", t8('List Transactions'), t8('Account'), $account->{text})));
+  $::form->{title} = $self->title;
 }
 
 sub set_dates {

--- a/SL/Controller/ListTransactions.pm
+++ b/SL/Controller/ListTransactions.pm
@@ -193,7 +193,7 @@ sub set_defaults {
 sub set_title {
   my ($self) = @_;
   my $account = first { $_->{accno} eq $::form->{accno} } @{ $self->accounts_list };
-  $self->title(escape(join(" ", t8('List Transactions'), t8('Account'), $account->{text})));
+  $self->title(join(" ", t8('List Transactions'), t8('Account'), $account->{text}));
   $::form->{title} = $self->title;
 }
 


### PR DESCRIPTION
Fehlende Seitentitel werden wir evtl. noch mehr finden, daher erst mal als Draft PR. Können wir in 1 bis 2 Wochen einfach mergen.

Problem vorher:
<img width="2109" height="67" alt="Screenshot 2026-06-15 at 21-09-24 kivitendo Version 4 0 1-unstable- Niklas Schmidt-" src="https://github.com/user-attachments/assets/c4e2673c-c581-4554-907a-3708e374f73e" />

Verbesserung nachher:
<img width="2109" height="91" alt="Screenshot 2026-06-15 at 21-10-13 Buchungsliste Konto 4949 - Kleidung - nschmidt - 4 0 1-unstable" src="https://github.com/user-attachments/assets/aed62448-97d0-4f8c-924b-8494c9825e31" />
