### PR TITLE
S:T:OpenDocument: load_xml(expand_entities => 0, ...)

### DIFF
--- a/SL/Template/OpenDocument.pm
+++ b/SL/Template/OpenDocument.pm
@@ -446,7 +446,7 @@ sub parse {
   if ($is_qr_bill) {
     # get placeholder path from odt XML
     my $qr_placeholder_path;
-    my $dom = XML::LibXML->load_xml(string => $contents);
+    my $dom = XML::LibXML->load_xml(string => $contents, expand_entities => 0);
     my @nodelist = $dom->getElementsByTagName("draw:frame");
     for my $node (@nodelist) {
       my $attr = $node->getAttribute('draw:name');


### PR DESCRIPTION
Danke an Harsh Raj Singhania für den Hinweis!

Siehe auch:
  commit f6ba56bd8d22a428534057589baace6b7bfdf2e9
  Author: Jan Büren <jan@kivitendo-premium.de>
  Date:   Mon Mar 24 12:25:59 2025 +0100

      Sicherheitslücke XXE, etwas umfassend deaktiviert

Im Falle der OpenDocument Druckvorlagen ist das zwar nicht remote angreifbar, allerdings helfen wir Entwicklern, die das XML Parsing später an anderen Stellen einsetzen, wenn wir die Mitigation einheitlich auch an unkritischen Stellen einpflegen.

Dass die Ersetzung in den OpenDocument Vorlagen noch funktioniert, habe ich an einem Beispiel probiert.