### PR TITLE
linked customer/vendor: synchronisiere BDVs: fix für Booleans

### DIFF
--- a/SL/DB/Helper/CustomerVendorLink.pm
+++ b/SL/DB/Helper/CustomerVendorLink.pm
@@ -83,10 +83,9 @@ sub make_sync_customer_vendor {
 
     $other->assign_attributes($_ => $self->$_) for qw(city country currency_id email fax homepage language_id name obsolete phone street taxnumber ustid zipcode);
 
-    my $own_cvars = $self->cvar_as_hashref;
     foreach my $other_cvar (@{$other->cvars_by_config}) {
       next unless $other_cvar->config->sync_linked_cv;
-      $other_cvar->value($own_cvars->{$other_cvar->config->name}{value});
+      $other_cvar->value($self->cvar_by_name($other_cvar->config->name)->value);
     }
   };
 }


### PR DESCRIPTION
Für die Werte der CVARs gibt es hier unterschiedliche Repräsentationsformen. (Strings "Ja"/"Nein" statt 1/0 oder '' statt undef)
Besser das setzen, was cvar_by_name(...)->value als Wert zurückliefert, sonst stimmt das Ergebnis nicht.