### PR TITLE
Bericht Lagerbuchungen: HTML-Templates: wrapper spendiert

### DIFF
--- a/templates/design40_webpages/wh/report_bottom.html
+++ b/templates/design40_webpages/wh/report_bottom.html
@@ -1,3 +1,4 @@
 [%- USE HTML %]
 <input type="hidden" name="callback" value="[% HTML.escape(callback) %]">
 </form>
+</div><!-- /.wrapper -->

--- a/templates/design40_webpages/wh/report_top.html
+++ b/templates/design40_webpages/wh/report_top.html
@@ -1,1 +1,2 @@
+<div class="wrapper">
 <form method="post" action="wh.pl" id="form">


### PR DESCRIPTION
Sonst hängt der Bericht an der linken Bildschirmseite.