### PR TITLE
Ansprechpartner löschbar: prüfe Verwendung in Briefen

### DIFF
--- a/SL/DB/Contact.pm
+++ b/SL/DB/Contact.pm
@@ -53,7 +53,9 @@ sub used {
        + SL::DB::Manager::PurchaseInvoice->get_all_count(query => [ cp_id => $self->cp_id ])
        + SL::DB::Manager::DeliveryOrder->get_all_count(query => [ cp_id => $self->cp_id ])
        + SL::DB::Manager::Letter->get_all_count(query => [ cp_id => $self->cp_id ])
-       + SL::DB::Manager::LetterDraft->get_all_count(query => [ cp_id => $self->cp_id ]);
+       + SL::DB::Manager::LetterDraft->get_all_count(query => [ cp_id => $self->cp_id ])
+       + SL::DB::Manager::PeriodicInvoicesConfig->get_all_count(query => [ email_recipient_contact_id => $self->cp_id ])
+       + SL::DB::Manager::Reclamation->get_all_count(query => [ contact_id => $self->cp_id ]);
 }
 
 sub full_name {

--- a/SL/DB/Contact.pm
+++ b/SL/DB/Contact.pm
@@ -45,11 +45,15 @@ sub used {
   require SL::DB::Invoice;
   require SL::DB::PurchaseInvoice;
   require SL::DB::DeliveryOrder;
+  require SL::DB::Letter;
+  require SL::DB::LetterDraft;
 
   return SL::DB::Manager::Order->get_all_count(query => [ cp_id => $self->cp_id ])
        + SL::DB::Manager::Invoice->get_all_count(query => [ cp_id => $self->cp_id ])
        + SL::DB::Manager::PurchaseInvoice->get_all_count(query => [ cp_id => $self->cp_id ])
-       + SL::DB::Manager::DeliveryOrder->get_all_count(query => [ cp_id => $self->cp_id ]);
+       + SL::DB::Manager::DeliveryOrder->get_all_count(query => [ cp_id => $self->cp_id ])
+       + SL::DB::Manager::Letter->get_all_count(query => [ cp_id => $self->cp_id ])
+       + SL::DB::Manager::LetterDraft->get_all_count(query => [ cp_id => $self->cp_id ]);
 }
 
 sub full_name {


### PR DESCRIPTION
Sonst kann bei einer Ansprechperson, die nur auf Briefen verwendet wird, der Button löschen zwar geklickt werden, es erscheint jedoch ein DB-Fehler aufgrund von verletzten Constraints.