### PR TITLE
Workflow Speichern u. ASP erfassen: wirklich den Kunden/Lieferanten Speichern

### DIFF
--- a/SL/Controller/CustomerVendor.pm
+++ b/SL/Controller/CustomerVendor.pm
@@ -56,6 +56,7 @@ __PACKAGE__->run_before(
     'save_and_order',
     'save_and_quotation',
     'save_and_rfq',
+    'save_and_new_contact',
     'delete',
     'delete_shipto',
     'delete_additional_billing_address',
@@ -471,6 +472,16 @@ sub action_save_and_quotation {
 
   $::form->{type} = 'sales_quotation';
   $self->_transaction('oe.pl');
+}
+
+sub action_save_and_new_contact {
+  my ($self) = @_;
+
+  $self->_save();
+
+  my $db  = $self->is_vendor() ? 'vendor' : 'customer';
+
+  $self->redirect_to(controller => 'Contact', action => 'edit', link_with_cv_id => $self->{cv}->id, link_with_cv_db => $db);
 }
 
 sub action_delete {
@@ -1246,9 +1257,9 @@ sub _setup_form_action_bar {
         ]) x !$self->is_vendor,
         action => [
           t8('Save and create new Contact'),
-          submit => [ '#form', { action => "Contact/edit", link_with_cv_id => $self->{cv}->id, link_with_cv_db => $::form->{db} } ],
+          submit => [ '#form', { action => "CustomerVendor/save_and_new_contact" } ],
           checks => [ 'check_taxzone_and_ustid' ],
-          disabled => !$self->{cv}->id? t8('This object has not been saved yet.') : $no_rights,
+          disabled => $no_rights,
         ],
       ], # end of combobox "Workflow"
 


### PR DESCRIPTION
Auf dem Button stand zwar "Speichern und ...." aber es hatte nicht gespeichert.
Dies ist hier behoben.
Getestet von Yvonne und mir.