### PR TITLE
DMS: html-Template: Fix Auflisten der Dateien mit Versionen.

### DIFF
--- a/templates/design40_webpages/file/list.html
+++ b/templates/design40_webpages/file/list.html
@@ -51,7 +51,7 @@
       [%- IF !is_other_version %]
         <tr>
       [%- ELSE %]
-        <tr class="[% 'version_row_' _ file.id %] hidden">
+        <tr class="[% 'version_row_' _ file.id %]" style="display:none">
       [%- END %]
         [% IF edit_attachments %]
           <td>[% L.checkbox_tag(checkname _ '[]', 'value'=file.file_version.guid, 'class'=checkname) %]</td>


### PR DESCRIPTION
Durch die "hidden"-Class kam ein "display:block" rein (keine Ahnung, warum); Das hat die Ausrichtung der ausgeklappten Versionszeilen kaputt gemacht.

Evtl. weiß ja jemand, voher das  "display:block" kam ;)