### PR TITLE
Mandantenconfig: fix Umbennen-Dialog; wrapper nicht um den Dialog

### DIFF
--- a/templates/design40_webpages/client_config/_attachments.html
+++ b/templates/design40_webpages/client_config/_attachments.html
@@ -2,12 +2,12 @@
 [% USE L %]
 
 <div id="attachments">
-<div class="wrapper">
 
 [% SET file_type = 'attachment' %]
 [% INCLUDE 'file/rename_dialog.html' %]
 
-<h3>[% LxERP.t8("for Document types") %]</h3>
+<div class="wrapper">
+ <h3>[% LxERP.t8("for Document types") %]</h3>
 </div><!-- /.wrapper -->
 <div class="tabwidget">
 


### PR DESCRIPTION
Behebt Fehler: no id or dbfile or guid...

Siehe auch "Dateimanagement: Stammdaten: DOM-Elemente bei multiples Tab-Aufrufen nicht duplizieren"
(commit 69e526ee5cfc3d153f738083b397a000c00c4468)

andere Lösung für #884 