### PR TITLE
DATEV-Export Kreditorenbuchungen: Beschreibung in Text

### DIFF
--- a/SL/DATEV.pm
+++ b/SL/DATEV.pm
@@ -587,7 +587,8 @@ sub generate_datev_data {
 
        SELECT ac.acc_trans_id, ac.transdate, ac.gldate, ac.trans_id,ap.id, ac.amount, ac.taxkey, ac.memo,
          ap.invnumber, ap.duedate, ap.amount as umsatz, COALESCE(ap.tax_point, ap.deliverydate) AS deliverydate, ap.itime::date,
-         ct.name, ct.ustid, ct.vendornumber AS vcnumber, NULL AS customer_id, ct.id AS vendor_id,
+         CASE WHEN (COALESCE(ap.invoice, FALSE) = TRUE OR COALESCE(ap.notes, '') = '') THEN ct.name ELSE ap.notes END AS name,
+         ct.ustid, ct.vendornumber AS vcnumber, NULL AS customer_id, ct.id AS vendor_id,
          $ap_accno, c.description AS accname, c.taxkey_id as charttax, c.datevautomatik, c.id, ac.chart_link AS link,
          ap.invoice,
          t.rate AS taxrate, t.taxdescription,

--- a/t/datev/invoices.t
+++ b/t/datev/invoices.t
@@ -277,7 +277,7 @@ $datev1->generate_datev_data;
 cmp_deeply $datev1->generate_datev_lines, [
                                         {
                                           'belegfeld1'             => 'ap1',
-                                          'buchungstext'           => 'Testvendor',
+                                          'buchungstext'           => 'test ap_transaction',
                                           'datum'                  => '01.01.2017',
                                           'gegenkonto'             => '1600',
                                           'konto'                  => '3400',
@@ -289,7 +289,7 @@ cmp_deeply $datev1->generate_datev_lines, [
                                         },
                                         {
                                           'belegfeld1'             => 'ap1',
-                                          'buchungstext'           => 'Testvendor',
+                                          'buchungstext'           => 'test ap_transaction',
                                           'datum'                  => '01.01.2017',
                                           'gegenkonto'             => '1600',
                                           'konto'                  => '3300',
@@ -305,7 +305,7 @@ $datev1->generate_datev_data;
 cmp_deeply $datev1->generate_datev_lines, [
                                         {
                                           'belegfeld1'             => 'ap1',
-                                          'buchungstext'           => 'Testvendor',
+                                          'buchungstext'           => 'test ap_transaction',
                                           'datum'                  => '01.01.2017',
                                           'gegenkonto'             => $vendor->vendornumber,
                                           'konto'                  => '3400',
@@ -317,7 +317,7 @@ cmp_deeply $datev1->generate_datev_lines, [
                                         },
                                         {
                                           'belegfeld1'             => 'ap1',
-                                          'buchungstext'           => 'Testvendor',
+                                          'buchungstext'           => 'test ap_transaction',
                                           'datum'                  => '01.01.2017',
                                           'gegenkonto'             => $vendor->vendornumber,
                                           'konto'                  => '3300',

--- a/t/tax/tax.t
+++ b/t/tax/tax.t
@@ -300,7 +300,7 @@ is($ap_transaction_2020_2_with_delivery_date_2020_1->amount,   226, 'ap transact
               {
                 'belegfeld1' => 'test ap_transaction 2020_2 with delivery date 2020_1',
                 'buchungsschluessel' => 8,
-                'buchungstext' => 'Testvendor',
+                'buchungstext' => 'test ap_transaction',
                 'datum' => '15.07.2020',
                 'gegenkonto' => $ap_accno,
                 'konto' => $chart_reisekosten_accno,
@@ -314,7 +314,7 @@ is($ap_transaction_2020_2_with_delivery_date_2020_1->amount,   226, 'ap transact
               {
                 'belegfeld1' => 'test ap_transaction 2020_2 with delivery date 2020_1',
                 'buchungsschluessel' => 9,
-                'buchungstext' => 'Testvendor',
+                'buchungstext' => 'test ap_transaction',
                 'datum' => '15.07.2020',
                 'gegenkonto' => $ap_accno,
                 'konto' => $chart_reisekosten_accno,


### PR DESCRIPTION
Moritz schrieb dazu in 2017:


    Standardmäßig wird in das Textfeld des DATEV-Exports bei
    Einkaufsrechnung und Kreditorenbuchungen der Lieferantenname
    eingetragen (DB-Feld ct.name).

    Jetzt wird bei Kreditorenbuchungen der Anfang des Bemerkungsfeldes
    (notes) eingetragen, außer Bemerkungen ist leer, dann wird weiterhin der
    Lieferantenname eingetragen.

    Die Ersetzung passiert direkt schon in der Datenbank, beim nächsten
    Programmupdate, wenn GoBD-Export und der neue DATEV-Export implementiert
    sind, sollte das wahrscheinlich besser nachträglich per Programmlogik
    implementiert werden, weil dann "name" auch für andere Fälle gebraucht
    werden könnte.
