### PR TITLE
ZUGFeRD-Export: Fix: Referenz auf Lieferschein

### DIFF
--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -739,12 +739,14 @@ sub _applicable_header_trade_delivery {
   $params{xml}->endTag;
   #       </ram:ActualDeliverySupplyChainEvent>
 
-  if ($self->donumber) {
-    #       <ram:DeliveryNoteReferencedDocument>
-    $params{xml}->startTag("ram:DeliveryNoteReferencedDocument");
-    $params{xml}->dataElement("ram:IssuerAssignedID", _u8($self->donumber));
-    $params{xml}->endTag;
-    #       </ram:DeliveryNoteReferencedDocument>
+  if (_is_profile($self, PROFILE_FACTURX_EXTENDED())) {
+    if ($self->donumber) {
+      #       <ram:DeliveryNoteReferencedDocument>
+      $params{xml}->startTag("ram:DeliveryNoteReferencedDocument");
+      $params{xml}->dataElement("ram:IssuerAssignedID", _u8($self->donumber));
+      $params{xml}->endTag;
+      #       </ram:DeliveryNoteReferencedDocument>
+    }
   }
 
   $params{xml}->endTag;

--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -740,11 +740,11 @@ sub _applicable_header_trade_delivery {
   #       </ram:ActualDeliverySupplyChainEvent>
 
   if ($self->donumber) {
-    #       <ram:DespatchAdviceReferencedDocument>
-    $params{xml}->startTag("ram:DespatchAdviceReferencedDocument");
+    #       <ram:DeliveryNoteReferencedDocument>
+    $params{xml}->startTag("ram:DeliveryNoteReferencedDocument");
     $params{xml}->dataElement("ram:IssuerAssignedID", _u8($self->donumber));
     $params{xml}->endTag;
-    #       </ram:DespatchAdviceReferencedDocument>
+    #       </ram:DeliveryNoteReferencedDocument>
   }
 
   $params{xml}->endTag;


### PR DESCRIPTION
DeliveryNoteReferencedDocument statt DespatchAdviceReferencedDocument

DespatchAdviceReferencedDocument ist das Liefer-Avis. Das haben wir in kivi nicht.

Und auch nur im Profil "Extended" ausgeben, da der Baden-Württembergische E-Rechnungs-Validator eine Warnung ausgibt.