### PR TITLE
Bugfix CT Search und Ansprechpartnersuche erweitern: nach vorname suchen

### DIFF
--- a/SL/CT.pm
+++ b/SL/CT.pm
@@ -599,7 +599,7 @@ sub search_contacts {
 
                      ORDER BY $order_by|;
 
-  my $contacts  = selectall_hashref_query($::form, $dbh, $query, @values);
+  my $contacts  = selectall_hashref_query($::form, $dbh, $query, @values, @values);
 
   $::lxdebug->leave_sub;
 

--- a/SL/DB/Contact.pm
+++ b/SL/DB/Contact.pm
@@ -47,6 +47,8 @@ sub used {
   require SL::DB::DeliveryOrder;
   require SL::DB::Letter;
   require SL::DB::LetterDraft;
+  require SL::DB::PeriodicInvoicesConfig;
+  require SL::DB::Reclamation;
 
   return SL::DB::Manager::Order->get_all_count(query => [ cp_id => $self->cp_id ])
        + SL::DB::Manager::Invoice->get_all_count(query => [ cp_id => $self->cp_id ])

--- a/bin/mozilla/ct.pl
+++ b/bin/mozilla/ct.pl
@@ -417,7 +417,7 @@ sub list_contacts {
     'cp_id'        => { 'text' => $::locale->text('ID'), },
     'vcname'       => { 'text' => $::locale->text('Customer/Vendor'), },
     'vcnumber'     => { 'text' => $::locale->text('Customer/Vendor Number'), },
-    'cp_name'      => { 'text' => $::locale->text('Name'), },
+    'cp_name'      => { 'text' => $::locale->text('Surname'), },
     'cp_givenname' => { 'text' => $::locale->text('Given Name'), },
     'cp_street'    => { 'text' => $::locale->text('Street'), },
     'cp_zipcode'   => { 'text' => $::locale->text('Zipcode'), },

--- a/templates/design40_webpages/ct/search_contact.html
+++ b/templates/design40_webpages/ct/search_contact.html
@@ -11,11 +11,11 @@
   <tbody>
     <tr>
       <th>[% 'Given Name' | $T8 %] </th>
-      <td><input type="text" name="filter.cp_givenname" class="wi-lightwide initial_focus"></td>
+      <td><input type="text" name="filter.cp_givenname" class="wi-lightwide"></td>
     </tr>
     <tr>
       <th>[% 'Surname' | $T8 %] </th>
-      <td><input type="text" name="filter.cp_name" class="wi-lightwide initial_focus"></td>
+      <td><input type="text" name="filter.cp_name" class="wi-lightwide"></td>
     </tr>
     <tr>
       <th>[% 'Greeting' | $T8 %] </th>

--- a/templates/design40_webpages/ct/search_contact.html
+++ b/templates/design40_webpages/ct/search_contact.html
@@ -10,7 +10,11 @@
 <table class="tbl-horizontal">
   <tbody>
     <tr>
-      <th>[% 'Name' | $T8 %] </th>
+      <th>[% 'Given Name' | $T8 %] </th>
+      <td><input type="text" name="filter.cp_givenname" class="wi-lightwide initial_focus"></td>
+    </tr>
+    <tr>
+      <th>[% 'Surname' | $T8 %] </th>
       <td><input type="text" name="filter.cp_name" class="wi-lightwide initial_focus"></td>
     </tr>
     <tr>
@@ -77,7 +81,7 @@
     </div>
     <div>
       <input name="l.cp_name" id="l_cp_name" type="checkbox" value="Y" checked>
-      <label for="l_cp_name"> [% 'Name' | $T8 %] </label>
+      <label for="l_cp_name"> [% 'Surname' | $T8 %] </label>
     </div>
     <div>
       <input name="l.cp_givenname" id="l_cp_givenname" type="checkbox" value="Y" checked>


### PR DESCRIPTION
Ansprechpersonensuche: Suche nach Vorname ergänzt

Im Template für das Suchformular "Nachname" statt nur "Name": klarere Bezeichnung


Parameter für UNION doppelt übergeben bei der Suche (das ist uns durch die Lappen gegangen)

Ansprechpartner löschbar: prüfe Verwendung... fix Includes
