### PR TITLE
Suchprofile Darstellung Eingabe repariert: search_profile_panel: div .clearfix

### DIFF
--- a/templates/design40_webpages/common/search_profile_panel.html
+++ b/templates/design40_webpages/common/search_profile_panel.html
@@ -1,6 +1,6 @@
 [%- USE LxERP -%][%- USE L -%][% BLOCK filter_toggle_panel %]
 
-  <div>
+  <div class="clearfix">
     <h2>[% LxERP.t8("search profiles") %]</h2>
 
     <table class="tbl-horizontal">

--- a/templates/design40_webpages/common/search_profile_panel.html
+++ b/templates/design40_webpages/common/search_profile_panel.html
@@ -1,6 +1,6 @@
 [%- USE LxERP -%][%- USE L -%][% BLOCK filter_toggle_panel %]
 
-  <div class="clearfix">
+  <div>
     <h2>[% LxERP.t8("search profiles") %]</h2>
 
     <table class="tbl-horizontal">

--- a/templates/design40_webpages/common/toggle_panel.html
+++ b/templates/design40_webpages/common/toggle_panel.html
@@ -59,7 +59,7 @@
 
 <div class="toggle_panel control-panel [% toggle_class %]" [% display_on %]>
   <a href="#" onClick='javascript:$(".[% toggle_class %]").toggle()' class="button toggle on neutral with-panel">[% button_open %]</a>
-  <div class="toggle_panel_block">
+  <div class="toggle_panel_block clearfix">
      [% IF block_name && block_name != ''   %]
       [%
         #Dumper.dump_html(block_name) ;


### PR DESCRIPTION
Andernfalls ragt die Tabelle mit den Input-Elementen unten aus dem Toggle- Wrapper heraus.

Mit dieser Änderung:
<img width="356" height="236" alt="grafik" src="https://github.com/user-attachments/assets/a4de54c7-8d71-4e7f-8d43-e51bde1ca4d4" />

Ohne diese Änderung:
<img width="371" height="225" alt="grafik" src="https://github.com/user-attachments/assets/a7fcbe53-3c76-46ab-b869-199d9df404de" />
