### PR TITLE
Bugfix Separate public files: beim Neustart des Dispatchers chdir()

### DIFF
--- a/SL/Dispatcher.pm
+++ b/SL/Dispatcher.pm
@@ -233,7 +233,10 @@ sub handle_all_requests {
     $request->LastCall              if $self->restart_after_request;
   }
 
-  exec $0 if $self->restart_after_request;
+  if ($self->restart_after_request) {
+    chdir('public');
+    exec $0;
+  }
 }
 
 sub handle_request {


### PR DESCRIPTION
Ansonsten erhalten wir Fehler nach dem automatischen Neustart (z.B. wenn Dateien verändert wurden):
- VERSION kann nicht gelesen werden
- locales fallen scheinbar auf Englisch zurück