### PR TITLE
Model:Record: new_from_workflow: cvars des Quell-Objekts initialisieren

### DIFF
--- a/SL/Model/Record.pm
+++ b/SL/Model/Record.pm
@@ -75,6 +75,15 @@ sub get_record {
 sub new_from_workflow {
   my ($class, $source_object, $target_type, %flags) = @_;
 
+  foreach my $item (@{ $source_object->items }) {
+    # autovivify all cvars that are not in the form (cvars_by_config can do it).
+    # workaround to pre-parse number-cvars (parse_custom_variable_values does not parse number values).
+    foreach my $var (@{ $item->cvars_by_config }) {
+      $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value})) if ($var->config->type eq 'number' && exists($var->{__unparsed_value}));
+    }
+    $item->parse_custom_variable_values;
+  }
+
   $flags{destination_type} = $target_type;
   my %defaults_flags = (
     no_linked_records => 0,


### PR DESCRIPTION
Die CVars sind evtl. nicht mit in der Form, da sie nur bei Bedarf (2. Zeile) geladen werden. Daher wurden deren Werte bei einem save_as_new bei Angebtoen/Aufträgen nicht übernommen.

In den anderen Controllern gibt es noch einen run-before-hook, der ggf. get_unalterable_data aufruft, wo das geschieht. Aber das macht andere Probleme und ist deshalb im Order-Controller rausgeflogen.

siehe auch commit a5b0b43c8ecfe4862dd08a6925a0eb32eb36ac54.