### PR TITLE
TopQuickSearch: CSS: flex-Layout um Platz optimal auszunutzen

### DIFF
--- a/public/css/design40/less/menu.less
+++ b/public/css/design40/less/menu.less
@@ -253,9 +253,9 @@ body > div.frame-main > div.layout-split-right {
   display:            flex;
   flex-direction:     column;
 
-  & > #content {
-    h1 { top: 28px !important; }
+  //.layout-actionbar { top: 42px; }
 
+  & > #content {
     & > .wrapper{
       padding-top: 2em ;
     }

--- a/public/css/design40/less/menu_frame_header.less
+++ b/public/css/design40/less/menu_frame_header.less
@@ -58,9 +58,9 @@
 .client {
   text-transform: uppercase;
   text-wrap: nowrap;
-  font-size: @font-size-large;
+  font-size: @font-size-larger;
   // set height for vertical centering
-  //height: @font-size-large;
+  //height: @font-size-larger;
 }
 
 // --------------------------------------

--- a/public/css/design40/less/menu_frame_header.less
+++ b/public/css/design40/less/menu_frame_header.less
@@ -147,20 +147,23 @@
     // QUICK-SEARCH
     // --------------------------------------
 
-    div.frame-header-quicksearch{
-      display: block;
-      overflow: hidden;
+    div.frame-header-quicksearch {
       margin: 0.1em auto 0 auto;
-      text-align: center;
       width: auto;
+      display: flex;
+      flex-wrap: wrap;
+      column-gap: 0.75ex;
+      row-gap: 0.75ex;
+      justify-content: center;
 
-      span.frame-header-quicksearch input {
+      input {
+        flex: 1;
+        height: 1.8em;
+        min-width: 7em;
+        max-width: 220px;
+        font-size: @font-size-smaller;
         //font-family: @font-family-sans-serif ;
-        margin-top: 0.1em;
         background-color: @dashbrd_input_bg ;
-        width: auto !important;
-        min-width: 5em;
-        max-width: 7em;
         padding: 0 0.2em ;
         border-width: 1px ;
         //border-color: #bcbcbc;

--- a/public/css/design40/less/menu_frame_header.less
+++ b/public/css/design40/less/menu_frame_header.less
@@ -15,164 +15,93 @@
 // CONTENTS:
 // - FRAME-HEADER
 // - FRAME-HEADER-ELEMENTS (Links left & right)
-// - FLASH TOGGLE
-// - AJAX-SPINNER (Beach Ball)
 // - QUICK-SEARCH
+// - AJAX-SPINNER (Beach Ball)
 // ----------------------------------------------------------------------------
 
 
 #frame-header {
+  background-color: @dashbrd_bg;
+  color: @dashbrd_text;
 
-    text-align: left;
-    margin: 0;
-    padding: 0.2em 0.6em;
-    border: 0;
-    //overflow: hidden;
-    //height: 28px;
-    width: 100%;
-    display: table-cell;
-    vertical-align: middle;
-    border-spacing: 0;
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+}
 
-    background-color: @dashbrd_bg;
-    line-height: 100%;
+// --------------------------------------
+// FRAME-HEADER-ELEMENTS (Left & Right)
+// --------------------------------------
 
-    + div {
-        // see main.less
-    }
+// these are boxes containing icons and text on the left and right
+.frame-header-element {
+  display: flex;
+  gap: 10px;
+  padding-left: 5px;
+  padding-right: 5px;
 
-
-    // --------------------------------------
-    // FRAME-HEADER-ELEMENTS (Left & Right)
-    // --------------------------------------
-
-    span.frame-header-element {
-        color: @dashbrd_text ;
-        padding-top: 0.2em;
-
-        a:link,
-        a:visited,
-        a:hover,
-        a:active {
-            text-decoration: none;
-            border-bottom: none;
-            color: @dashbrd_link ;
-        }
-
-        a:hover{
-            color: @dashbrd_link_hover ;
-            text-decoration: @dashbrd_link_deco; /*underline*/
-        }
-        span.client{
-          text-transform: uppercase ;
-          font-size: 130% ;
-        }
-    } // /span.frame-header-element
-
-
-    span.frame-header-left,
-    span.frame-header-center,
-    span.frame-header-right    {
-        border-spacing: 0;
-        padding: 0;
-        vertical-align: middle;
-        height: 100%;
-        display: table-row;
-
-        & > span {
-          height: 24px;
-          margin: 0 10px;
-          display: table-cell ;
-          vertical-align: middle;
-        }
-    }
-
-    span.frame-header-left {
-        float: left;
-        padding: 0 1.0em 0 0.2em ;
-        margin-right: 1.0em ;
-        & > span { padding-right: 1.0em ; }
-    }
-    span.frame-header-right {
-        float: right;
-        vertical-align: middle;
-        padding: 0 1.2em 0 1.0em ;
-        margin-left: 1.0em;
-        & > span { padding-left: 1.0em ; }
-    }
-
-    // --------------------------------------
-    // FLASH TOGGLE
-    // --------------------------------------
-
-    .layout-flash-toggle {
-        cursor: pointer;
-    }
-    .layout-flash-toggle img {
-        transform-origin: top center;
-    }
-    .layout-flash-toggle img.shake {
-        animation: shake-bell 0.6s ease-in-out;
-    }
-    #flash-number {
-      padding-left: 2px;
-    }
-
-    @keyframes shake-bell {
-      0% { transform: rotate(0); }
-      15% { transform: rotate(10deg); }
-      30% { transform: rotate(-10deg); }
-      45% { transform: rotate(8deg); }
-      60% { transform: rotate(-8deg); }
-      75% { transform: rotate(4deg); }
-      100% { transform: rotate(0); }
-    }
-
-
-    // --------------------------------------
-    // AJAX-SPINNER (Beach Ball)
-    // --------------------------------------
-
-    #ajax-spinner-container {
-      width: 16px;
-      padding-left: 0;
-    }
-    #ajax-spinner {
-      display: none;
-    }
-
-
-
-    // --------------------------------------
-    // QUICK-SEARCH
-    // --------------------------------------
-
-    div.frame-header-quicksearch {
-      margin: 0.1em auto 0 auto;
-      width: auto;
+  span {
+    a {
+      // this centers the icon element in the link vertically
       display: flex;
-      flex-wrap: wrap;
-      column-gap: 0.75ex;
-      row-gap: 0.75ex;
-      justify-content: center;
+    }
+  }
+}
 
-      input {
-        flex: 1;
-        height: 1.8em;
-        min-width: 7em;
-        max-width: 220px;
-        font-size: @font-size-smaller;
-        //font-family: @font-family-sans-serif ;
-        background-color: @dashbrd_input_bg ;
-        padding: 0 0.2em ;
-        border-width: 1px ;
-        //border-color: #bcbcbc;
-        border-style: solid;
-        border-top-color: #949494;
-        border-right-color: #BCBCBC;
-        border-bottom-color: #BCBCBC;
-        border-left-color: #949494;
-      }
-    } // /div.frame-header-quicksearch
+// container for the name of the client
+// added a box to center the text vertically
+.frame-header-client-box {
+  display: flex;
+  align-items: center;
+}
+.client {
+  text-transform: uppercase;
+  text-wrap: nowrap;
+  font-size: @font-size-large;
+  // set height for vertical centering
+  height: @font-size-large;
+}
 
-} /* /#frame-header  */
+// --------------------------------------
+// QUICK-SEARCH
+// --------------------------------------
+
+// NOTE: div needed here because the same class name is used for the span below
+div.frame-header-quicksearch {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 5px;
+  // limit maximum height and make input fields scrollable if needed
+  // TODO: later this can be adapted so that the input fields wrap on a narrower
+  // screen (up to 1 or 2 lines/rows), but for this to work more changes in the
+  // underlying less/CSS are required so that the content below can shift down
+  // dynamically, currently these heights are hard coded
+  max-height: 35px;
+  overflow-y: scroll;
+}
+
+span.frame-header-quicksearch input {
+  min-width: 5em;
+  max-width: 7em;
+  // NOTE: set the font size explicitly here otherwise the browser renders
+  // it as 13.3333px, despite inheriting 14px
+  font-size: @font-size-base;
+  background-color: @dashbrd_input_bg;
+}
+
+
+// --------------------------------------
+// AJAX-SPINNER (Beach Ball)
+// --------------------------------------
+
+.frame-header-spinner-box {
+  // this is used as a place holder in order to avoid content shift when
+  // the spinner is displayed and hidden
+  width: 16px;
+}
+
+#ajax-spinner {
+  display: none;
+}

--- a/public/css/design40/less/menu_frame_header.less
+++ b/public/css/design40/less/menu_frame_header.less
@@ -60,7 +60,7 @@
   text-wrap: nowrap;
   font-size: @font-size-large;
   // set height for vertical centering
-  height: @font-size-large;
+  //height: @font-size-large;
 }
 
 // --------------------------------------
@@ -73,23 +73,59 @@ div.frame-header-quicksearch {
   flex-wrap: wrap;
   gap: 5px;
   padding: 5px;
+  flex: 1;
+  justify-content: center;
   // limit maximum height and make input fields scrollable if needed
   // TODO: later this can be adapted so that the input fields wrap on a narrower
   // screen (up to 1 or 2 lines/rows), but for this to work more changes in the
   // underlying less/CSS are required so that the content below can shift down
   // dynamically, currently these heights are hard coded
-  max-height: 35px;
-  overflow-y: scroll;
+  //max-height: 35px;
+  //overflow-y: scroll;
 }
 
-span.frame-header-quicksearch input {
+div.frame-header-quicksearch input {
+  flex: 1;
   min-width: 5em;
-  max-width: 7em;
+  max-width: 15em;
   // NOTE: set the font size explicitly here otherwise the browser renders
   // it as 13.3333px, despite inheriting 14px
   font-size: @font-size-base;
   background-color: @dashbrd_input_bg;
 }
+
+
+    // --------------------------------------
+    // FLASH TOGGLE
+    // --------------------------------------
+
+    #flash-toggle {
+      display: flex;
+      align-items: center;
+    }
+    .layout-flash-toggle {
+        cursor: pointer;
+    }
+    .layout-flash-toggle img {
+        transform-origin: top center;
+    }
+    .layout-flash-toggle img.shake {
+        animation: shake-bell 0.6s ease-in-out;
+    }
+    #flash-number {
+      padding-left: 2px;
+    }
+
+    @keyframes shake-bell {
+      0% { transform: rotate(0); }
+      15% { transform: rotate(10deg); }
+      30% { transform: rotate(-10deg); }
+      45% { transform: rotate(8deg); }
+      60% { transform: rotate(-8deg); }
+      75% { transform: rotate(4deg); }
+      100% { transform: rotate(0); }
+    }
+
 
 
 // --------------------------------------

--- a/public/css/design40/less/scaffolding.less
+++ b/public/css/design40/less/scaffolding.less
@@ -86,8 +86,8 @@ body {
     z-index: @zindex-actionbar;
     //float: left !important;
     float: right !important;
-    width: fit-content;
     height: 25px;
+    width: auto;
     //left: 656px ;
     right: 0.2em ;
     margin: 0 0.4em 0 0;

--- a/templates/design40_webpages/menu/header.html
+++ b/templates/design40_webpages/menu/header.html
@@ -12,13 +12,19 @@
     [% END %]
     <div class="frame-header-quicksearch">
       [% FOREACH search = quick_search.enabled_modules %]
-        <span class='frame-header-quicksearch'><input type="text" id="top-quick-search-[% search.name %]" module="[% search.name %]" placeholder="[% search.description_field %]" maxlength="20" class="quick-search"></span>
+        <input type="text" id="top-quick-search-[% search.name %]" module="[% search.name %]" placeholder="[% search.description_field %]" maxlength="20" class="quick-search">
       [% END %]
     </div>
 
     <div class="frame-header-spinner-box">
       <span class="frame-header-spinner" id="ajax-spinner">
          <img src="image/spinner-blue.gif" alt="[% LxERP.t8('Loading...') %]">
+      </span>
+    </div>
+    <div class="frame-header-element">
+      <span id="flash-toggle" title="[% 'Show/Hide flash messages' | $T8 %]">
+        <span class="layout-flash-toggle"><img src="image/header-icon-bell.svg" alt="Flash" width="24" height="24"></span>
+        <span id="flash-number" class="layout-flash-number">0</span>
       </span>
     </div>
     <div class="frame-header-client-box">

--- a/templates/design40_webpages/menu/header.html
+++ b/templates/design40_webpages/menu/header.html
@@ -10,24 +10,24 @@
         <span><a href="JavaScript:top.print();" title="[% 'Hardcopy' | $T8 %]"><img alt="[% 'Print' | $T8 %]" src="image/header-icon-print.png"></a></span>
       </span>
     [% END %]
-    <span class="frame-header-element frame-header-right">
-      <span id="ajax-spinner-container">
-        <span id="ajax-spinner">
-          <img src="image/spinner-blue.gif" alt="[% LxERP.t8('Loading...') %]">
-        </span>
+    <div class="frame-header-quicksearch">
+      [% FOREACH search = quick_search.enabled_modules %]
+        <span class='frame-header-quicksearch'><input type="text" id="top-quick-search-[% search.name %]" module="[% search.name %]" placeholder="[% search.description_field %]" maxlength="20" class="quick-search"></span>
+      [% END %]
+    </div>
+
+    <div class="frame-header-spinner-box">
+      <span class="frame-header-spinner" id="ajax-spinner">
+         <img src="image/spinner-blue.gif" alt="[% LxERP.t8('Loading...') %]">
       </span>
-      <span id="flash-toggle" title="[% 'Show/Hide flash messages' | $T8 %]">
-        <span class="layout-flash-toggle"><img src="image/header-icon-bell.svg" alt="Flash" width="24" height="24"></span>
-      </span>
-      <span id="flash-number" class="layout-flash-number">0</span>
+    </div>
+    <div class="frame-header-client-box">
       <span title="[% 'Client' | $T8 %]" class="client">[% AUTH.client.name | html %]</span>
+    </div>
+    <span class="frame-header-element frame-header-right">
       <span><a href="am.pl?action=config" title="[% 'User' | $T8 %]: [% MYCONFIG.login | html %] / [% 'Client' | $T8 %]: [% AUTH.client.name | html %]"><!-- [% #MYCONFIG.login | html %] / [% #AUTH.client.name | html %] --><img alt="[% 'User' | $T8 %]/[% 'Client' | $T8 %]" src="image/header-icon-user.png"></a></span>
       <span><a href="controller.pl?action=LoginScreen/logout" target="_top" title="[% 'Logout now' | $T8 %]"><img alt="[% 'Logout' | $T8 %]" src="image/header-icon-logout.png"></a></span>
     </span>
-    <div class="frame-header-quicksearch">
-      [% FOREACH search = quick_search.enabled_modules %]
-        <input type="text" id="top-quick-search-[% search.name %]" module="[% search.name %]" placeholder="[% search.description_field %]" maxlength="20" class="quick-search">
-      [% END %]
-    </div>
   </div>
+</div>
 [% END %]

--- a/templates/design40_webpages/menu/header.html
+++ b/templates/design40_webpages/menu/header.html
@@ -35,5 +35,4 @@
       <span><a href="controller.pl?action=LoginScreen/logout" target="_top" title="[% 'Logout now' | $T8 %]"><img alt="[% 'Logout' | $T8 %]" src="image/header-icon-logout.png"></a></span>
     </span>
   </div>
-</div>
 [% END %]

--- a/templates/design40_webpages/menu/header.html
+++ b/templates/design40_webpages/menu/header.html
@@ -26,7 +26,7 @@
     </span>
     <div class="frame-header-quicksearch">
       [% FOREACH search = quick_search.enabled_modules %]
-        <span class='frame-header-quicksearch'><input type="text" id="top-quick-search-[% search.name %]" module="[% search.name %]" placeholder="[% search.description_field %]" class="quick-search"></span>
+        <input type="text" id="top-quick-search-[% search.name %]" module="[% search.name %]" placeholder="[% search.description_field %]" maxlength="20" class="quick-search">
       [% END %]
     </div>
   </div>


### PR DESCRIPTION
## Was dies bewirkt

Die Felder der Schnellsuche füllen den ihnen zur Verfügung stehenden Platz besser aus. Sie passen sich in ihrer Breite dynamisch an. Es wird eine bestimmte Mindestbreite sichergestellt.

mit breitem Viewport sieht es so aus:
<img width="1917" height="36" alt="grafik" src="https://github.com/user-attachments/assets/0c35e3f5-b5df-4f7f-82ae-3cf19bed89fe" />


mit schmalem Viewport sieht es so aus:
<img width="1149" height="36" alt="grafik" src="https://github.com/user-attachments/assets/6b96d38b-ca19-497c-b08a-e681b511dfd1" />

