### PR TITLE
SL::DB::Order ShopOrders bei den preceding Belegen rausnehmen ...

### DIFF
--- a/SL/DB/DeliveryOrder.pm
+++ b/SL/DB/DeliveryOrder.pm
@@ -161,7 +161,7 @@ sub preceding_purchase_order_confirmations {
 
   my @lrs = ();
   if ($self->id) {
-    @lrs = grep { $_->record_type eq PURCHASE_ORDER_CONFIRMATION_TYPE() } @{$self->linked_records(from => 'SL::DB::Order')};
+    @lrs = grep { 'SL::DB::Order' eq ref($_) && $_->record_type eq PURCHASE_ORDER_CONFIRMATION_TYPE() } @{$self->linked_records(from => 'SL::DB::Order')};
   } else {
     if ('SL::DB::Order' eq $self->{RECORD_TYPE_REF()}) {
       my $order = SL::DB::Order->load_cached($self->{RECORD_ID()});

--- a/SL/DB/Order.pm
+++ b/SL/DB/Order.pm
@@ -849,7 +849,7 @@ sub preceding_sales_order_intakes {
 
   my @lrs = ();
   if ($self->id) {
-    @lrs = grep { $_->record_type eq SALES_ORDER_INTAKE_TYPE() } @{$self->linked_records(from => 'SL::DB::Order')};
+    @lrs = grep { 'SL::DB::Order' eq ref($_) && $_->record_type eq SALES_ORDER_INTAKE_TYPE() } @{$self->linked_records(from => 'SL::DB::Order')};
   } else {
     if ('SL::DB::Order' eq $self->{RECORD_TYPE_REF()}) {
       my $order = SL::DB::Order->load_cached($self->{RECORD_ID()});
@@ -865,7 +865,7 @@ sub preceding_purchase_orders {
 
   my @lrs = ();
   if ($self->id) {
-    @lrs = grep { $_->record_type eq PURCHASE_ORDER_TYPE() } @{$self->linked_records(from => 'SL::DB::Order')};
+    @lrs = grep { 'SL::DB::Order' eq ref($_) && $_->record_type eq PURCHASE_ORDER_TYPE() } @{$self->linked_records(from => 'SL::DB::Order')};
   } else {
     if ('SL::DB::Order' eq $self->{RECORD_TYPE_REF()}) {
       my $order = SL::DB::Order->load_cached($self->{RECORD_ID()});
@@ -881,7 +881,7 @@ sub preceding_purchase_quotation_intakes {
 
   my @lrs = ();
   if ($self->id) {
-    @lrs = grep { $_->record_type eq PURCHASE_QUOTATION_INTAKE_TYPE() } @{$self->linked_records(from => 'SL::DB::Order', recursive => 1)};
+    @lrs = grep { 'SL::DB::Order' eq ref($_) && $_->record_type eq PURCHASE_QUOTATION_INTAKE_TYPE() } @{$self->linked_records(from => 'SL::DB::Order', recursive => 1)};
   } else {
     if ('SL::DB::Order' eq $self->{RECORD_TYPE_REF()}) {
       my $order = SL::DB::Order->load_cached($self->{RECORD_ID()});
@@ -902,7 +902,7 @@ sub preceding_request_quotations {
 
   my @lrs = ();
   if ($self->id) {
-    @lrs = grep { $_->record_type eq REQUEST_QUOTATION_TYPE() } @{$self->linked_records(from => 'SL::DB::Order', recursive => 1)};
+    @lrs = grep { 'SL::DB::Order' eq ref($_) && $_->record_type eq REQUEST_QUOTATION_TYPE() } @{$self->linked_records(from => 'SL::DB::Order', recursive => 1)};
   } else {
     if ('SL::DB::Order' eq $self->{RECORD_TYPE_REF()}) {
       my $order = SL::DB::Order->load_cached($self->{RECORD_ID()});


### PR DESCRIPTION
bzw. nur SL::DB::Orders akzeptieren
Da ShopOrder kein klassischer Beleg mit record_type ist. Warf Fehler beim Drucken da im Array lrs auch die ShopOrder waren.