### PR TITLE
Factur-X/ZUGFeRD: Fix Text: elektronische Verkäufer-Adresse

### DIFF
--- a/locale/de/all
+++ b/locale/de/all
@@ -1571,6 +1571,7 @@ $self->{texts} = {
   'Email of the delivery order recipient' => 'E-Mail des Lieferscheinempfängers',
   'Email of the dunning recipient' => 'E-Mail des Mahnungsempfängers',
   'Email of the invoice recipient' => 'E-Mail des Rechnungsempfängers',
+  'Email of the invoicing party' => 'E-Mail des Rechnungsstellers',
   'Email signature'             => 'E-Mail-Signatur',
   'Employee'                    => 'Bearbeiter',
   'Employee #1 saved!'          => 'Benutzer #1 gespeichert!',

--- a/locale/en/all
+++ b/locale/en/all
@@ -1571,6 +1571,7 @@ $self->{texts} = {
   'Email of the delivery order recipient' => '',
   'Email of the dunning recipient' => '',
   'Email of the invoice recipient' => '',
+  'Email of the invoicing party' => '',
   'Email signature'             => '',
   'Employee'                    => '',
   'Employee #1 saved!'          => '',

--- a/templates/design40_webpages/client_config/_features.html
+++ b/templates/design40_webpages/client_config/_features.html
@@ -231,7 +231,7 @@
         <td class="long-desc"> [% LxERP.t8('Include the transaction description in the preset email subject.') %] </td>
       </tr>
       <tr>
-        <th>[% LxERP.t8('Email of the invoice recipient') %]</th>
+        <th>[% LxERP.t8('Email of the invoicing party') %]</th>
         <td colspan="2">
           [% L.input_tag('defaults.invoice_mail', SELF.defaults.invoice_mail) %]
           <div class ="description">[% 'Used in Factur-X/ZUGFeRD & XRechnung invoice data for the seller party\'s contact information' | $T8 %]</div>


### PR DESCRIPTION
Adresse des Rechnungsstellers statt Adresse der Rechnungsempfängers im Text in der Mandantenkonfig