### PR TITLE
ZUGFeRD: Fix: Zeilensumme bei "Steuer inbegriffen.

### DIFF
--- a/SL/DB/Helper/ZUGFeRD.pm
+++ b/SL/DB/Helper/ZUGFeRD.pm
@@ -309,9 +309,10 @@ sub _line_item {
   $params{xml}->endTag;
   #     </ram:ApplicableTradeTax>
 
+  my $linetotal_net = $self->taxincluded ? $item_ptc->{linetotal} - $item_ptc->{tax_amount} : $item_ptc->{linetotal};
   #     <ram:SpecifiedTradeSettlementLineMonetarySummation>
   $params{xml}->startTag("ram:SpecifiedTradeSettlementLineMonetarySummation");
-  $params{xml}->dataElement("ram:LineTotalAmount", _r2($item_ptc->{linetotal}));
+  $params{xml}->dataElement("ram:LineTotalAmount", _r2($linetotal_net));
   $params{xml}->endTag;
   #     </ram:SpecifiedTradeSettlementLineMonetarySummation>
 


### PR DESCRIPTION
<ram:SpecifiedTradeSettlementLineMonetarySummation>
  <ram:LineTotalAmount>

LineTotalAmount ist die Zeilensumme ohne MwSt.

Hinweise aus "ZUGFeRD 2.4 / Factur-X 1.08 Spezifikation - Technischer Anhang gültig ab: 16.01.2026; Profil EXTENDED":

SpecifiedTradeSettlementLineMonetarySummation ...
LineTotalAmount: Nettobetrag der Rechnungsposition Hinweis: Dies ist der „Netto“-Betrag d. h. ohne die Umsatzsteuer, aber einschließlich aller für die Positionsebene geltenden Zu- und Abschläge sowie sonstiger anfallender Steuern.
EN16931-ID: BT-131
Anwendung: Der Gesamtbetrag der Rechnungsposition