### PR TITLE
Shared Contacts: DB Upgrade: Constraint cp_main erzwingen

### DIFF
--- a/sql/Pg-upgrade2/shared_contacts.sql
+++ b/sql/Pg-upgrade2/shared_contacts.sql
@@ -17,6 +17,15 @@
 
 */
 
+-- Before this change, the uniqueness of the main flag among one customer's
+-- contacts was not enforced and cannot be relied upon.
+-- We enforce the uniqueness first, to avoid conflicts with the unique index
+-- below.
+
+update contacts c1 set cp_main = false
+where c1.cp_main and exists ( select 1 FROM contacts c2 where (c1.cp_id != c2.cp_id) and (c1.cp_cv_id = c2.cp_cv_id) and c2.cp_main );
+
+
 create table customer_contacts (
   id serial primary key,
   customer_id integer not null references customer(id)    on delete cascade,


### PR DESCRIPTION
fixes #821 

Getestet habe ich das mit einem INSERT vor dem DB-Upgrade:

kivitendo_unstable=# insert into contacts (cp_cv_id, cp_name, cp_main) values (1037, 'Tester', true);
INSERT 0 1
kivitendo_unstable=# insert into contacts (cp_cv_id, cp_name, cp_main) values (1754, 'Hu', true);
INSERT 0 1
kivitendo_unstable=# insert into contacts (cp_cv_id, cp_name, cp_main) values (1754, 'Ha', true);
INSERT 0 1
kivitendo_unstable=# insert into contacts (cp_cv_id, cp_name, cp_main) values (1754, 'Da', false);
INSERT 0 1

und erhalte dann nach dem DB-Upgrade:
<img width="349" height="186" alt="grafik" src="https://github.com/user-attachments/assets/95129a31-0bd6-4199-9953-cd8cfedfeee4" />
<img width="351" height="238" alt="grafik" src="https://github.com/user-attachments/assets/c01e638c-53ca-42ef-aaf6-7efef1fd1b79" />
