### PR TITLE
CVar multiselect: Changelog

### DIFF
--- a/doc/changelog
+++ b/doc/changelog
@@ -87,6 +87,14 @@ Mittelgroße neue Features:
   bei welchen bisher der Abrechnungszeitraum lediglich als Text im
   Bemerkungsfeld durch Variablenersetzung aufgenommen werden konnte.
 
+- Neuer Benutzerdefinierte-Variablen-Typ Auswahlbox (mehrfach)
+  Gegenüber dem bisher existierenen Typen »Auswahlbox« erlaubt der neue Typ
+  »Auswahlbox (mehrfach)« das gleichzeitige Setzen und Speichern mehrerer
+  Auswahloptionen. Dieser BDV-Typ kann überall eingesetzt werden, wo BDVs
+  unterstützt werden: Artikel, Ansprechpersonen, Kunden und Lieferanten, ...
+  Lediglich Preisregeln an Artikeln lassen sich nicht über den BDV-Typen
+  Auswahlbox (mehrfach) steuern.
+
 Kleinere neue Features und Detailverbesserungen:
 
 - Anordnung der Elemente in der Maske für Wiedervorlagen verbessert

--- a/doc/changelog
+++ b/doc/changelog
@@ -87,7 +87,7 @@ Mittelgroße neue Features:
   bei welchen bisher der Abrechnungszeitraum lediglich als Text im
   Bemerkungsfeld durch Variablenersetzung aufgenommen werden konnte.
 
-- Neuer Benutzerdefinierte-Variablen-Typ Auswahlbox (mehrfach)
+- Neuer Typ von benutzerdefinierten Variablen: Auswahlbox (mehrfach)
   Gegenüber dem bisher existierenen Typen »Auswahlbox« erlaubt der neue Typ
   »Auswahlbox (mehrfach)« das gleichzeitige Setzen und Speichern mehrerer
   Auswahloptionen. Dieser BDV-Typ kann überall eingesetzt werden, wo BDVs


### PR DESCRIPTION
- Neuer Benutzerdefinierte-Variablen-Typ Auswahlbox (mehrfach)
  Gegenüber dem bisher existierenen Typen »Auswahlbox« erlaubt der neue Typ
  »Auswahlbox (mehrfach)« das gleichzeitige Setzen und Speichern mehrerer
  Auswahloptionen. Dieser BDV-Typ kann überall eingesetzt werden, wo BDVs
  unterstützt werden: Artikel, Ansprechpersonen, Kunden und Lieferanten, ...
  Lediglich Preisregeln an Artikeln lassen sich nicht über den BDV-Typen
  Auswahlbox (mehrfach) steuern.