### PR TITLE
202607 fix rose auto create trailing semicolon

### DIFF
--- a/SL/DB/MetaSetup/AccTransaction.pm
+++ b/SL/DB/MetaSetup/AccTransaction.pm
@@ -51,4 +51,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AdditionalBillingAddress.pm
+++ b/SL/DB/MetaSetup/AdditionalBillingAddress.pm
@@ -46,4 +46,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ApGl.pm
+++ b/SL/DB/MetaSetup/ApGl.pm
@@ -32,4 +32,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Assembly.pm
+++ b/SL/DB/MetaSetup/Assembly.pm
@@ -36,4 +36,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AssortmentItem.pm
+++ b/SL/DB/MetaSetup/AssortmentItem.pm
@@ -41,4 +41,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthClient.pm
+++ b/SL/DB/MetaSetup/AuthClient.pm
@@ -36,4 +36,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthClientGroup.pm
+++ b/SL/DB/MetaSetup/AuthClientGroup.pm
@@ -29,4 +29,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthClientUser.pm
+++ b/SL/DB/MetaSetup/AuthClientUser.pm
@@ -29,4 +29,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthGroup.pm
+++ b/SL/DB/MetaSetup/AuthGroup.pm
@@ -20,4 +20,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->unique_keys([ 'name' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthGroupRight.pm
+++ b/SL/DB/MetaSetup/AuthGroupRight.pm
@@ -25,4 +25,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthMasterRight.pm
+++ b/SL/DB/MetaSetup/AuthMasterRight.pm
@@ -22,4 +22,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->unique_keys([ 'name' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthSchemaInfo.pm
+++ b/SL/DB/MetaSetup/AuthSchemaInfo.pm
@@ -20,4 +20,4 @@ __PACKAGE__->meta->primary_key_columns([ 'tag' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthSession.pm
+++ b/SL/DB/MetaSetup/AuthSession.pm
@@ -18,4 +18,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthSessionContent.pm
+++ b/SL/DB/MetaSetup/AuthSessionContent.pm
@@ -26,4 +26,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthUser.pm
+++ b/SL/DB/MetaSetup/AuthUser.pm
@@ -20,4 +20,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->unique_keys([ 'login' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthUserConfig.pm
+++ b/SL/DB/MetaSetup/AuthUserConfig.pm
@@ -25,4 +25,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/AuthUserGroup.pm
+++ b/SL/DB/MetaSetup/AuthUserGroup.pm
@@ -29,4 +29,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/BackgroundJob.pm
+++ b/SL/DB/MetaSetup/BackgroundJob.pm
@@ -24,4 +24,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/BackgroundJobHistory.pm
+++ b/SL/DB/MetaSetup/BackgroundJobHistory.pm
@@ -22,4 +22,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/BankAccount.pm
+++ b/SL/DB/MetaSetup/BankAccount.pm
@@ -42,4 +42,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/BankTransaction.pm
+++ b/SL/DB/MetaSetup/BankTransaction.pm
@@ -47,4 +47,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/BankTransactionAccTrans.pm
+++ b/SL/DB/MetaSetup/BankTransactionAccTrans.pm
@@ -52,4 +52,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Bin.pm
+++ b/SL/DB/MetaSetup/Bin.pm
@@ -28,4 +28,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Buchungsgruppe.pm
+++ b/SL/DB/MetaSetup/Buchungsgruppe.pm
@@ -26,4 +26,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Business.pm
+++ b/SL/DB/MetaSetup/Business.pm
@@ -23,4 +23,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/BusinessModel.pm
+++ b/SL/DB/MetaSetup/BusinessModel.pm
@@ -36,4 +36,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Chart.pm
+++ b/SL/DB/MetaSetup/Chart.pm
@@ -35,4 +35,4 @@ __PACKAGE__->meta->unique_keys([ 'accno' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Contact.pm
+++ b/SL/DB/MetaSetup/Contact.pm
@@ -49,4 +49,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ContactDepartment.pm
+++ b/SL/DB/MetaSetup/ContactDepartment.pm
@@ -18,4 +18,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->unique_keys([ 'description' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ContactTitle.pm
+++ b/SL/DB/MetaSetup/ContactTitle.pm
@@ -18,4 +18,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->unique_keys([ 'description' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Country.pm
+++ b/SL/DB/MetaSetup/Country.pm
@@ -25,4 +25,4 @@ __PACKAGE__->meta->unique_keys([ 'iso2' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CsvImportProfile.pm
+++ b/SL/DB/MetaSetup/CsvImportProfile.pm
@@ -19,4 +19,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CsvImportProfileSetting.pm
+++ b/SL/DB/MetaSetup/CsvImportProfileSetting.pm
@@ -27,4 +27,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CsvImportReport.pm
+++ b/SL/DB/MetaSetup/CsvImportReport.pm
@@ -29,4 +29,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CsvImportReportRow.pm
+++ b/SL/DB/MetaSetup/CsvImportReportRow.pm
@@ -26,4 +26,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CsvImportReportStatus.pm
+++ b/SL/DB/MetaSetup/CsvImportReportStatus.pm
@@ -26,4 +26,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Currency.pm
+++ b/SL/DB/MetaSetup/Currency.pm
@@ -18,4 +18,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->unique_keys([ 'name' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CustomDataExportQuery.pm
+++ b/SL/DB/MetaSetup/CustomDataExportQuery.pm
@@ -23,4 +23,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CustomDataExportQueryParameter.pm
+++ b/SL/DB/MetaSetup/CustomDataExportQueryParameter.pm
@@ -32,4 +32,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CustomVariable.pm
+++ b/SL/DB/MetaSetup/CustomVariable.pm
@@ -33,4 +33,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CustomVariableConfig.pm
+++ b/SL/DB/MetaSetup/CustomVariableConfig.pm
@@ -32,4 +32,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CustomVariableConfigPartsgroup.pm
+++ b/SL/DB/MetaSetup/CustomVariableConfigPartsgroup.pm
@@ -32,4 +32,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CustomVariableValidity.pm
+++ b/SL/DB/MetaSetup/CustomVariableValidity.pm
@@ -27,4 +27,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Customer.pm
+++ b/SL/DB/MetaSetup/Customer.pm
@@ -119,4 +119,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CustomerContact.pm
+++ b/SL/DB/MetaSetup/CustomerContact.pm
@@ -32,4 +32,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/CustomerVendorLink.pm
+++ b/SL/DB/MetaSetup/CustomerVendorLink.pm
@@ -35,4 +35,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Datev.pm
+++ b/SL/DB/MetaSetup/Datev.pm
@@ -25,4 +25,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Default.pm
+++ b/SL/DB/MetaSetup/Default.pm
@@ -346,4 +346,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/DeliveryOrder.pm
+++ b/SL/DB/MetaSetup/DeliveryOrder.pm
@@ -128,4 +128,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/DeliveryOrderItem.pm
+++ b/SL/DB/MetaSetup/DeliveryOrderItem.pm
@@ -80,4 +80,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/DeliveryOrderItemsStock.pm
+++ b/SL/DB/MetaSetup/DeliveryOrderItemsStock.pm
@@ -43,4 +43,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/DeliveryTerm.pm
+++ b/SL/DB/MetaSetup/DeliveryTerm.pm
@@ -23,4 +23,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Department.pm
+++ b/SL/DB/MetaSetup/Department.pm
@@ -20,4 +20,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Draft.pm
+++ b/SL/DB/MetaSetup/Draft.pm
@@ -30,4 +30,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Dunning.pm
+++ b/SL/DB/MetaSetup/Dunning.pm
@@ -46,4 +46,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/DunningConfig.pm
+++ b/SL/DB/MetaSetup/DunningConfig.pm
@@ -30,4 +30,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/EmailImport.pm
+++ b/SL/DB/MetaSetup/EmailImport.pm
@@ -21,4 +21,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/EmailJournal.pm
+++ b/SL/DB/MetaSetup/EmailJournal.pm
@@ -46,4 +46,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/EmailJournalAttachment.pm
+++ b/SL/DB/MetaSetup/EmailJournalAttachment.pm
@@ -32,4 +32,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Employee.pm
+++ b/SL/DB/MetaSetup/Employee.pm
@@ -31,4 +31,4 @@ __PACKAGE__->meta->unique_keys([ 'login' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/EmployeeProjectInvoices.pm
+++ b/SL/DB/MetaSetup/EmployeeProjectInvoices.pm
@@ -28,4 +28,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Exchangerate.pm
+++ b/SL/DB/MetaSetup/Exchangerate.pm
@@ -30,4 +30,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/File.pm
+++ b/SL/DB/MetaSetup/File.pm
@@ -31,4 +31,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/FileFullText.pm
+++ b/SL/DB/MetaSetup/FileFullText.pm
@@ -28,4 +28,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/FileVersion.pm
+++ b/SL/DB/MetaSetup/FileVersion.pm
@@ -31,4 +31,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Finanzamt.pm
+++ b/SL/DB/MetaSetup/Finanzamt.pm
@@ -35,4 +35,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/FollowUp.pm
+++ b/SL/DB/MetaSetup/FollowUp.pm
@@ -34,4 +34,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/FollowUpAccess.pm
+++ b/SL/DB/MetaSetup/FollowUpAccess.pm
@@ -29,4 +29,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/FollowUpCreatedForEmployee.pm
+++ b/SL/DB/MetaSetup/FollowUpCreatedForEmployee.pm
@@ -29,4 +29,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/FollowUpDone.pm
+++ b/SL/DB/MetaSetup/FollowUpDone.pm
@@ -35,4 +35,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/FollowUpLink.pm
+++ b/SL/DB/MetaSetup/FollowUpLink.pm
@@ -30,4 +30,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/GLTransaction.pm
+++ b/SL/DB/MetaSetup/GLTransaction.pm
@@ -53,4 +53,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/GenericTranslation.pm
+++ b/SL/DB/MetaSetup/GenericTranslation.pm
@@ -26,4 +26,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Greeting.pm
+++ b/SL/DB/MetaSetup/Greeting.pm
@@ -18,4 +18,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->unique_keys([ 'description' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/History.pm
+++ b/SL/DB/MetaSetup/History.pm
@@ -30,4 +30,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Inventory.pm
+++ b/SL/DB/MetaSetup/Inventory.pm
@@ -81,4 +81,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Invoice.pm
+++ b/SL/DB/MetaSetup/Invoice.pm
@@ -146,4 +146,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/InvoiceItem.pm
+++ b/SL/DB/MetaSetup/InvoiceItem.pm
@@ -95,4 +95,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Language.pm
+++ b/SL/DB/MetaSetup/Language.pm
@@ -26,4 +26,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Letter.pm
+++ b/SL/DB/MetaSetup/Letter.pm
@@ -58,4 +58,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/LetterDraft.pm
+++ b/SL/DB/MetaSetup/LetterDraft.pm
@@ -58,4 +58,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/MakeModel.pm
+++ b/SL/DB/MetaSetup/MakeModel.pm
@@ -34,4 +34,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Note.pm
+++ b/SL/DB/MetaSetup/Note.pm
@@ -31,4 +31,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Order.pm
+++ b/SL/DB/MetaSetup/Order.pm
@@ -153,4 +153,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/OrderItem.pm
+++ b/SL/DB/MetaSetup/OrderItem.pm
@@ -92,4 +92,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/OrderStatus.pm
+++ b/SL/DB/MetaSetup/OrderStatus.pm
@@ -25,4 +25,4 @@ __PACKAGE__->meta->unique_keys([ 'name' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/OrderVersion.pm
+++ b/SL/DB/MetaSetup/OrderVersion.pm
@@ -40,4 +40,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Part.pm
+++ b/SL/DB/MetaSetup/Part.pm
@@ -100,4 +100,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PartClassification.pm
+++ b/SL/DB/MetaSetup/PartClassification.pm
@@ -20,4 +20,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PartCustomerPrice.pm
+++ b/SL/DB/MetaSetup/PartCustomerPrice.pm
@@ -37,4 +37,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PartsGroup.pm
+++ b/SL/DB/MetaSetup/PartsGroup.pm
@@ -22,4 +22,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PartsPriceHistory.pm
+++ b/SL/DB/MetaSetup/PartsPriceHistory.pm
@@ -40,4 +40,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PaymentApproval.pm
+++ b/SL/DB/MetaSetup/PaymentApproval.pm
@@ -35,4 +35,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PaymentTerm.pm
+++ b/SL/DB/MetaSetup/PaymentTerm.pm
@@ -28,4 +28,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PeriodicInvoice.pm
+++ b/SL/DB/MetaSetup/PeriodicInvoice.pm
@@ -33,4 +33,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PeriodicInvoicesConfig.pm
+++ b/SL/DB/MetaSetup/PeriodicInvoicesConfig.pm
@@ -57,4 +57,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Price.pm
+++ b/SL/DB/MetaSetup/Price.pm
@@ -32,4 +32,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PriceFactor.pm
+++ b/SL/DB/MetaSetup/PriceFactor.pm
@@ -18,4 +18,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PriceRule.pm
+++ b/SL/DB/MetaSetup/PriceRule.pm
@@ -24,4 +24,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PriceRuleItem.pm
+++ b/SL/DB/MetaSetup/PriceRuleItem.pm
@@ -37,4 +37,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Pricegroup.pm
+++ b/SL/DB/MetaSetup/Pricegroup.pm
@@ -18,4 +18,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Printer.pm
+++ b/SL/DB/MetaSetup/Printer.pm
@@ -18,4 +18,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Project.pm
+++ b/SL/DB/MetaSetup/Project.pm
@@ -57,4 +57,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ProjectParticipant.pm
+++ b/SL/DB/MetaSetup/ProjectParticipant.pm
@@ -41,4 +41,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ProjectPhase.pm
+++ b/SL/DB/MetaSetup/ProjectPhase.pm
@@ -35,4 +35,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ProjectPhaseParticipant.pm
+++ b/SL/DB/MetaSetup/ProjectPhaseParticipant.pm
@@ -41,4 +41,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ProjectRole.pm
+++ b/SL/DB/MetaSetup/ProjectRole.pm
@@ -22,4 +22,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ProjectStatus.pm
+++ b/SL/DB/MetaSetup/ProjectStatus.pm
@@ -22,4 +22,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ProjectType.pm
+++ b/SL/DB/MetaSetup/ProjectType.pm
@@ -18,4 +18,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PurchaseBasketItem.pm
+++ b/SL/DB/MetaSetup/PurchaseBasketItem.pm
@@ -35,4 +35,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/PurchaseInvoice.pm
+++ b/SL/DB/MetaSetup/PurchaseInvoice.pm
@@ -119,4 +119,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Reclamation.pm
+++ b/SL/DB/MetaSetup/Reclamation.pm
@@ -128,4 +128,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ReclamationItem.pm
+++ b/SL/DB/MetaSetup/ReclamationItem.pm
@@ -78,4 +78,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ReclamationReason.pm
+++ b/SL/DB/MetaSetup/ReclamationReason.pm
@@ -24,4 +24,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ReconciliationLink.pm
+++ b/SL/DB/MetaSetup/ReconciliationLink.pm
@@ -30,4 +30,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RecordLink.pm
+++ b/SL/DB/MetaSetup/RecordLink.pm
@@ -22,4 +22,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RecordTemplate.pm
+++ b/SL/DB/MetaSetup/RecordTemplate.pm
@@ -81,4 +81,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RecordTemplateItem.pm
+++ b/SL/DB/MetaSetup/RecordTemplateItem.pm
@@ -45,4 +45,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpec.pm
+++ b/SL/DB/MetaSetup/RequirementSpec.pm
@@ -58,4 +58,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecAcceptanceStatus.pm
+++ b/SL/DB/MetaSetup/RequirementSpecAcceptanceStatus.pm
@@ -24,4 +24,4 @@ __PACKAGE__->meta->unique_keys([ 'name', 'description' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecComplexity.pm
+++ b/SL/DB/MetaSetup/RequirementSpecComplexity.pm
@@ -23,4 +23,4 @@ __PACKAGE__->meta->unique_keys([ 'description' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecDependency.pm
+++ b/SL/DB/MetaSetup/RequirementSpecDependency.pm
@@ -28,4 +28,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecItem.pm
+++ b/SL/DB/MetaSetup/RequirementSpecItem.pm
@@ -66,4 +66,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecOrder.pm
+++ b/SL/DB/MetaSetup/RequirementSpecOrder.pm
@@ -41,4 +41,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecPart.pm
+++ b/SL/DB/MetaSetup/RequirementSpecPart.pm
@@ -38,4 +38,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecPicture.pm
+++ b/SL/DB/MetaSetup/RequirementSpecPicture.pm
@@ -46,4 +46,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecPredefinedText.pm
+++ b/SL/DB/MetaSetup/RequirementSpecPredefinedText.pm
@@ -27,4 +27,4 @@ __PACKAGE__->meta->unique_keys([ 'description' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecRisk.pm
+++ b/SL/DB/MetaSetup/RequirementSpecRisk.pm
@@ -23,4 +23,4 @@ __PACKAGE__->meta->unique_keys([ 'description' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecStatus.pm
+++ b/SL/DB/MetaSetup/RequirementSpecStatus.pm
@@ -24,4 +24,4 @@ __PACKAGE__->meta->unique_keys([ 'name', 'description' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecTextBlock.pm
+++ b/SL/DB/MetaSetup/RequirementSpecTextBlock.pm
@@ -32,4 +32,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecType.pm
+++ b/SL/DB/MetaSetup/RequirementSpecType.pm
@@ -26,4 +26,4 @@ __PACKAGE__->meta->unique_keys([ 'description' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/RequirementSpecVersion.pm
+++ b/SL/DB/MetaSetup/RequirementSpecVersion.pm
@@ -36,4 +36,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/SchemaInfo.pm
+++ b/SL/DB/MetaSetup/SchemaInfo.pm
@@ -19,4 +19,4 @@ __PACKAGE__->meta->primary_key_columns([ 'tag' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/SearchProfile.pm
+++ b/SL/DB/MetaSetup/SearchProfile.pm
@@ -30,4 +30,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/SearchProfileSetting.pm
+++ b/SL/DB/MetaSetup/SearchProfileSetting.pm
@@ -33,4 +33,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Secret.pm
+++ b/SL/DB/MetaSetup/Secret.pm
@@ -23,4 +23,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->unique_keys([ 'tag' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/SepaExport.pm
+++ b/SL/DB/MetaSetup/SepaExport.pm
@@ -29,4 +29,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/SepaExportItem.pm
+++ b/SL/DB/MetaSetup/SepaExportItem.pm
@@ -57,4 +57,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/SepaExportMessageId.pm
+++ b/SL/DB/MetaSetup/SepaExportMessageId.pm
@@ -24,4 +24,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Shipto.pm
+++ b/SL/DB/MetaSetup/Shipto.pm
@@ -41,4 +41,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Shop.pm
+++ b/SL/DB/MetaSetup/Shop.pm
@@ -47,4 +47,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ShopImage.pm
+++ b/SL/DB/MetaSetup/ShopImage.pm
@@ -33,4 +33,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ShopOrder.pm
+++ b/SL/DB/MetaSetup/ShopOrder.pm
@@ -100,4 +100,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ShopOrderItem.pm
+++ b/SL/DB/MetaSetup/ShopOrderItem.pm
@@ -34,4 +34,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ShopPart.pm
+++ b/SL/DB/MetaSetup/ShopPart.pm
@@ -46,4 +46,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Status.pm
+++ b/SL/DB/MetaSetup/Status.pm
@@ -25,4 +25,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/StockCounting.pm
+++ b/SL/DB/MetaSetup/StockCounting.pm
@@ -56,4 +56,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/StockCountingItem.pm
+++ b/SL/DB/MetaSetup/StockCountingItem.pm
@@ -56,4 +56,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Stocktaking.pm
+++ b/SL/DB/MetaSetup/Stocktaking.pm
@@ -56,4 +56,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Tax.pm
+++ b/SL/DB/MetaSetup/Tax.pm
@@ -44,4 +44,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/TaxKey.pm
+++ b/SL/DB/MetaSetup/TaxKey.pm
@@ -34,4 +34,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/TaxZone.pm
+++ b/SL/DB/MetaSetup/TaxZone.pm
@@ -18,4 +18,4 @@ __PACKAGE__->meta->columns(
 __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/TaxzoneChart.pm
+++ b/SL/DB/MetaSetup/TaxzoneChart.pm
@@ -44,4 +44,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/TimeRecording.pm
+++ b/SL/DB/MetaSetup/TimeRecording.pm
@@ -64,4 +64,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/TimeRecordingArticle.pm
+++ b/SL/DB/MetaSetup/TimeRecordingArticle.pm
@@ -27,4 +27,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/TodoUserConfig.pm
+++ b/SL/DB/MetaSetup/TodoUserConfig.pm
@@ -34,4 +34,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/TransferType.pm
+++ b/SL/DB/MetaSetup/TransferType.pm
@@ -22,4 +22,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Translation.pm
+++ b/SL/DB/MetaSetup/Translation.pm
@@ -30,4 +30,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/TriggerInformation.pm
+++ b/SL/DB/MetaSetup/TriggerInformation.pm
@@ -19,4 +19,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->unique_keys([ 'key', 'value' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Unit.pm
+++ b/SL/DB/MetaSetup/Unit.pm
@@ -29,4 +29,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/UnitsLanguage.pm
+++ b/SL/DB/MetaSetup/UnitsLanguage.pm
@@ -31,4 +31,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/UserPreference.pm
+++ b/SL/DB/MetaSetup/UserPreference.pm
@@ -22,4 +22,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->unique_keys([ 'login', 'namespace', 'version', 'key' ]);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/ValidityToken.pm
+++ b/SL/DB/MetaSetup/ValidityToken.pm
@@ -23,4 +23,4 @@ __PACKAGE__->meta->unique_keys([ 'scope', 'token' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Vendor.pm
+++ b/SL/DB/MetaSetup/Vendor.pm
@@ -105,4 +105,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/VendorContact.pm
+++ b/SL/DB/MetaSetup/VendorContact.pm
@@ -32,4 +32,4 @@ __PACKAGE__->meta->foreign_keys(
 );
 
 1;
-;
+

--- a/SL/DB/MetaSetup/Warehouse.pm
+++ b/SL/DB/MetaSetup/Warehouse.pm
@@ -22,4 +22,4 @@ __PACKAGE__->meta->primary_key_columns([ 'id' ]);
 __PACKAGE__->meta->allow_inline_column_values(1);
 
 1;
-;
+

--- a/scripts/rose_auto_create_model.pl
+++ b/scripts/rose_auto_create_model.pl
@@ -222,7 +222,7 @@ CODE
   my $full_definition = <<CODE;
 # This file has been auto-generated. Do not modify it; it will be overwritten
 # by $::script automatically.
-$definition;
+$definition
 CODE
 
   my $meta_definition = <<CODE;


### PR DESCRIPTION
Das `scripts/rose_auto_create_model.pl` hing an die erzeugten MetaSetup-Dateien immer ein einzelnes Semikolon an. Das ist an sich kein Problem, aber  copilot meckert da macnhmal und es sieht auch nicht schön aus ;)

Dieser PR ändert das Script und enthält neu erzeugte MetaSetups.

Ich hatte Probleme mit der Fremschlüsselerkennung für die Auth-DB-Tabellen, aber das ist ein anderes Problem.