### PR TITLE
Auth Sessions: legacy API Token entfernt und md5(rand()) ersetzt

### DIFF
--- a/SL/Auth.pm
+++ b/SL/Auth.pm
@@ -629,11 +629,7 @@ sub restore_session {
   # The session ID provided is valid in the following cases:
   #  1. session ID exists in the database
   #  2. hasn't expired yet
-  #  3. if cookie for the API token is given: the cookie's value equal database column 'auth.session.api_token' for the session ID
-  $self->{api_token}   = $cookie->{api_token} if $cookie;
-  my $api_token_cookie = $self->get_api_token_cookie;
   my $cookie_is_bad    = !$cookie || $cookie->{is_expired};
-  $cookie_is_bad     ||= $api_token_cookie && ($api_token_cookie ne $cookie->{api_token}) if  $api_token_cookie;
   if ($cookie_is_bad) {
     $self->destroy_session();
     return $self->session_restore_result($cookie ? SESSION_EXPIRED() : SESSION_NONE());
@@ -814,11 +810,6 @@ sub save_session {
     do_query($::form, $dbh, qq|INSERT INTO auth.session (id, ip_address, mtime) VALUES (?, ?, now())|, $session_id, $ENV{REMOTE_ADDR});
   }
 
-  if ($self->{column_information}->has('api_token', 'session')) {
-    my ($stored_api_token) = $dbh->selectrow_array(qq|SELECT api_token FROM auth.session WHERE id = ?|, undef, $session_id);
-    do_query($::form, $dbh, qq|UPDATE auth.session SET api_token = ? WHERE id = ?|, $self->_create_session_id, $session_id) unless $stored_api_token;
-  }
-
   my @values_to_save = grep    { $_->{modified} }
                        values %{ $self->{SESSION} };
   if (@values_to_save) {
@@ -961,25 +952,12 @@ sub get_session_cookie_name {
 
   $params{type}     ||= 'id';
   my $name            = $self->{cookie_name} || 'lx_office_erp_session_id';
-  $name              .= '_api_token' if $params{type} eq 'api_token';
 
   return $name;
 }
 
 sub get_session_id {
   return $session_id;
-}
-
-sub get_api_token_cookie {
-  my ($self) = @_;
-
-  $::request->{cgi}->cookie($self->get_session_cookie_name(type => 'api_token'));
-}
-
-sub is_api_token_cookie_valid {
-  my ($self)             = @_;
-  my $provided_api_token = $self->get_api_token_cookie;
-  return $self->{api_token} && $provided_api_token && ($self->{api_token} eq $provided_api_token);
 }
 
 sub _tables_present {

--- a/SL/Auth.pm
+++ b/SL/Auth.pm
@@ -2,6 +2,7 @@ package SL::Auth;
 
 use DBI;
 
+use Crypt::PRNG;
 use Digest::MD5 qw(md5_hex);
 use IO::File;
 use Time::HiRes qw(gettimeofday);
@@ -773,12 +774,7 @@ sub expire_sessions {
 }
 
 sub _create_session_id {
-  my @data;
-  map { push @data, int(rand() * 255); } (1..32);
-
-  my $id = md5_hex(pack 'C*', @data);
-
-  return $id;
+  return Crypt::PRNG::random_bytes_hex(16);
 }
 
 sub create_or_refresh_session {

--- a/SL/Auth.pm
+++ b/SL/Auth.pm
@@ -948,10 +948,9 @@ sub set_cookie_environment_variable {
 }
 
 sub get_session_cookie_name {
-  my ($self, %params) = @_;
+  my ($self) = @_;
 
-  $params{type}     ||= 'id';
-  my $name            = $self->{cookie_name} || 'lx_office_erp_session_id';
+  my $name = $self->{cookie_name} || 'lx_office_erp_session_id';
 
   return $name;
 }

--- a/SL/DB/MetaSetup/AuthSession.pm
+++ b/SL/DB/MetaSetup/AuthSession.pm
@@ -10,7 +10,6 @@ __PACKAGE__->meta->table('session');
 __PACKAGE__->meta->schema('auth');
 
 __PACKAGE__->meta->columns(
-  api_token  => { type => 'text' },
   id         => { type => 'text', not_null => 1 },
   ip_address => { type => 'scalar' },
   mtime      => { type => 'timestamp' },

--- a/SL/Dispatcher/AuthHandler/Admin.pm
+++ b/SL/Dispatcher/AuthHandler/Admin.pm
@@ -10,8 +10,7 @@ sub handle {
 
   %::myconfig = User->get_default_myconfig;
 
-  my $ok =  $::auth->is_api_token_cookie_valid;
-  $ok  ||=  $::form->{'{AUTH}admin_password'} && ($::auth->authenticate_root($::form->{'{AUTH}admin_password'})            == $::auth->OK());
+  my $ok =  $::form->{'{AUTH}admin_password'} && ($::auth->authenticate_root($::form->{'{AUTH}admin_password'})            == $::auth->OK());
   $ok  ||= !$::form->{'{AUTH}admin_password'} && ($::auth->authenticate_root($::auth->get_session_value('admin_password')) == $::auth->OK());
   $ok  ||=  $params{action} eq 'login';
 

--- a/SL/Dispatcher/AuthHandler/User.pm
+++ b/SL/Dispatcher/AuthHandler/User.pm
@@ -47,8 +47,7 @@ sub handle {
     ? SL::Layout::Dispatcher->new(style => 'mobile')
     : SL::Layout::Dispatcher->new(style => $::myconfig{menustyle});
 
-  my $ok   =  $::auth->is_api_token_cookie_valid;
-  $ok    ||=  SL::Auth::OK() == $::auth->authenticate($::myconfig{login}, $password);
+  my $ok   =  SL::Auth::OK() == $::auth->authenticate($::myconfig{login}, $password);
 
   return $self->_error(%param) if !$ok;
 

--- a/doc/UPGRADE
+++ b/doc/UPGRADE
@@ -23,6 +23,9 @@ Wichtige Hinweise:
   ab, durch welches Land aus der ISO-3166 Alpha-2 Liste der Wert des
   Freitextfeldes ersetzt werden soll.
 
+- Die Authentifizierung über Cookies mit API-Token für das alte CRM-Menü wurde
+  entfernt.
+
 
 Upgrade auf v4.0.0
 

--- a/doc/changelog
+++ b/doc/changelog
@@ -120,6 +120,9 @@ Kleinere neue Features und Detailverbesserungen:
 
 - Bankkonten: Einstellung von DATEV Export ausnehmen hinzugefügt
 
+- Die Authentifizierung über Cookies mit API-Token für das alte CRM-Menü wurde
+  entfernt.
+
 Bugfixes (Tracker: https://www.kivitendo.de/redmine/projects/forum/issues/):
 
 - XRechnung: beim Herunterladen der XRechnung-XML-Datei beginnt der

--- a/sql/Pg-upgrade2-auth/remove_api_token.sql
+++ b/sql/Pg-upgrade2-auth/remove_api_token.sql
@@ -1,0 +1,4 @@
+-- @tag: remove_api_token
+-- @description: Automatische Authentifizierung bestehender Sessions über Session-ID + API-Token für längst entferntes CRM-Menü ebenfalls entfernen
+-- @depends:
+ALTER TABLE auth.session DROP COLUMN api_token;

--- a/sql/Pg-upgrade2-auth/remove_api_token.sql
+++ b/sql/Pg-upgrade2-auth/remove_api_token.sql
@@ -1,4 +1,4 @@
 -- @tag: remove_api_token
 -- @description: Automatische Authentifizierung bestehender Sessions über Session-ID + API-Token für längst entferntes CRM-Menü ebenfalls entfernen
--- @depends:
+-- @depends: release_4_0_0
 ALTER TABLE auth.session DROP COLUMN api_token;


### PR DESCRIPTION
Auth über Session-ID + API-Token (legacy CRM) entfernt

Den Authentifikations-bezogenen Code möchte ich möglichst einfach halten.
Das API Token, welches nicht mehr benötigt wird, mit zu schleppen,
macht die Sache komplizierter als wirklich nötig ist.

Wenn ihr heutsotage aus Fremdsystemen kivitendo aufrufen wollt, dann nutzt
HTTP Header Auth oder Single Sign On. Beides existiert und funktioniert.
Oder implementiert Open ID Connect, das liegt nicht zu weit entfernt. Aber
erfindet das nicht neu mit Cookies.
(Für 2012 verstehe ich das, heute aber nicht mehr.)

Siehe folgende Commits:

commit 6c21fd13caa00ecee7acac38ac6395948dad20a7

commit 89deb5d8fb0ba6f79aae50a84b1e524b89e8ecef
