### PR TITLE
Report Generator: Treffer pro Seite einstellbar gemacht: 20, 100, 1000

### DIFF
--- a/SL/Controller/SellPriceInformation.pm
+++ b/SL/Controller/SellPriceInformation.pm
@@ -20,7 +20,7 @@ sub action_list {
   );
 
   my $db_args = $self->setup_for_list(%list_params);
-  $self->{pages} = SL::DB::Manager::OrderItem->paginate(%list_params, args => $db_args, per_page => 5);
+  $self->{pages} = SL::DB::Manager::OrderItem->paginate(%list_params, args => $db_args, per_page => $::form->{per_page} // 5);
 
   my $bottom = $::form->parse_html_template('price_information/report_bottom', { SELF => $self });
 
@@ -177,7 +177,7 @@ sub self_url {
     action   => $self->{action},
     sort_by  => $self->{sort_by},
     sort_dir => $self->{sort_dir},
-    page     => $self->{pages}{cur},
+    (page    => $self->{pages}{cur}) x !! $self->{pages}{cur},
     filter   => $::form->{filter},
     %params,
   );

--- a/doc/changelog
+++ b/doc/changelog
@@ -176,6 +176,9 @@ Kleinere neue Features und Detailverbesserungen:
 - Falls eine Ware in einem Erzeugnis verbaut wurde, wird das Erzeugnis im
   Lagerbuchungsbericht zusätzlich als Link zum Erzeugnis angezeigt.
 
+- Beim Blättern der Berichte kann die Anzahl der Treffer pro Seite ausgewählt
+  werden.
+
 Bugfixes (Tracker: https://www.kivitendo.de/redmine/projects/forum/issues/):
 
 - XRechnung: beim Herunterladen der XRechnung-XML-Datei beginnt der

--- a/public/js/kivi.CustomerVendor.js
+++ b/public/js/kivi.CustomerVendor.js
@@ -168,17 +168,6 @@ namespace('kivi.CustomerVendor', function(ns) {
     window.open(url, "_new_generic", parm);
   };
 
-  this.inline_report = function(target, source, data){
-    $.ajax({
-      url:        source,
-      success:    function (rsp) {
-        $(target).html(rsp);
-        kivi.init_report_paginate_controls($(target));
-      },
-      data:       data,
-    });
-  };
-
   var KEY = {
     BACKSPACE: 8,
     TAB:       9,
@@ -420,28 +409,48 @@ namespace('kivi.CustomerVendor', function(ns) {
     ns.reinit_widgets();
   }
 
-  ns.get_price_report = function(target, source, data) {
-    $.ajax({
-      url:        source,
-      success:    function (rsp) {
-        $(target).html(rsp);
-        kivi.init_report_paginate_controls($(target));
-      },
-    });
-  };
+  ns.price_list_and_price_rules_init = function () {
+    const load_price_list = function () {
+      kivi.inline_report_load_into_container(
+        'controller.pl',
+        '#price_list',
+        { action: 'CustomerVendor/ajax_list_prices', id: $('#cv_id').val(), db: $('#db').val(), callback: $('#callback').val() }
+      );
+    };
 
-  ns.price_list_init = function () {
-    $("#customer_vendor_tabs").on('tabsbeforeactivate', function(event, ui){
-      if (ui.newPanel.attr('id') == 'price_list') {
-        ns.get_price_report('#price_list', "controller.pl?action=CustomerVendor/ajax_list_prices&id=" + $('#cv_id').val() + "&db=" + $('#db').val() + "&callback=" + $('#callback').val());
-      }
+    $("#customer_vendor_tabs").on('tabsbeforeactivate', function (event, ui){
+      if (ui.newPanel.attr('id') == 'price_list') { load_price_list(); }
       return 1;
     });
 
-    $("#customer_vendor_tabs").on('tabscreate', function(event, ui){
-      if (ui.panel.attr('id') == 'price_list') {
-        ns.get_price_report('#price_list', "controller.pl?action=CustomerVendor/ajax_list_prices&id=" + $('#cv_id').val() + "&db=" + $('#db').val() + "&callback=" + $('#callback').val());
+    $("#customer_vendor_tabs").on('tabscreate', function (event, ui){
+      if (ui.panel.attr('id') == 'price_list') { load_price_list(); }
+      return 1;
+    });
+
+    const load_price_rules = function () {
+      if ($('#db').val() == 'customer') {
+        kivi.inline_report_load_into_container(
+          'controller.pl',
+          '#price_rules_customer_report',
+          { action: 'PriceRule/list', 'filter.item_type_matches[].customer': $('#cv_id').val(), 'filter.type': 'customer', inline: 1 }
+        );
+      } else {
+        kivi.inline_report_load_into_container(
+          'controller.pl',
+          '#price_rules_vendor_report',
+          { action: 'PriceRule/list', 'filter.item_type_matches[].vendor': $('#cv_id').val(), 'filter.type': 'vendor', inline: 1 }
+        );
       }
+    };
+
+    $("#customer_vendor_tabs").on('tabsbeforeactivate', function (event, ui){
+      if (ui.newPanel.attr('id') == 'price_rules') { load_price_rules(); }
+      return 1;
+    });
+
+    $("#customer_vendor_tabs").on('tabscreate', function (event, ui){
+      if (ui.panel.attr('id') == 'price_rules') { load_price_rules(); }
       return 1;
     });
   }
@@ -505,6 +514,6 @@ namespace('kivi.CustomerVendor', function(ns) {
 
   $(function(){
     ns.init();
-    ns.price_list_init();
+    ns.price_list_and_price_rules_init();
   });
 });

--- a/public/js/kivi.CustomerVendor.js
+++ b/public/js/kivi.CustomerVendor.js
@@ -173,15 +173,10 @@ namespace('kivi.CustomerVendor', function(ns) {
       url:        source,
       success:    function (rsp) {
         $(target).html(rsp);
-        $(target).find('.paginate').find('a').click(function(event){ ns.redirect_event(event, target) });
-        $(target).find('a.report-generator-header-link').click(function(event){ ns.redirect_event(event, target) });
+        kivi.init_report_paginate_controls($(target));
       },
       data:       data,
     });
-  };
-  this.redirect_event = function(event, target){
-    event.preventDefault();
-    ns.inline_report(target, event.target + '', {});
   };
 
   var KEY = {
@@ -430,14 +425,9 @@ namespace('kivi.CustomerVendor', function(ns) {
       url:        source,
       success:    function (rsp) {
         $(target).html(rsp);
-        $(target).find('a.report-generator-header-link').click(function(event){ ns.price_report_redirect_event(event, target) });
+        kivi.init_report_paginate_controls($(target));
       },
     });
-  };
-
-  ns.price_report_redirect_event = function (event, target) {
-    event.preventDefault();
-    ns.get_price_report(target, event.target + '');
   };
 
   ns.price_list_init = function () {

--- a/public/js/kivi.CustomerVendor.js
+++ b/public/js/kivi.CustomerVendor.js
@@ -169,7 +169,6 @@ namespace('kivi.CustomerVendor', function(ns) {
   };
 
   this.inline_report = function(target, source, data){
-//    alert("HALLO S " + source + " --T " + target + " tt D " + data);
     $.ajax({
       url:        source,
       success:    function (rsp) {

--- a/public/js/kivi.Part.js
+++ b/public/js/kivi.Part.js
@@ -886,6 +886,24 @@ namespace('kivi.Part', function(ns) {
     ns.reinit_widgets();
   };
 
+  ns.init_price_information_and_history = function() {
+    const load_lists = function () {
+      const id = $('#part_id').val();
+      kivi.inline_report_load_into_container('controller.pl', '#sales_price_information_sales_order', { action: 'SellPriceInformation/list', 'filter.part.id': id, 'filter.order.type': 'sales_order' });
+      kivi.inline_report_load_into_container('controller.pl', '#sales_price_information_sales_quotation', { action: 'SellPriceInformation/list', 'filter.part.id': id, 'filter.order.type': 'sales_quotation' });
+      kivi.inline_report_load_into_container('controller.pl', '#parts_price_history', { action: 'PartsPriceHistory/list', 'filter.part_id': id });
+    };
+    $('.tabwidget').on('tabsbeforeactivate', function(event, ui){
+      if (ui.newPanel.attr('id') == 'sales_price_information') { load_lists(); }
+      return 1;
+    });
+
+    $('.tabwidget').on('tabscreate', function(event, ui){
+      if (ui.panel.attr('id') == 'sales_price_information') { load_lists(); }
+      return 1;
+    });
+  };
+
   ns.add_to_basket = function() {
     var data = $('#ic').serializeArray();
     data.push({ name: 'action', value: 'Part/add_to_basket' });
@@ -901,5 +919,6 @@ namespace('kivi.Part', function(ns) {
     $('#part_warehouse_id').change(kivi.Part.reload_bin_selection);
 
     ns.init();
+    ns.init_price_information_and_history();
   });
 });

--- a/public/js/kivi.PriceRule.js
+++ b/public/js/kivi.PriceRule.js
@@ -34,21 +34,10 @@ namespace('kivi.PriceRule', function(ns) {
     }
   };
 
-  ns.inline_report = function(target, source, data){
-    $.ajax({
-      url:        source,
-      success:    function (rsp) {
-        $(target).html(rsp);
-        kivi.init_report_paginate_controls($(target));
-      },
-      data:       data,
-    });
-  };
-
   ns.load_price_rules_for_part = function(id) {
     window.setTimeout(function(){
-      ns.inline_report('#price_rules_customer_report', 'controller.pl', { action: 'PriceRule/list', 'filter.item_type_matches[].part': id, 'filter.type': 'customer', inline: 1 });
-      ns.inline_report('#price_rules_vendor_report', 'controller.pl', { action: 'PriceRule/list', 'filter.item_type_matches[].part': id, 'filter.type': 'vendor', inline: 1 });
+      kivi.inline_report_load_into_container('controller.pl', '#price_rules_customer_report', { action: 'PriceRule/list', 'filter.item_type_matches[].part': id, 'filter.type': 'customer', inline: 1 });
+      kivi.inline_report_load_into_container('controller.pl', '#price_rules_vendor_report', { action: 'PriceRule/list', 'filter.item_type_matches[].part': id, 'filter.type': 'vendor', inline: 1 });
     }, 200);
   };
 

--- a/public/js/kivi.PriceRule.js
+++ b/public/js/kivi.PriceRule.js
@@ -39,15 +39,10 @@ namespace('kivi.PriceRule', function(ns) {
       url:        source,
       success:    function (rsp) {
         $(target).html(rsp);
-        $(target).find('.paginate').find('a').click(function(event){ ns.redirect_event(event, target) });
-        $(target).find('a.report-generator-header-link').click(function(event){ ns.redirect_event(event, target) });
+        kivi.init_report_paginate_controls($(target));
       },
       data:       data,
     });
-  };
-  ns.redirect_event = function(event, target){
-    event.preventDefault();
-    ns.inline_report(target, event.target + '', {});
   };
 
   ns.load_price_rules_for_part = function(id) {

--- a/public/js/kivi.js
+++ b/public/js/kivi.js
@@ -377,34 +377,35 @@ namespace("kivi", function(ns) {
   };
 
   ns.init_report_paginate_controls = function($element) {
-    /* For dynamic reloading via AJAX, the handler is overwritten in init_inline_report(). */
+    /* init_report_paginate_controls() is relevant for reports which are loaded with the page.
+       For dynamic reloading via AJAX, see init_inline_report(). */
     $element.find('select').change(function(event) { window.location = event.target.value; });
   };
 
-  ns.inline_report_set_event_handlers_for_ajax = function(url, container_div) {
+  ns.inline_report_load_into_container = function(url, container_div, data = {}) {
     $.ajax({
       url:        url,
       success:    function (rsp) {
         $(container_div).html(rsp);
-        ns.init_inline_report(container_div);
+        ns.init_inline_report($(container_div));
       },
-      data:       {},
+      data:       data,
     });
   };
 
-  ns.init_inline_report = function($element) {
+  ns.init_inline_report = function($container_div) {
     /* redirect links to reload report in-place */
 
-    $element.find('.paginate').find('a').click(function(event) {
+    $container_div.find('a.report-generator-header-link').click(function (event) {
       event.preventDefault();
-      ns.inline_report_set_event_handlers_for_ajax(event.target.href, $element);
+      ns.inline_report_load_into_container(event.target.href, $container_div);
     });
-    $element.find('.paginate').find('select').change(function(event) {
-      ns.inline_report_set_event_handlers_for_ajax(event.target.value, $element);
-    });
-    $element.find('a.report-generator-header-link').click(function(event){
+    $container_div.find('.paginate').find('a').click(function (event) {
       event.preventDefault();
-      ns.inline_report_set_event_handlers_for_ajax(event.target.href, $element);
+      ns.inline_report_load_into_container(event.target.href, $container_div);
+    });
+    $container_div.find('.paginate').find('select').change(function (event) {
+      ns.inline_report_load_into_container(event.target.value, $container_div);
     });
   };
 

--- a/public/js/kivi.js
+++ b/public/js/kivi.js
@@ -376,6 +376,38 @@ namespace("kivi", function(ns) {
     });
   };
 
+  ns.init_report_paginate_controls = function($element) {
+    /* For dynamic reloading via AJAX, the handler is overwritten in init_inline_report(). */
+    $element.find('select').change(function(event) { window.location = event.target.value; });
+  };
+
+  ns.inline_report_set_event_handlers_for_ajax = function(url, container_div) {
+    $.ajax({
+      url:        url,
+      success:    function (rsp) {
+        $(container_div).html(rsp);
+        ns.init_inline_report(container_div);
+      },
+      data:       {},
+    });
+  };
+
+  ns.init_inline_report = function($element) {
+    /* redirect links to reload report in-place */
+
+    $element.find('.paginate').find('a').click(function(event) {
+      event.preventDefault();
+      ns.inline_report_set_event_handlers_for_ajax(event.target+'', $element)
+    });
+    $element.find('.paginate').find('select').change(function(event) {
+      ns.inline_report_set_event_handlers_for_ajax(event.target.value, $element); console.log(event.target.value)
+    });
+    $element.find('a.report-generator-header-link').click(function(event){
+      event.preventDefault();
+      ns.inline_report_set_event_handlers_for_ajax(event.target+'', $element)
+    });
+  };
+
   ns.filter_select = function() {
     var $input  = $(this);
     var $select = $('#' + $input.data('select-id'));
@@ -433,6 +465,7 @@ namespace("kivi", function(ns) {
 
     ns.run_once_for('.tabwidget', 'tabwidget', kivi.init_tabwidget);
     ns.run_once_for('.texteditor', 'texteditor', kivi.init_text_editor5);
+    ns.run_once_for('.paginate',  'paginate', kivi.init_report_paginate_controls);
   };
 
   ns.submit_ajax_form = function(url, form_selector, additional_data) {

--- a/public/js/kivi.js
+++ b/public/js/kivi.js
@@ -397,14 +397,14 @@ namespace("kivi", function(ns) {
 
     $element.find('.paginate').find('a').click(function(event) {
       event.preventDefault();
-      ns.inline_report_set_event_handlers_for_ajax(event.target+'', $element)
+      ns.inline_report_set_event_handlers_for_ajax(event.target.href, $element);
     });
     $element.find('.paginate').find('select').change(function(event) {
-      ns.inline_report_set_event_handlers_for_ajax(event.target.value, $element); console.log(event.target.value)
+      ns.inline_report_set_event_handlers_for_ajax(event.target.value, $element);
     });
     $element.find('a.report-generator-header-link').click(function(event){
       event.preventDefault();
-      ns.inline_report_set_event_handlers_for_ajax(event.target+'', $element)
+      ns.inline_report_set_event_handlers_for_ajax(event.target.href, $element);
     });
   };
 

--- a/templates/design40_webpages/common/paginate.html
+++ b/templates/design40_webpages/common/paginate.html
@@ -1,11 +1,11 @@
 [% USE T8 %]
-[% MACRO build_url BLOCK %]
- [% IF base_url %]
-  [% base_url %]&page=[% page %]
- [% ELSE %]
-  [% url_maker('page' => page) %]
- [% END %]
-[% END %]
+[%- MACRO build_url BLOCK %]
+ [%- IF base_url %]
+  [%- base_url %]&page=[% page %]&per_page=[% per_page || pages.per_page %]
+ [%- ELSE %]
+  [%- url_maker(page=page, per_page=per_page||pages.per_page) %]
+ [%- END %]
+[%- END %]
 
 [% IF pages.max > 1 %]
 <div class="paginate control-panel">
@@ -24,6 +24,13 @@
   [% ELSE %]
     <span class="paginate-next"></span>
   [% END %]
+  <span>
+    <select onchange="window.location = this.value;" title="[% "Results per page" | $T8 %]">
+      <option [% IF pages.per_page ==   20 %]selected[% END %] value="[% build_url(page=1, per_page=  20) %]">20</option>
+      <option [% IF pages.per_page ==  100 %]selected[% END %] value="[% build_url(page=1, per_page= 100) %]">100</option>
+      <option [% IF pages.per_page == 1000 %]selected[% END %] value="[% build_url(page=1, per_page=1000) %]">1000</option>
+    </select>
+  </span>
 </div>
 [% END %]
 

--- a/templates/design40_webpages/common/paginate.html
+++ b/templates/design40_webpages/common/paginate.html
@@ -7,6 +7,7 @@
  [%- END %]
 [%- END %]
 
+
 [% IF pages.max > 1 %]
 <div class="paginate control-panel">
 [% IF pages.page > 1 %]
@@ -25,7 +26,8 @@
     <span class="paginate-next"></span>
   [% END %]
   <span>
-    <select onchange="window.location = this.value;" title="[% "Results per page" | $T8 %]">
+    <select  title="[% "Results per page" | $T8 %]">
+      [% IF pages.per_page  <   20 %]<option selected value="[% build_url(page=1) %]">[% pages.per_page %]</option>[% END %]
       <option [% IF pages.per_page ==   20 %]selected[% END %] value="[% build_url(page=1, per_page=  20) %]">20</option>
       <option [% IF pages.per_page ==  100 %]selected[% END %] value="[% build_url(page=1, per_page= 100) %]">100</option>
       <option [% IF pages.per_page == 1000 %]selected[% END %] value="[% build_url(page=1, per_page=1000) %]">1000</option>

--- a/templates/design40_webpages/csv_import/_deferred_report.html
+++ b/templates/design40_webpages/csv_import/_deferred_report.html
@@ -8,16 +8,11 @@
       url:        source,
       success:    function (rsp) {
         $(target).html(rsp);
-        $(target).find('.paginate').find('a').click(function(event){ redirect_event(event, target) });
+        kivi.init_report_paginate_controls($(target));
       },
       data:       data,
     });
   };
-
-  function redirect_event(event, target){
-    event.preventDefault();
-    get_report(target, event.target + '', {});
-  }
 
   $(document).ready(function(){
     [%- IF error %]

--- a/templates/design40_webpages/csv_import/_deferred_report.html
+++ b/templates/design40_webpages/csv_import/_deferred_report.html
@@ -3,23 +3,12 @@
 <div id='csv_import_report'></div>
 
 <script type='text/javascript'>
-  function get_report(target, source, data){
-    $.ajax({
-      url:        source,
-      success:    function (rsp) {
-        $(target).html(rsp);
-        kivi.init_report_paginate_controls($(target));
-      },
-      data:       data,
-    });
-  };
-
   $(document).ready(function(){
     [%- IF error %]
       kivi.display_flash('error', '[% P.escape_js(error) %]');
     [%- END %]
     [%- IF SELF.background_job.data_as_hash.report_id %]
-      get_report('#csv_import_report', 'controller.pl', { action: 'CsvImport/report', 'no_layout': 1, 'id': [% SELF.background_job.data_as_hash.report_id %] });
+      kivi.inline_report_load_into_container('controller.pl', '#csv_import_report', { action: 'CsvImport/report', 'no_layout': 1, 'id': [% SELF.background_job.data_as_hash.report_id %] });
     [%- END %]
   });
 

--- a/templates/design40_webpages/customer_vendor/tabs/price_rules.html
+++ b/templates/design40_webpages/customer_vendor/tabs/price_rules.html
@@ -7,25 +7,5 @@
 <div class="wrapper">
   <div id='price_rules_customer_report'></div>
   <div id='price_rules_vendor_report'></div>
-  <script type='text/javascript'>
-    $(function() {
-      window.setTimeout(function(){
-      [% IF SELF.is_customer %]
-        kivi.CustomerVendor.inline_report(
-          '#price_rules_customer_report', 
-          'controller.pl', 
-          { action: 'PriceRule/list', 'filter.item_type_matches[].customer': [% HTML.escape(SELF.cv.id) %], 'filter.type': 'customer', inline: 1 }
-        );
-      [% END %]
-      [% IF SELF.is_vendor %]
-        kivi.CustomerVendor.inline_report(
-          '#price_rules_vendor_report', 
-          'controller.pl', 
-          { action: 'PriceRule/list', 'filter.item_type_matches[].vendor': [% HTML.escape(SELF.cv.id) %], 'filter.type': 'vendor', inline: 1 }
-        );
-      [% END %]
-      }, 200);
-    })
-  </script>
 </div><!-- /.wrapper -->
 </div><!-- /#price_rules -->

--- a/templates/design40_webpages/part/_sales_price_information.html
+++ b/templates/design40_webpages/part/_sales_price_information.html
@@ -25,5 +25,13 @@
     return 1;
   });
 
+  $('.tabwidget').on('tabscreate', function(event, ui){
+    if (ui.panel.attr('id') == 'sales_price_information') {
+      get_report('#sales_price_information_sales_order', 'controller.pl', { action: 'SellPriceInformation/list', 'filter.part.id': [% id %], 'filter.order.type': 'sales_order' });
+      get_report('#sales_price_information_sales_quotation', 'controller.pl', { action: 'SellPriceInformation/list', 'filter.part.id': [% id %], 'filter.order.type': 'sales_quotation' });
+      get_report('#parts_price_history', 'controller.pl', { action: 'PartsPriceHistory/list', 'filter.part_id': [% id %] });
+    }
+    return 1;
+  });
 
 </script>

--- a/templates/design40_webpages/part/_sales_price_information.html
+++ b/templates/design40_webpages/part/_sales_price_information.html
@@ -4,34 +4,3 @@
 <div id="parts_price_history"></div>
 </div><!-- /.wrapper -->
 
-<script type="text/javascript">
-  function get_report(target, source, data){
-    $.ajax({
-      url:        source,
-      success:    function (rsp) {
-        $(target).html(rsp);
-        kivi.init_inline_report($(target));
-      },
-      data:       data,
-    });
-  };
-
-  $('.tabwidget').on('tabsbeforeactivate', function(event, ui){
-    if (ui.newPanel.attr('id') == 'sales_price_information') {
-      get_report('#sales_price_information_sales_order', 'controller.pl', { action: 'SellPriceInformation/list', 'filter.part.id': [% id %], 'filter.order.type': 'sales_order' });
-      get_report('#sales_price_information_sales_quotation', 'controller.pl', { action: 'SellPriceInformation/list', 'filter.part.id': [% id %], 'filter.order.type': 'sales_quotation' });
-      get_report('#parts_price_history', 'controller.pl', { action: 'PartsPriceHistory/list', 'filter.part_id': [% id %] });
-    }
-    return 1;
-  });
-
-  $('.tabwidget').on('tabscreate', function(event, ui){
-    if (ui.panel.attr('id') == 'sales_price_information') {
-      get_report('#sales_price_information_sales_order', 'controller.pl', { action: 'SellPriceInformation/list', 'filter.part.id': [% id %], 'filter.order.type': 'sales_order' });
-      get_report('#sales_price_information_sales_quotation', 'controller.pl', { action: 'SellPriceInformation/list', 'filter.part.id': [% id %], 'filter.order.type': 'sales_quotation' });
-      get_report('#parts_price_history', 'controller.pl', { action: 'PartsPriceHistory/list', 'filter.part_id': [% id %] });
-    }
-    return 1;
-  });
-
-</script>

--- a/templates/design40_webpages/part/_sales_price_information.html
+++ b/templates/design40_webpages/part/_sales_price_information.html
@@ -8,20 +8,13 @@
   function get_report(target, source, data){
     $.ajax({
       url:        source,
-//      beforeSend: function () { $(target).html('<img src="image/spinner.gif">') },
       success:    function (rsp) {
         $(target).html(rsp);
-        $(target).find('.paginate').find('a').click(function(event){ redirect_event(event, target) });
-        $(target).find('a.report-generator-header-link').click(function(event){ redirect_event(event, target) });
+        kivi.init_inline_report($(target));
       },
       data:       data,
     });
   };
-
-  function redirect_event(event, target){
-    event.preventDefault();
-    get_report(target, event.target + '', {});
-  }
 
   $('.tabwidget').on('tabsbeforeactivate', function(event, ui){
     if (ui.newPanel.attr('id') == 'sales_price_information') {


### PR DESCRIPTION
## Was dies verbessert

Fügt ein Select-Feld in die Paginate Controls hinzu, mit welchem sich die Anzahl der Treffer pro Seite steuern lässt.

<img width="325" height="68" alt="grafik" src="https://github.com/user-attachments/assets/87ec9ac0-3e86-4823-8c71-7dc3aab463cd" />


Behebt Issue #649

Getestet mit dem Lagerbuchungsbericht und dem E-Mail-Journal.