### PR TITLE
202608 fix cvars number format

### DIFF
--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1126,7 +1126,7 @@ sub action_load_second_rows {
     my $idx  = first_index { $_ eq $item_id } @{ $::form->{orderitem_ids} };
     my $item = $self->order->items_sorted->[$idx];
 
-    $self->js_load_second_row($item, $item_id, 0);
+    $self->js_load_second_row($item, $item_id);
   }
 
   # for lastcosts change-callback
@@ -1491,17 +1491,7 @@ sub action_render_item_selection {
 }
 
 sub js_load_second_row {
-  my ($self, $item, $item_id, $do_parse) = @_;
-
-  if ($do_parse) {
-    # Parse values from form (they are formated while rendering (template)).
-    # Workaround to pre-parse number-cvars (parse_custom_variable_values does not parse number values).
-    # This parsing is not necessary at all, if we assure that the second row/cvars are only loaded once.
-    foreach my $var (@{ $item->cvars_by_config }) {
-      $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value})) if ($var->config->type eq 'number' && exists($var->{__unparsed_value}));
-    }
-    $item->parse_custom_variable_values;
-  }
+  my ($self, $item, $item_id) = @_;
 
   my $row_as_html = $self->p->render('delivery_order/tabs/_second_row', ITEM => $item, TYPE => $self->type);
 

--- a/SL/Controller/DeliveryOrder.pm
+++ b/SL/Controller/DeliveryOrder.pm
@@ -1922,10 +1922,7 @@ sub get_unalterable_data {
 
   foreach my $item (@{ $self->order->items }) {
     # autovivify all cvars that are not in the form (cvars_by_config can do it).
-    # workaround to pre-parse number-cvars (parse_custom_variable_values does not parse number values).
-    foreach my $var (@{ $item->cvars_by_config }) {
-      $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value})) if ($var->config->type eq 'number' && exists($var->{__unparsed_value}));
-    }
+    $item->cvars_by_config;
     $item->parse_custom_variable_values;
   }
 }

--- a/SL/Controller/Order.pm
+++ b/SL/Controller/Order.pm
@@ -2077,10 +2077,7 @@ sub get_unalterable_data {
 
   foreach my $item (@{ $self->order->items }) {
     # autovivify all cvars that are not in the form (cvars_by_config can do it).
-    # workaround to pre-parse number-cvars (parse_custom_variable_values does not parse number values).
-    foreach my $var (@{ $item->cvars_by_config }) {
-      $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value})) if ($var->config->type eq 'number' && exists($var->{__unparsed_value}));
-    }
+    $item->cvars_by_config;
     $item->parse_custom_variable_values;
   }
 }

--- a/SL/Controller/Order.pm
+++ b/SL/Controller/Order.pm
@@ -1346,7 +1346,7 @@ sub action_load_second_rows {
     my $idx  = first_index { $_ eq $item_id } @{ $::form->{orderitem_ids} };
     my $item = $self->order->items_sorted->[$idx];
 
-    $self->js_load_second_row($item, $item_id, 0);
+    $self->js_load_second_row($item, $item_id);
   }
 
   $self->js->run('kivi.Order.init_row_handlers') if $self->order->is_sales; # for lastcosts change-callback
@@ -1523,17 +1523,7 @@ sub action_show_conversion_to_purchase_delivery_order_item_selection {
 }
 
 sub js_load_second_row {
-  my ($self, $item, $item_id, $do_parse) = @_;
-
-  if ($do_parse) {
-    # Parse values from form (they are formated while rendering (template)).
-    # Workaround to pre-parse number-cvars (parse_custom_variable_values does not parse number values).
-    # This parsing is not necessary at all, if we assure that the second row/cvars are only loaded once.
-    foreach my $var (@{ $item->cvars_by_config }) {
-      $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value})) if ($var->config->type eq 'number' && exists($var->{__unparsed_value}));
-    }
-    $item->parse_custom_variable_values;
-  }
+  my ($self, $item, $item_id) = @_;
 
   my $row_as_html = $self->p->render('order/tabs/_second_row', ITEM => $item, TYPE => $self->type);
 

--- a/SL/Controller/Reclamation.pm
+++ b/SL/Controller/Reclamation.pm
@@ -988,7 +988,7 @@ sub action_load_second_rows {
     my $idx  = first_index { $_ eq $item_id } @{ $::form->{reclamation_item_ids} };
     my $item = $self->reclamation->items_sorted->[$idx];
 
-    $self->js_load_second_row($item, $item_id, 0);
+    $self->js_load_second_row($item, $item_id);
   }
 
   $self->js->run('kivi.Reclamation.init_row_handlers') if $self->reclamation->is_sales; # for lastcosts change-callback
@@ -1053,20 +1053,7 @@ sub action_update_row_from_master_data {
 }
 
 sub js_load_second_row {
-  my ($self, $item, $item_id, $do_parse) = @_;
-
-  if ($do_parse) {
-    # Parse values from form (they are formated while rendering (template)).
-    # Workaround to pre-parse number-cvars (parse_custom_variable_values does
-    # not parse number values). This parsing is not necessary at all, if we
-    # assure that the second row/cvars are only loaded once.
-    foreach my $var (@{ $item->cvars_by_config }) {
-      if ($var->config->type eq 'number' && exists($var->{__unparsed_value})) {
-        $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value}));
-      }
-    }
-    $item->parse_custom_variable_values;
-  }
+  my ($self, $item, $item_id) = @_;
 
   my $row_as_html = $self->p->render('reclamation/tabs/basic_data/_second_row', ITEM => $item, TYPE => $self->type);
 

--- a/SL/Controller/Reclamation.pm
+++ b/SL/Controller/Reclamation.pm
@@ -1572,12 +1572,7 @@ sub get_unalterable_data {
 
   foreach my $item (@{ $self->reclamation->items }) {
     # autovivify all cvars that are not in the form (cvars_by_config can do it).
-    # workaround to pre-parse number-cvars (parse_custom_variable_values does not parse number values).
-    foreach my $var (@{ $item->cvars_by_config }) {
-      if ($var->config->type eq 'number' && exists($var->{__unparsed_value})) {
-        $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value}));
-      }
-    }
+    $item->cvars_by_config;
     $item->parse_custom_variable_values;
   }
 }

--- a/SL/DB/CustomVariable.pm
+++ b/SL/DB/CustomVariable.pm
@@ -38,10 +38,14 @@ sub parse_value {
 
   my $unparsed = delete $self->{__unparsed_value};
 
-  if ($type =~ m{^(?:customer|vendor|part|number)}) {
+  if ($type =~ m{^(?:customer|vendor|part)}) {
     return $self->number_value(!defined($unparsed) ? undef
                                : (any { ref($unparsed) eq $_ } qw(SL::DB::Customer SL::DB::Vendor SL::DB::Part)) ? $unparsed->id
                                : $unparsed * 1);
+  }
+
+  if ($type =~ m{^(?:number)}) {
+    return $self->number_value(!defined($unparsed) ? undef : $::form->parse_amount(\%::myconfig, $unparsed));
   }
 
   if ($type =~ m{^(?:bool)}) {
@@ -60,13 +64,36 @@ sub parse_value {
   $self->text_value($unparsed);
 }
 
+sub _set_value {
+  my ($self, $value) = @_;
+
+  my $type = $self->_ensure_config->type;
+
+  my $method = 'text_value';
+
+  if ($type =~ m{^(?:customer|vendor|part|number)}) {
+    $method = 'number_value';
+    $value *= 1 if defined $value;
+
+  } elsif ($type =~ m{^(?:bool)}) {
+    $method = 'bool_value';
+
+  } elsif ($type =~ m{^(?:date|timestamp)}) {
+    $method = 'timestamp_value' ;
+
+  } elsif ($type =~ m{^(?:multiselect)}) {
+    $value = 'ARRAY' ne ref $value ? undef : '##' . join('##', @$value) . '##';
+  }
+
+  $self->$method($value);
+}
+
 sub value {
   my $self = $_[0];
   my $type = $self->_ensure_config->type;
 
   if (scalar(@_) > 1) {
-    $self->unparsed_value($_[1]);
-    $self->parse_value;
+    $self->_set_value($_[1]);
     @_ = ($self);
   }
 
@@ -80,20 +107,21 @@ sub value {
   if ( $type eq 'customer' ) {
     require SL::DB::Customer;
 
-    my $id = defined($self->number_value) ? int($self->number_value) : undef;
-    return $id ? SL::DB::Customer->new(id => $id)->load() : undef;
+    return defined($self->number_value) ? int($self->number_value) : undef;
+
   } elsif ( $type eq 'vendor' ) {
     require SL::DB::Vendor;
 
-    my $id = defined($self->number_value) ? int($self->number_value) : undef;
-    return $id ? SL::DB::Vendor->new(id => $id)->load() : undef;
+    return defined($self->number_value) ? int($self->number_value) : undef;
+
   } elsif ( $type eq 'part' ) {
     require SL::DB::Part;
 
-    my $id = defined($self->number_value) ? int($self->number_value) : undef;
-    return $id ? SL::DB::Part->new(id => $id)->load() : undef;
+    return defined($self->number_value) ? int($self->number_value) : undef;
+
   } elsif ( $type eq 'date' ) {
     return $self->timestamp_value ? $self->timestamp_value->clone->truncate(to => 'day') : undef;
+
   } elsif ( $type eq 'multiselect' ) {
     return $self->text_value ? [ split /##/, ($self->text_value =~ s/^##|##$//gr) ] : [];
   }

--- a/SL/Model/Record.pm
+++ b/SL/Model/Record.pm
@@ -75,6 +75,15 @@ sub get_record {
 sub new_from_workflow {
   my ($class, $source_object, $target_type, %flags) = @_;
 
+  foreach my $item (@{ $source_object->items }) {
+    # autovivify all cvars that are not in the form (cvars_by_config can do it).
+    # workaround to pre-parse number-cvars (parse_custom_variable_values does not parse number values).
+    foreach my $var (@{ $item->cvars_by_config }) {
+      $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value})) if ($var->config->type eq 'number' && exists($var->{__unparsed_value}));
+    }
+    $item->parse_custom_variable_values;
+  }
+
   $flags{destination_type} = $target_type;
   my %defaults_flags = (
     no_linked_records => 0,

--- a/SL/Model/Record.pm
+++ b/SL/Model/Record.pm
@@ -77,10 +77,7 @@ sub new_from_workflow {
 
   foreach my $item (@{ $source_object->items }) {
     # autovivify all cvars that are not in the form (cvars_by_config can do it).
-    # workaround to pre-parse number-cvars (parse_custom_variable_values does not parse number values).
-    foreach my $var (@{ $item->cvars_by_config }) {
-      $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value})) if ($var->config->type eq 'number' && exists($var->{__unparsed_value}));
-    }
+    $item->cvars_by_config;
     $item->parse_custom_variable_values;
   }
 
@@ -234,10 +231,7 @@ sub save {
 
   foreach my $item (@{ $record->items }) {
     # autovivify all cvars that are not in the form (cvars_by_config can do it).
-    # workaround to pre-parse number-cvars (parse_custom_variable_values does not parse number values).
-    foreach my $var (@{ $item->cvars_by_config }) {
-      $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value})) if ($var->config->type eq 'number' && exists($var->{__unparsed_value}));
-    }
+    $item->cvars_by_config;
     $item->parse_custom_variable_values;
   }
 

--- a/bin/mozilla/io.pl
+++ b/bin/mozilla/io.pl
@@ -1093,7 +1093,6 @@ sub order {
      foreach my $var (@{ $item->cvars_by_config }) {
       my $key = 'ic_cvar_' . $var->config->name . '_' . $row;
       $var->unparsed_value($::form->{$key});
-      $var->unparsed_value($::form->parse_amount(\%::myconfig, $var->{__unparsed_value})) if ($var->config->type eq 'number' && exists($var->{__unparsed_value}));
     }
     $item->parse_custom_variable_values;
 

--- a/t/db/price_rule.t
+++ b/t/db/price_rule.t
@@ -321,11 +321,13 @@ for (@SL::Controller::CustomVariableConfig::types) {
 
     test($price_rule, $order, $item, "$name -- global project, but no value", 0);
 
-    $order->globalproject->cvar_by_name($name)->value($item->part);
+    $order->globalproject->cvar_by_name($name)->unparsed_value($item->part);
+    $order->globalproject->parse_custom_variable_values;
     $order->globalproject->cvar_by_name($name)->save;
     test($price_rule, $order, $item, "$name -- global project, not matching", 0);
 
-    $order->globalproject->cvar_by_name($name)->value($part);
+    $order->globalproject->cvar_by_name($name)->unparsed_value($part);
+    $order->globalproject->parse_custom_variable_values;
     $order->globalproject->cvar_by_name($name)->save;
     test($price_rule, $order, $item, "$name -- global project, matching", 1);
 
@@ -338,11 +340,13 @@ for (@SL::Controller::CustomVariableConfig::types) {
 
     test($price_rule, $order, $item, "$name -- item project, but no value", 0);
 
-    $item->project->cvar_by_name($name)->value($item->part);
+    $item->project->cvar_by_name($name)->unparsed_value($item->part);
+    $item->project->parse_custom_variable_values;
     $item->project->cvar_by_name($name)->save;
     test($price_rule, $order, $item, "$name -- item project, not matching", 0);
 
-    $item->project->cvar_by_name($name)->value($part);
+    $item->project->cvar_by_name($name)->unparsed_value($part);
+    $item->project->parse_custom_variable_values;
     $item->project->cvar_by_name($name)->save;
     test($price_rule, $order, $item, "$name -- item project, matching", 1);
   }
@@ -384,11 +388,13 @@ for (@SL::Controller::CustomVariableConfig::types) {
 
     test($price_rule, $order, $item, "$name -- no value", 0);
 
-    $item->part->cvar_by_name($name)->value(new_customer());
+    $item->part->cvar_by_name($name)->unparsed_value(new_customer());
+    $item->part->parse_custom_variable_values;
     $item->part->cvar_by_name($name)->save;
     test($price_rule, $order, $item, "$name -- not matching", 0);
 
-    $item->part->cvar_by_name($name)->value($customer);
+    $item->part->cvar_by_name($name)->unparsed_value($customer);
+    $item->part->parse_custom_variable_values;
     $item->part->cvar_by_name($name)->save;
     test($price_rule, $order, $item, "$name -- matching", 1);
   }


### PR DESCRIPTION
Dazu gab es 2015 schon mal eine Diskussion auf der Devel-Liste und im Chat:

Aus dem Chat kopiere ich nur einen Teil hier  rein, da die Mails auf der devel-Liste aussagekräftiger sind:

10:43 <felixfunke> Ich blick's grad nicht: die Doku zum
                   Sl::DB::Helper::CustomVariables sagt, setze
                   Benutzereingaben mit unparsed_value, die werden
                   dann geparsed.
10:43 <felixfunke> Aber in SL::DB::CustomVariable->parse_value, das
                   aufgerufen wird, werden z.B. numbers nicht
                   geparsed.
10:44 <felixfunke> Und der value-accesor setzt unparsed und ruft
                   auch parse_value auf. Controller, die das jetzt
                   schon benutzen (z.B. CustomerVendor) parsen
                   selber und setzen mit value().
10:45 <felixfunke> Entweder ist das parsen in parse_value vergessen
                   worden, oder ich übersehe irgendwas.
10:46 <gorash> hmm. sieht für mich kaputt aus ja
10:47 <gorash> aber ich sagte ja, der ganze parse kram da ist müll
10:47 <gorash> kannst du gerne fixen

https://sourceforge.net/p/lx-office/mailman/lx-office-devel/thread/56095732.5010103%40kivitendo-premium.de/#msg34497005
... und folgende
