### PR TITLE
202607 fix contacts wf rg order

### DIFF
--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1633,7 +1633,7 @@ sub cv_assigned_contacts {
   my ($self) = @_;
 
   my $contacts = $self->order->customervendor ? $self->order->customervendor->contacts() : [];
-  if ($self->order->contact && none { $_->cp_id == $self->order->contact->cp_id } @$contacts) {
+  if ($self->order->cp_id && none { $_->cp_id == $self->order->cp_id } @$contacts) {
     push @$contacts, $self->order->contact;
   }
 

--- a/SL/Controller/Letter.pm
+++ b/SL/Controller/Letter.pm
@@ -593,7 +593,7 @@ sub cv_assigned_contacts {
   my ($self) = @_;
 
   my $contacts = $self->letter->customer_vendor ? $self->letter->customer_vendor->contacts() : [];
-  if ($self->letter->contact && none { $_->cp_id == $self->letter->contact->cp_id } @$contacts) {
+  if ($self->letter->cp_id && none { $_->cp_id == $self->letter->cp_id } @$contacts) {
     push @$contacts, $self->letter->contact;
   }
 

--- a/SL/Controller/Order.pm
+++ b/SL/Controller/Order.pm
@@ -1727,7 +1727,7 @@ sub cv_assigned_contacts {
   my ($self) = @_;
 
   my $contacts = $self->order->customervendor ? $self->order->customervendor->contacts() : [];
-  if ($self->order->contact && none { $_->cp_id == $self->order->contact->cp_id } @$contacts) {
+  if ($self->order->cp_id && none { $_->cp_id == $self->order->cp_id } @$contacts) {
     push @$contacts, $self->order->contact;
   }
 

--- a/SL/Controller/Reclamation.pm
+++ b/SL/Controller/Reclamation.pm
@@ -1275,7 +1275,7 @@ sub cv_assigned_contacts {
   my ($self) = @_;
 
   my $contacts = $self->reclamation->customervendor ? $self->reclamation->customervendor->contacts() : [];
-  if ($self->reclamation->contact && none { $_->cp_id == $self->reclamation->contact->cp_id } @$contacts) {
+  if ($self->reclamation->contact_id && none { $_->cp_id == $self->reclamation->contact_id } @$contacts) {
     push @$contacts, $self->reclamation->contact;
   }
 

--- a/templates/design40_webpages/reclamation/tabs/basic_data.html
+++ b/templates/design40_webpages/reclamation/tabs/basic_data.html
@@ -43,7 +43,7 @@
         </td>
       </tr>
 
-      <tr id='contact_row' [%- IF !SELF.cv_assigned_contacts.size %]style='display:none'[%- END %]>
+      <tr id='cp_row' [%- IF !SELF.cv_assigned_contacts.size %]style='display:none'[%- END %]>
         <th>[% 'Contact Person' | $T8 %]</th>
         <td>[% L.select_tag('reclamation.contact_id',
                             SELF.cv_assigned_contacts,


### PR DESCRIPTION
Der Workflow aus der alten Masken (hier Rechnung->Auftrag) kann cp_id statt 'undef' auch schon mal '0' haben. Dann gibt es einen Fehler beim Instanziieren des contact-Objekts.

Zudem muss das vom Beleg referenzierte contact-Objekt nur geladen werden, wenn es auch mit in die Liste der Kontakte zusätzlich aufgenommen wird, also, wenn die gesetzte Ansprechperson zwischenzeitlich von Kunden/Lieferanten entfernt wurde.
Deshalb auch in den anderen Controllern angepasst.

Zusätzlich noch die Auswahl der ASP in der Reklamation gefixt,