### PR TITLE
Bugfix feat Countries Schnellsuche und Briefdruck

### DIFF
--- a/SL/Controller/Letter.pm
+++ b/SL/Controller/Letter.pm
@@ -172,6 +172,11 @@ sub action_print_letter {
 
   my $letter = $self->_update;
 
+  my %print_form                 = %$::form;
+  my $language_code              = SL::DB::Manager::Language->find_by_or_create(id => $::form->{language_id}*1)->template_code;
+  $print_form{customer}          = $self->letter->customer;
+  $print_form{customer}{country} = $self->letter->customer->country->description_localized($language_code);
+
   my ($template_file, @template_files) = SL::Helper::CreatePDF->find_template(
     name        => 'letter',
     printer_id  => $::form->{printer_id},
@@ -189,7 +194,7 @@ sub action_print_letter {
     %result = SL::Template::LaTeX->parse_and_create_pdf(
       $template_file,
       SELF          => $self,
-      FORM          => $::form,
+      FORM          => \%print_form,
       letter        => $letter,
       template_meta => {
         formname  => 'letter',

--- a/SL/Controller/Letter.pm
+++ b/SL/Controller/Letter.pm
@@ -174,8 +174,8 @@ sub action_print_letter {
 
   my %print_form                 = %$::form;
   my $language_code              = SL::DB::Manager::Language->find_by_or_create(id => $::form->{language_id}*1)->template_code;
-  $print_form{customer}          = $self->letter->customer;
-  $print_form{customer}{country} = $self->letter->customer->country->description_localized($language_code);
+  $print_form{customer}          = $self->letter->customer_vendor;
+  $print_form{customer}{country} = $self->letter->customer_vendor->country->description_localized($language_code) if $self->letter->customer_vendor;
 
   my ($template_file, @template_files) = SL::Helper::CreatePDF->find_template(
     name        => 'letter',

--- a/SL/DB/Customer.pm
+++ b/SL/DB/Customer.pm
@@ -26,7 +26,7 @@ use SL::DB::Helper::DisplayableNamePreferences (
                {name => 'zipcode',        title => t8('Zipcode')},
                {name => 'email',          title => t8('E-Mail') },
                {name => 'phone',          title => t8('Phone')  },
-               {name => 'country',        title => t8('Country') }, ]
+               {name => 'country',        title => t8('Country'), sub => sub { $_[0]->country->description_localized($::myconfig{countrycode}) } }, ]
 );
 use SL::DB::Helper::CustomerVendorContacts (
   join_package  => 'SL::DB::CustomerContact',

--- a/SL/DB/Vendor.pm
+++ b/SL/DB/Vendor.pm
@@ -24,7 +24,8 @@ use SL::DB::Helper::DisplayableNamePreferences (
                {name => 'city',           title => t8('City') },
                {name => 'zipcode',        title => t8('Zipcode')},
                {name => 'email',          title => t8('E-Mail') },
-               {name => 'phone',          title => t8('Phone')  }, ]
+               {name => 'phone',          title => t8('Phone')  },
+               {name => 'country',        title => t8('Country'), sub => sub { $_[0]->country->description_localized($::myconfig{countrycode}) } }, ]
 );
 use SL::DB::Helper::CustomerVendorContacts (
   join_package  => 'SL::DB::VendorContact',


### PR DESCRIPTION

Wenn man in der Mandantenkonfig unter Features → Anzeigeoptionen → Einstellungen für Anzeigenamen → Kunden einstellt:
```
<%customernumber%> <%name%> <%country%>
```
Dann erhält man in der Schnellsuche den Ländernamen.

Ebenso beim Briefdruck, welcher nicht flatten_to_form() verwendet:

<img width="310" height="202" alt="grafik" src="https://github.com/user-attachments/assets/417908ce-0540-40f6-97da-dda3b8007d89" />
