### PR TITLE
Auftragsbericht: Spalten und Suche Lieferbedingungen und Zahlungsbedingungen

### DIFF
--- a/SL/OE.pm
+++ b/SL/OE.pm
@@ -320,6 +320,16 @@ SQL
     push(@values, $form->{taxzone_id});
   }
 
+  if ($form->{payment_term_id}) {
+    $query .= qq| AND o.payment_id = ?|;
+    push(@values, $form->{payment_term_id});
+  }
+
+  if ($form->{delivery_term_id}) {
+    $query .= qq| AND o.delivery_term_id = ?|;
+    push(@values, $form->{delivery_term_id});
+  }
+
   if ($form->{transaction_description}) {
     $query .= qq| AND o.transaction_description ILIKE ?|;
     push(@values, like($form->{transaction_description}));

--- a/SL/OE.pm
+++ b/SL/OE.pm
@@ -156,6 +156,7 @@ SQL
     qq|  department.description as department, | .
     qq|  ex.$rate AS daily_exchangerate, | .
     qq|  pt.description AS payment_terms, | .
+    qq|  dt.description AS delivery_terms, | .
     qq|  pr.projectnumber AS globalprojectnumber, | .
     qq|  e.name AS employee, s.name AS salesman, | .
     qq|  ct.${vc}number AS vcnumber, countries.$country_description_key AS country, ct.ustid, ct.business_id,  | .
@@ -176,6 +177,7 @@ SQL
     qq|  AND ex.transdate = o.transdate) | .
     qq|LEFT JOIN project pr ON (o.globalproject_id = pr.id) | .
     qq|LEFT JOIN payment_terms pt ON (pt.id = o.payment_id)| .
+    qq|LEFT JOIN delivery_terms dt ON (dt.id = o.delivery_term_id)| .
     qq|LEFT JOIN tax_zones tz ON (o.taxzone_id = tz.id) | .
     qq|LEFT JOIN countries ON (ct.country_id = countries.id) | .
     qq|LEFT JOIN department   ON (o.department_id = department.id) | .
@@ -501,6 +503,7 @@ SQL
     "insertdate"              => "o.itime",
     "taxzone"                 => "tz.description",
     "payment_terms"           => "pt.description",
+    "delivery_terms"          => "dt.description",
     "department"              => "department.description",
     "intnotes"                => "o.intnotes",
     "order_status"            => "order_statuses.name",

--- a/bin/mozilla/oe.pl
+++ b/bin/mozilla/oe.pl
@@ -437,7 +437,8 @@ sub orders {
     "country",                 "shippingpoint",
     "taxzone",                 "insertdate",
     "order_probability",       "expected_billing_date", "expected_netamount",
-    "payment_terms", "delivery_terms",          "intnotes",              "order_status",
+    "payment_terms",           "delivery_terms",
+    "intnotes",                "order_status",
     "items",
     "shiptoname", "shiptodepartment_1", "shiptodepartment_2", "shiptostreet",
     "shiptozipcode", "shiptocity", "shiptocountry",
@@ -567,8 +568,8 @@ sub orders {
 
   foreach my $name (qw(id transdate reqdate quonumber ordnumber cusordnumber
                        name employee salesman shipvia transaction_description
-                       shippingpoint taxzone insertdate payment_terms delivery_terms department
-                       intnotes order_status vendor_confirmation_number)) {
+                       shippingpoint taxzone insertdate payment_terms delivery_terms
+                       department intnotes order_status vendor_confirmation_number)) {
     my $sortdir                 = $form->{sort} eq $name ? 1 - $form->{sortdir} : $form->{sortdir};
     $column_defs{$name}->{link} = $href . "&sort=$name&sortdir=$sortdir";
   }

--- a/bin/mozilla/oe.pl
+++ b/bin/mozilla/oe.pl
@@ -434,7 +434,7 @@ sub orders {
     "country",                 "shippingpoint",
     "taxzone",                 "insertdate",
     "order_probability",       "expected_billing_date", "expected_netamount",
-    "payment_terms",           "intnotes",              "order_status",
+    "payment_terms", "delivery_terms",          "intnotes",              "order_status",
     "items",
     "shiptoname", "shiptodepartment_1", "shiptodepartment_2", "shiptostreet",
     "shiptozipcode", "shiptocity", "shiptocountry",
@@ -547,6 +547,7 @@ sub orders {
     'expected_billing_date'   => { 'text' => $locale->text('Exp. bill. date'), },
     'expected_netamount'      => { 'text' => $locale->text('Exp. netamount'), },
     'payment_terms'           => { 'text' => $locale->text('Payment Terms'), },
+    'delivery_terms'          => { 'text' => $locale->text('Delivery Terms'), },
     'intnotes'                => { 'text' => $locale->text('Internal Notes'), },
     'order_status'            => { 'text' => $locale->text('Status'), },
     'items'                   => { 'text' => $locale->text('Positions'), },
@@ -563,7 +564,7 @@ sub orders {
 
   foreach my $name (qw(id transdate reqdate quonumber ordnumber cusordnumber
                        name employee salesman shipvia transaction_description
-                       shippingpoint taxzone insertdate payment_terms department
+                       shippingpoint taxzone insertdate payment_terms delivery_terms department
                        intnotes order_status vendor_confirmation_number)) {
     my $sortdir                 = $form->{sort} eq $name ? 1 - $form->{sortdir} : $form->{sortdir};
     $column_defs{$name}->{link} = $href . "&sort=$name&sortdir=$sortdir";

--- a/bin/mozilla/oe.pl
+++ b/bin/mozilla/oe.pl
@@ -59,6 +59,7 @@ use SL::Controller::Order;
 use SL::DB::Customer;
 use SL::DB::TaxZone;
 use SL::DB::PaymentTerm;
+use SL::DB::DeliveryTerm;
 use SL::DB::ValidityToken;
 use SL::DB::Vendor;
 

--- a/bin/mozilla/oe.pl
+++ b/bin/mozilla/oe.pl
@@ -351,6 +351,8 @@ sub search {
   $form->{ALL_EMPLOYEES}      = SL::DB::Manager::Employee->get_all_sorted(query => [ deleted => 0 ]);
   $form->{ALL_DEPARTMENTS}    = SL::DB::Manager::Department->get_all;
   $form->{ALL_ORDER_STATUSES} = SL::DB::Manager::OrderStatus->get_all_sorted;
+  $form->{ALL_PAYMENT_TERMS}  = SL::DB::Manager::PaymentTerm->get_all_sorted;
+  $form->{ALL_DELIVERY_TERMS} = SL::DB::Manager::DeliveryTerm->get_all_sorted;
 
   $form->{CT_CUSTOM_VARIABLES}                  = CVar->get_configs('module' => 'CT');
   ($form->{CT_CUSTOM_VARIABLES_FILTER_CODE},
@@ -495,7 +497,7 @@ sub orders {
     quonumber cusordnumber transaction_description transdatefrom transdateto
     type vc employee_id salesman_id reqdatefrom reqdateto projectnumber
     project_id periodic_invoices_active periodic_invoices_inactive
-    business_id shippingpoint taxzone_id reqdate_unset_or_old insertdatefrom
+    business_id shippingpoint taxzone_id payment_term_id delivery_term_id reqdate_unset_or_old insertdatefrom
     insertdateto order_probability_op order_probability_value
     expected_billing_date_from expected_billing_date_to parts_partnumber
     parts_description all department_id intnotes phone_notes fulltext
@@ -651,6 +653,14 @@ sub orders {
   }
   if ($form->{taxzone_id} ne '') { # taxzone_id could be 0
     push @options, $locale->text('Steuersatz') . " : " . SL::DB::TaxZone->new(id => $form->{taxzone_id})->load->description;
+  }
+
+  if ($form->{payment_term_id}) {
+    push @options, $locale->text('Payment Terms') . " : " . SL::DB::PaymentTerm->new(id => $form->{payment_term_id})->load->description;
+  }
+
+  if ($form->{delivery_term_id}) {
+    push @options, $locale->text('Delivery Terms') . " : " . SL::DB::DeliveryTerm->new(id => $form->{delivery_term_id})->load->description;
   }
 
   if ($form->{department_id}) {

--- a/templates/design40_webpages/oe/search.html
+++ b/templates/design40_webpages/oe/search.html
@@ -392,6 +392,10 @@
     <label for="l_payment_terms">[% 'Payment Terms' | $T8 %]</label>
   </div>
   <div>
+    <input name="l_delivery_terms" id="l_delivery_terms" type="checkbox" value="Y">
+    <label for="l_delivery_terms">[% 'Delivery Terms' | $T8 %]</label>
+  </div>
+  <div>
     <input name="l_transaction_description" id="l_transaction_description" type="checkbox" value="Y" [% IF INSTANCE_CONF.get_require_transaction_description_ps %] checked[% END %]>
     <label for="l_transaction_description">[% 'Transaction description' | $T8 %]</label>
   </div>

--- a/templates/design40_webpages/oe/search.html
+++ b/templates/design40_webpages/oe/search.html
@@ -84,6 +84,14 @@
      </tr>
      [%- END %]
     <tr>
+      <th>[% 'Payment Terms' | $T8 %]</th>
+      <td>[% L.select_tag('payment_term_id', ALL_PAYMENT_TERMS, with_empty=1, title_key='description', class="wi-lightwide") %]</td>
+    </tr>
+    <tr>
+      <th>[% 'Delivery Terms' | $T8 %]</th>
+      <td>[% L.select_tag('delivery_term_id', ALL_DELIVERY_TERMS, with_empty=1, title_key='description', class="wi-lightwide") %]</td>
+    </tr>
+    <tr>
       <th>[% IF type == 'purchase_order_confirmation' %][% 'Confirmation Date' | $T8 %][% ELSIF is_order %][% 'Order Date' | $T8 %][% ELSIF type == 'request_quotation' %][% 'RFQ Date' | $T8 %][% ELSE %][% 'Quotation Date' | $T8 %][% END %] [% 'From' | $T8 %]</th>
       <td>[% L.date_tag('transdatefrom','', class='wi-date') %] [% 'Bis' | $T8 %] [% L.date_tag('transdateto','', class='wi-date') %]</td>
     </tr>


### PR DESCRIPTION
lediglich angezeigt wurde die Spalte Zahlungsbedingungen.
Nun werden beiden Spalten angezeigt und sind per L.select_tag durchsuchbar.
Getestet habe ich, dass der ausgewählte Suchfilter angezeigt wird und dass die Suche für beide Optionen ausschließlich die richtigen Ergebnisse zeigt.