### PR TITLE
CTI: Feld cp privatphone für Telefonnummern-Lookup und Click-to-dial ergänzt

### DIFF
--- a/SL/Controller/PhoneNumber.pm
+++ b/SL/Controller/PhoneNumber.pm
@@ -170,10 +170,10 @@ C<49> (Germany) respectively.
 
 Next the function will look up a contact whose normalized numbers
 equals the requested number. The fields C<phone1>, C<phone2>,
-C<mobile1>, C<mobile2> and C<fax> are considered. Active contacts are
-given preference over inactive ones (inactive meaning that they don't
-belong to a customer/vendor anymore or that the customer/vendor itself
-is flagged as obsolete).
+C<mobile1>, C<mobile2>, C<fax> and C<privatphone> are considered.
+Active contacts are given preference over inactive ones (inactive
+meaning that they don't belong to a customer/vendor anymore or that the
+customer/vendor itself is flagged as obsolete).
 
 If no contact is found, customers & vendors are searched. Their fields
 C<phone> and C<fax> are considered. The first customer/vendor who

--- a/SL/Controller/PhoneNumber.pm
+++ b/SL/Controller/PhoneNumber.pm
@@ -35,7 +35,7 @@ sub action_look_up {
 sub find_contact_for_number {
   my ($self, $number) = @_;
 
-  my @number_fields = qw(cp_phone1 cp_phone2 cp_mobile1 cp_mobile2 cp_fax);
+  my @number_fields = qw(cp_phone1 cp_phone2 cp_mobile1 cp_mobile2 cp_fax cp_privatphone);
 
   my $contacts = SL::DB::Manager::Contact->get_all(
     inject_results => 1,


### PR DESCRIPTION
Im Gegensatz zu den anderen Telefonnummern-Feldern fehlte das Feld für die private Telefonnummer einer Ansprechperson.

Getestet habe ich,
- dass das grüne Hörersymbol nun auch am Feld Privates Tel. erscheint,
- dass das Wählen funktioniert, und
- dass eingehende Anrufe entsprechend der Telefonnummer im Feld Privates Tel. nachgeschlagen werden.