### PR TITLE
js: File: Dialoge nach Aktion verstecken, nicht entfernen; behebt Fehler beim Umbenennen

### DIFF
--- a/public/js/kivi.File.js
+++ b/public/js/kivi.File.js
@@ -28,7 +28,7 @@ namespace('kivi.File', function(ns) {
                                , height: 200
                                , modal:  true
                                , close: function() {
-                                 $dlg.remove().appendTo('#' + parent_id);
+                                 $dlg.hide();
                                }
                               }
     });
@@ -71,7 +71,7 @@ namespace('kivi.File', function(ns) {
                   , height: 200
                   , modal:  true
                   , close: function() {
-                    $dlg.remove().appendTo('#' + parent_id);
+                    $dlg.hide();
                   } }
       }
     );


### PR DESCRIPTION

Behebt Fehler: no id or dbfile or guid...

Getestet unter Mandantenkonfiguration → Allgemeine Dokumentenanhänge und für eine Auftragsbestätigung → Dokumente.
Evtl. kam eine Verhaltensänderung mit dem Update von jQuery UI herein.
Es ergibt jedenfalls keinen Sinn, den Dialog aus dem DOM weg zu werfen, denn dieser wird für die nächste Aktion wieder benötigt.


<img width="510" height="358" alt="grafik" src="https://github.com/user-attachments/assets/f534b327-2678-4dbb-b9af-810b1619050f" />
