### PR TITLE
Tests: Lösche nur durch Unit-Tests angelegte CVars

### DIFF
--- a/t/controllers/csvimport/contact.t
+++ b/t/controllers/csvimport/contact.t
@@ -16,6 +16,8 @@ use_ok 'SL::Controller::CsvImport::Contact';
 
 Support::TestSetup::login();
 
+my @test_cvar_config_ids = ();
+
 #####
 sub do_import {
   my ($file, $settings) = @_;
@@ -51,7 +53,11 @@ sub _obj_of {
 
 sub clear_up {
   SL::DB::Manager::Contact->delete_all(all => 1);
-  SL::DB::Manager::CustomVariableConfig->delete_all(all => 1);
+  if (@test_cvar_config_ids) {
+    SL::DB::Manager::CustomVariable->delete_all(where => [ config_id => \@test_cvar_config_ids ]);
+    SL::DB::Manager::CustomVariableConfig->delete_all(where => [ id => \@test_cvar_config_ids ]);
+    @test_cvar_config_ids = ();
+  }
 
   # Reset request to clear caches. Here especially for cvar-configs.
   $::request = Support::TestSetup->create_new_request;

--- a/t/controllers/csvimport/customervendor.t
+++ b/t/controllers/csvimport/customervendor.t
@@ -16,6 +16,8 @@ use_ok 'SL::Controller::CsvImport::CustomerVendor';
 
 Support::TestSetup::login();
 
+my @test_cvar_config_ids = ();
+
 #####
 sub do_import {
   my ($file, $settings) = @_;
@@ -51,7 +53,11 @@ sub _obj_of {
 
 sub clear_up {
   SL::DB::Manager::Customer->delete_all(all => 1);
-  SL::DB::Manager::CustomVariableConfig->delete_all(all => 1);
+  if (@test_cvar_config_ids) {
+    SL::DB::Manager::CustomVariable->delete_all(where => [ config_id => \@test_cvar_config_ids ]);
+    SL::DB::Manager::CustomVariableConfig->delete_all(where => [ id => \@test_cvar_config_ids ]);
+    @test_cvar_config_ids = ();
+  }
 
   SL::DB::Default->get->update_attributes(customernumber => '10000');
 
@@ -189,7 +195,7 @@ clear_up;
 # leave it untouched?)
 
 # create cvars
-SL::DB::CustomVariableConfig->new(
+my $cvar_config1 = SL::DB::CustomVariableConfig->new(
   module              => 'CT',
   name                => 'no_default',
   description         => 'no default',
@@ -199,8 +205,9 @@ SL::DB::CustomVariableConfig->new(
   includeable         => 0,
   included_by_default => 0,
 )->save;
+push @test_cvar_config_ids, $cvar_config1->id;
 
-SL::DB::CustomVariableConfig->new(
+my $cvar_config2 = SL::DB::CustomVariableConfig->new(
   module              => 'CT',
   name                => 'with_default',
   description         => 'with default',
@@ -211,6 +218,7 @@ SL::DB::CustomVariableConfig->new(
   includeable         => 0,
   included_by_default => 0,
 )->save;
+push @test_cvar_config_ids, $cvar_config2->id;
 
 # - new customer in csv - no cvars given -> one should be unset, the other one
 #   should have the default value

--- a/t/controllers/csvimport/parts.t
+++ b/t/controllers/csvimport/parts.t
@@ -13,6 +13,7 @@ use List::MoreUtils qw(pairwise);
 use SL::Controller::CsvImport;
 
 my $DEBUG = 0;
+my @test_cvar_config_ids = ();
 
 use_ok 'SL::Controller::CsvImport::Part';
 
@@ -80,6 +81,7 @@ sub reset_state {
     includeable => 0,
     included_by_default => 0,
   )->save;
+  push @test_cvar_config_ids, $cvarconfig->id;
 
   foreach ( { id => 1, pricegroup => 'A', sortkey => 1 },
             { id => 2, pricegroup => 'B', sortkey => 2 },
@@ -277,7 +279,7 @@ $entries = test_import($file,$settings2);
 $entry = $entries->[0];
 is $entry->{object}->partnumber, 'P1000', 'P1000 set';
 is $entry->{raw_data}->{cvar_mycvar},'das ist der Ring','CVAR set';
-is @{$entry->{object}->custom_variables}[0]->text_value,'das ist der Ring','Cvar mit richtigem Wert';
+is $entry->{object}->cvar_by_name('mycvar')->text_value,'das ist der Ring','Cvar mit richtigem Wert';
 
 # set locale to de so we can match abbreviations
 $::locale = $old_locale;
@@ -317,7 +319,11 @@ sub clear_up {
   SL::DB::Manager::Language   ->delete_all(all => 1);
   SL::DB::Manager::Bin        ->delete_all(all => 1);
   SL::DB::Manager::Warehouse  ->delete_all(all => 1);
-  SL::DB::Manager::CustomVariableConfig->delete_all(all => 1);
+  if (@test_cvar_config_ids) {
+    SL::DB::Manager::CustomVariable->delete_all(where => [ config_id => \@test_cvar_config_ids ]);
+    SL::DB::Manager::CustomVariableConfig->delete_all(where => [ id => \@test_cvar_config_ids ]);
+    @test_cvar_config_ids = ();
+  }
 }
 
 

--- a/t/db/price_rule.t
+++ b/t/db/price_rule.t
@@ -19,10 +19,15 @@ use SL::DB::CustomVariableConfig;
 
 Support::TestSetup::login();
 
+my @test_cvar_config_ids = ();
+
 sub reset_db {
   SL::DB::Manager::PriceRule->delete_all(all => 1);
-  SL::DB::Manager::CustomVariable->delete_all(all => 1);
-  SL::DB::Manager::CustomVariableConfig->delete_all(all => 1);
+  if (@test_cvar_config_ids) {
+    SL::DB::Manager::CustomVariable->delete_all(where => [ config_id => \@test_cvar_config_ids ]);
+    SL::DB::Manager::CustomVariableConfig->delete_all(where => [ id => \@test_cvar_config_ids ]);
+    @test_cvar_config_ids = ();
+  }
   SL::DB::Manager::Order->delete_all(all => 1);
   SL::DB::Manager::Shipto->delete_all(all => 1);
 
@@ -48,6 +53,7 @@ sub reset_db {
     includeable => 0,
     included_by_default => 0,
   )->save->load;
+  push @test_cvar_config_ids, $cvar_config->id;
 
   my $name = "price for test A";
 
@@ -94,6 +100,7 @@ sub reset_db {
     includeable => 0,
     included_by_default => 0,
   )->save->load;
+  push @test_cvar_config_ids, $cvar_config->id;
 
   my $name = "price for test A";
 
@@ -191,6 +198,7 @@ for (@SL::Controller::CustomVariableConfig::types) {
       includeable => 0,
       included_by_default => 0,
     )->save->load;
+    push @test_cvar_config_ids, $config->id;
 
     my $price_rule = SL::DB::PriceRule->new(
       name  => $name,
@@ -234,6 +242,7 @@ for (@SL::Controller::CustomVariableConfig::types) {
       includeable => 0,
       included_by_default => 0,
     )->save->load;
+    push @test_cvar_config_ids, $config->id;
 
     my $price_rule = SL::DB::PriceRule->new(
       name  => $name,
@@ -281,6 +290,7 @@ for (@SL::Controller::CustomVariableConfig::types) {
       includeable => 0,
       included_by_default => 0,
     )->save->load;
+    push @test_cvar_config_ids, $config->id;
 
     my $part = new_part()->save;
 
@@ -352,6 +362,7 @@ for (@SL::Controller::CustomVariableConfig::types) {
       included_by_default => 0,
       flags => '',
     )->save->load;
+    push @test_cvar_config_ids, $config->id;
 
     my $customer = new_customer()->save->load;
 
@@ -398,6 +409,7 @@ for (@SL::Controller::CustomVariableConfig::types) {
       included_by_default => 0,
       flags => '',
     )->save->load;
+    push @test_cvar_config_ids, $config->id;
 
     my $price_rule = SL::DB::PriceRule->new(
       name  => $name,
@@ -442,6 +454,7 @@ for (@SL::Controller::CustomVariableConfig::types) {
       included_by_default => 0,
       flags => '',
     )->save->load;
+    push @test_cvar_config_ids, $config->id;
 
     my $price_rule = SL::DB::PriceRule->new(
       name  => $name,
@@ -489,6 +502,7 @@ for (@SL::Controller::CustomVariableConfig::types) {
       included_by_default => 0,
       flags => '',
     )->save->load;
+    push @test_cvar_config_ids, $config->id;
 
     my $price_rule = SL::DB::PriceRule->new(
       name  => $name,
@@ -536,6 +550,7 @@ for (@SL::Controller::CustomVariableConfig::types) {
       included_by_default => 0,
       flags => '',
     )->save->load;
+    push @test_cvar_config_ids, $config->id;
 
     my $price_rule = SL::DB::PriceRule->new(
       name  => $name,
@@ -592,6 +607,7 @@ for (@SL::Controller::CustomVariableConfig::types) {
       included_by_default => 0,
       flags => '',
     )->save->load;
+    push @test_cvar_config_ids, $config1->id;
 
     my $config2 = SL::DB::CustomVariableConfig->new(
       module => 'Customer',
@@ -603,6 +619,7 @@ for (@SL::Controller::CustomVariableConfig::types) {
       included_by_default => 0,
       flags => '',
     )->save->load;
+    push @test_cvar_config_ids, $config2->id;
 
     my $order = create_sales_order()->save->load;
     my $item = $order->items_sorted->[0];


### PR DESCRIPTION
wichtig für Kundenerweiterungen, bei welchen CVars per DB-Upgradeskript angelegt werden und in Code mit Testabdeckung eingesetzt werden.