### PR TITLE
202606 enhance zugferd ean gln global

### DIFF
--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -270,14 +270,25 @@ sub _line_item {
 
   #   <ram:SpecifiedTradeProduct>
   $params{xml}->startTag("ram:SpecifiedTradeProduct");
-  if ($params{item}->part->ean) {
-    $params{xml}->dataElement("ram:SellerAssignedID", _u8($params{item}->part->ean), schemeID => '0160');
-  } else {
+
+  if (_is_profile($self, PROFILE_XRECHNUNG())) {
+    if ($params{item}->part->ean) {
+      $params{xml}->dataElement("ram:SellerAssignedID", _u8($params{item}->part->ean), schemeID => '0160');
+    } else {
+      $params{xml}->dataElement("ram:SellerAssignedID", _u8($params{item}->part->partnumber));
+    }
+
+  } else {                      # profile != XRechnung
+    if ($params{item}->part->ean) {
+      $params{xml}->dataElement("ram:GlobalID", _u8($params{item}->part->ean), schemeID => '0160');
+    }
     $params{xml}->dataElement("ram:SellerAssignedID", _u8($params{item}->part->partnumber));
   }
+
   $params{xml}->dataElement("ram:Name",             _u8($params{item}->description));
   $params{xml}->dataElement("ram:Description",      _u8($params{item}->longdescription_as_stripped_html))
     if $params{item}->longdescription_as_stripped_html;
+
   $params{xml}->endTag;
   #   </ram:SpecifiedTradeProduct>
 

--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -608,16 +608,36 @@ sub _seller_trade_party {
 
   #       <ram:SellerTradeParty>
   $params{xml}->startTag("ram:SellerTradeParty");
-  # 0088 = GLN, 0060 = D-U-N-S, only one ID is allowed
-  if ($self->customer->c_vendor_id) {
-    $params{xml}->dataElement("ram:ID", _u8($self->customer->c_vendor_id));
-  } elsif($::instance_conf->get_gln) {
-    $params{xml}->dataElement("ram:ID", _u8($::instance_conf->get_gln), schemeID => '0088');
-  } elsif($::instance_conf->get_duns) {
-    $params{xml}->dataElement("ram:ID", _u8($::instance_conf->get_duns), schemeID => '0060');
-  } else {
-    # no sensible default yet
+
+  if (_is_profile($self, PROFILE_XRECHNUNG())) {
+    # 0088 = GLN, 0060 = D-U-N-S, only one ID is allowed
+    if ($self->customer->c_vendor_id) {
+      $params{xml}->dataElement("ram:ID", _u8($self->customer->c_vendor_id));
+
+    } elsif ($::instance_conf->get_gln) {
+      $params{xml}->dataElement("ram:ID", _u8($::instance_conf->get_gln),  schemeID => '0088');
+
+    } elsif ($::instance_conf->get_duns) {
+      $params{xml}->dataElement("ram:ID", _u8($::instance_conf->get_duns), schemeID => '0060')
+
+    } else {
+      # no sensible default yet
+    }
+
+  } else {                      # profile != XRechnung
+    if ($self->customer->c_vendor_id) {
+      $params{xml}->dataElement("ram:ID", _u8($self->customer->c_vendor_id));
+    }
+
+    if ($::instance_conf->get_gln) {
+      $params{xml}->dataElement("ram:GlobalID", _u8($::instance_conf->get_gln),  schemeID => '0088');
+    }
+
+    if ($::instance_conf->get_duns) {
+      $params{xml}->dataElement("ram:GlobalID", _u8($::instance_conf->get_duns), schemeID => '0060');
+    }
   }
+
   $params{xml}->dataElement("ram:Name", _u8($::instance_conf->get_company));
 
   #         <ram:DefinedTradeContact>
@@ -666,11 +686,21 @@ sub _buyer_trade_party {
 
   #       <ram:BuyerTradeParty>
   $params{xml}->startTag("ram:BuyerTradeParty");
-  if ($self->customer->gln) {
-    $params{xml}->dataElement("ram:ID", _u8($self->customer->gln), schemeID => '0088');
+
+  if (_is_profile($self, PROFILE_XRECHNUNG())) {
+    if ($self->customer->gln) {
+      $params{xml}->dataElement("ram:ID", _u8($self->customer->gln), schemeID => '0088');
+    } else {
+      $params{xml}->dataElement("ram:ID", _u8($self->customer->customernumber));
+    }
+
   } else {
     $params{xml}->dataElement("ram:ID", _u8($self->customer->customernumber));
+    if ($self->customer->gln) {
+      $params{xml}->dataElement("ram:GlobalID", _u8($self->customer->gln), schemeID => '0088');
+    }
   }
+
   $params{xml}->dataElement("ram:Name", _u8($self->customer->name));
 
   _buyer_contact_information($self, %params, contact => $self->contact) if ($self->cp_id);


### PR DESCRIPTION
In der ZUGFeRD-Spezifikation (ZUGFeRD 2.4 / Factur-X 1.08 Spezifikation - Technischer Anhang
gültig ab: 16.01.2026 Profil EXTENDED) stehen GLN/DUNS/EAN als Beispiele für eine GlobalID.

Diese wird jetzt hier verwendet, falls das Profil nicht XRECHNUNG ist.

Ich weiß nicht genau, was der CIUS-Check ist, der die GlobalID abgelehnt hatte und ich finde auch nichts erhellendes in der XRechnung-Spezifikation, die ja aber nur das spezielle subset beschreibt.

Falls jmd. eine Quelle hat, wo drin steht, dass das für X-Rechnung nicht geht, wäre das toll.