### PR TITLE
DB-Upgrade: SEPA END-TO-END-ID für Duplikatserkennung aktiviert

### DIFF
--- a/doc/UPGRADE
+++ b/doc/UPGRADE
@@ -3,6 +3,16 @@ Wichtige Hinweise zum Upgrade von älteren Versionen
 
 ** BITTE FERTIGEN SIE VOR DEM UPGRADE EIN BACKUP IHRER DATENBANK(EN) AN! **
 
+Upgrade auf v4.2.0
+
+Wichtige Hinweise:
+
+- Die Einstellung »Verwende die SEPA END-TO-END-ID zur Duplikatserkennung beim
+  Import der Banküberweisungen« wird per DB-Upgrade-Skript auf »Ja« gesetzt. Da
+  die SEPA END-TO-END-ID seit kivitendo 3.9.1 in alle SEPA-Anweisungen
+  geschrieben wird, entstehen dadurch keine Duplikate beim Rückimport der ab
+  Version 3.9.1 erzeugten SEPA-Anweisungen.
+
 Upgrade auf v4.1.0
 
 Es sind keine neuen Perl-Abhängigkeiten hinzugekommen.

--- a/sql/Pg-upgrade2/defaults_endtoend_enabled_by_default.sql
+++ b/sql/Pg-upgrade2/defaults_endtoend_enabled_by_default.sql
@@ -1,0 +1,5 @@
+-- @tag: defaults_endtoend_enabled_by_default
+-- @description: Standardmäßig wird die END-TO-END Id zur Duplikaterkennung für den Bankimport verwendet
+-- @depends: release_4_1_0
+
+UPDATE defaults SET check_bt_duplicates_endtoend = true;


### PR DESCRIPTION
aus doc/UPGRADE:

- Die Einstellung »Verwende die SEPA END-TO-END-ID zur Duplikatserkennung beim
  Import der Banküberweisungen« wird per DB-Upgrade-Skript auf »Ja« gesetzt. Da
  die SEPA END-TO-END-ID seit kivitendo 3.9.1 in alle SEPA-Anweisungen
  geschrieben wird, entstehen dadurch keine Duplikate beim Rückimport der ab
  Version 3.9.1 erzeugten SEPA-Anweisungen.

So vorhin mit Jan besprochen; Die Erkennung sollte standardmäßig genutzt werden. Nur wer extreme Versionssprünge (Update von vor-3.9.1 zu 4.1+) durchführt oder mit Write-and-forget-Banken arbeitet, kann hierdurch Duplikate erhalten und sollte dann die Einstellung noch so lange aus lassen, bis alle SEPAs aus einer kivi-Version >= 3.9.1 Rückimportiert wurden.