### PR TITLE
Kosmetik: no trailing whitespaces

### DIFF
--- a/SL/Controller/StockCountingReconciliation.pm
+++ b/SL/Controller/StockCountingReconciliation.pm
@@ -147,7 +147,7 @@ sub action_reconcile {
     flash_later('error', t8('Stock counting does not contain any counted items'));
     return $self->redirect_to($::form->{callback});
   }
-  
+
   my $comment = t8('correction from stock counting (counting "#1")', $counting->name);
 
   my $transfer_error;

--- a/templates/design40_webpages/admin/create_dataset.html
+++ b/templates/design40_webpages/admin/create_dataset.html
@@ -13,7 +13,7 @@
     [% LxERP.t8('You can either create a new database or chose an existing database.') %]
     [% LxERP.t8('In the latter case the tables needed by kivitendo will be created in that database.') %]
   </p>
- 
+
   [% IF !superuser.have_privileges %]
     <p>
       [% LxERP.t8("Database superuser privileges are required for parts of the database modifications.") %]
@@ -21,7 +21,7 @@
     </p>
   [% END %]
 
- 
+
   <table class="tbl-horizontal">
     <tbody>
       <tr>
@@ -32,7 +32,7 @@
         <th>[% LxERP.t8('Create Dataset') %]</th>
         <td>[% L.input_tag('db', FORM.db, class="initial_focus") %]</td>
       </tr>
-      [% IF !superuser.have_privileges %] 
+      [% IF !superuser.have_privileges %]
         <tr>
           <th>[% LxERP.t8("Database Superuser") %]</th>
           <td>[% L.input_tag("database_superuser_user", superuser.username) %]</td>
@@ -41,7 +41,7 @@
           <th>[% LxERP.t8("Password") %]</th>
           <td>[% L.input_tag("database_superuser_password", superuser.password, type="password") %]</td>
         </tr>
-      [% END %] 
+      [% END %]
       <tr>
         <th>[% LxERP.t8('Default currency') %]</th>
         <td>[% L.input_tag('defaultcurrency', FORM.defaultcurrency) %]</td>

--- a/templates/design40_webpages/admin/edit_user.html
+++ b/templates/design40_webpages/admin/edit_user.html
@@ -24,12 +24,12 @@
     <th>[% LxERP.t8('Login Name') %]</th>
     <td>[% L.input_tag("user.login", SELF.user.login, class="initial_focus wi-wide") %]</td>
   </tr>
-  [% IF AUTH.can_change_password %] 
+  [% IF AUTH.can_change_password %]
   <tr>
     <th>[% LxERP.t8("New Password") %]</th>
     <td>[% L.input_tag("new_password", "", type="password", class="wi-wide") %]</td>
   </tr>
-  [% END %] 
+  [% END %]
   <tr>
     <th>[% LxERP.t8("Name") %]</th>
     <td>[% L.input_tag("user.config_values.name", props.name, class="wi-wide") %]</td>

--- a/templates/design40_webpages/admin/list_printers.html
+++ b/templates/design40_webpages/admin/list_printers.html
@@ -5,15 +5,15 @@
 <h1>[% HTML.escape(title) %]</h1>
 
 <div class="wrapper">
-[% IF !SELF.all_clients.size %] 
+[% IF !SELF.all_clients.size %]
   <div class="error">
-    [% LxERP.t8("Error") %]: [% LxERP.t8("No clients have been created yet.") %] 
+    [% LxERP.t8("Error") %]: [% LxERP.t8("No clients have been created yet.") %]
   </div>
-[% ELSE %] 
+[% ELSE %]
   <p> [% LxERP.t8("Client to configure the printers for") %]: [% L.select_tag('client.id', SELF.all_clients, id='client_id', title_key='name', default=SELF.client.id) %] </p>
-  [% IF !SELF.all_printers.size %] 
+  [% IF !SELF.all_printers.size %]
     <p> [% LxERP.t8("No printers have been created yet.") %] </p>
-  [% ELSE %] 
+  [% ELSE %]
   <table class="tbl-list">
     <thead>
       <tr>
@@ -23,13 +23,13 @@
       </tr>
     </thead>
     <tbody>
-      [% FOREACH printer = SELF.all_printers %] 
+      [% FOREACH printer = SELF.all_printers %]
       <tr valign="top" class="listrow">
         <td><a href="[% SELF.url_for(action='edit_printer', 'client.id'=SELF.client.id, id=printer.id) %]">[% HTML.escape(printer.printer_description) %]</a></td>
         <td>[% HTML.escape(printer.printer_command) %]</td>
         <td>[% HTML.escape(printer.template_code) %]</td>
       </tr>
-      [% END %] 
+      [% END %]
     </tbody>
   </table>
   [% END %]
@@ -45,5 +45,3 @@
   });
 -->
 </script>
-
-

--- a/templates/design40_webpages/background_job/form.html
+++ b/templates/design40_webpages/background_job/form.html
@@ -14,12 +14,12 @@
        </tr>
        <tr>
         <th>[% LxERP.t8('Execution type') %]</th>
-        <td>[% 
+        <td>[%
           L.select_tag('background_job.type', [
             [ 'once', LxERP.t8('one-time execution') ],
             [ 'interval', LxERP.t8('repeated execution') ]
           ],
-          'default' = SELF.background_job.type) 
+          'default' = SELF.background_job.type)
         %]</td>
        </tr>
        <tr>

--- a/templates/design40_webpages/custom_data_export_designer/edit_parameters.html
+++ b/templates/design40_webpages/custom_data_export_designer/edit_parameters.html
@@ -16,7 +16,7 @@
     [% ELSE %]
 
     <div class="input-panel control-panel">
-      <table class="tbl-plain condensed"> 
+      <table class="tbl-plain condensed">
         <tbody>
           <tr>
             <td>[% LxERP.t8("Variable Name") %]</td>

--- a/templates/design40_webpages/customer_vendor/tabs/bank.html
+++ b/templates/design40_webpages/customer_vendor/tabs/bank.html
@@ -1,7 +1,7 @@
 [% USE T8 %]
 [% USE HTML %]
 [% USE LxERP %]
-[% USE L %] 
+[% USE L %]
 
 <div id="bank">
   <div class="wrapper">
@@ -39,7 +39,7 @@
         </tr>
       </tbody>
     </table>
-    [% IF ( SELF.is_customer ) %] 
+    [% IF ( SELF.is_customer ) %]
     <table class="tbl-horizontal">
       <caption> [% 'Mandator' | $T8 %] </caption>
       <tbody>
@@ -53,6 +53,6 @@
         </tr>
       </tbody>
     </table>
-    [% END %] 
+    [% END %]
   </div>
 </div>

--- a/templates/design40_webpages/liquidity_projection/_filter.html
+++ b/templates/design40_webpages/liquidity_projection/_filter.html
@@ -1,6 +1,6 @@
 [% USE LxERP %]
 [% USE L %]
-[% USE T8 %]  
+[% USE T8 %]
 <div class="wrapper">
 
 <form method="post" action="controller.pl" id="filter_form">
@@ -13,7 +13,7 @@
     </tr>
     <tr>
       <th>[% LxERP.t8("Break down by") %]</th>
-      <td> 
+      <td>
         [% L.checkbox_tag("params.type",           value=1, checked=FORM.params.type,           label=LxERP.t8("Basis of calculation")) %] <br>
         [% L.checkbox_tag("params.salesman",       value=1, checked=FORM.params.salesman,       label=LxERP.t8("Salesman")) %] <br>
         [% L.checkbox_tag("params.buchungsgruppe", value=1, checked=FORM.params.buchungsgruppe, label=LxERP.t8("Booking group")) %]<br>
@@ -25,4 +25,3 @@
 </form>
 
 </div><!-- /.wrapper -->
-

--- a/templates/design40_webpages/payment_term/form.html
+++ b/templates/design40_webpages/payment_term/form.html
@@ -25,26 +25,26 @@
     </tr>
     <tr>
       <td> [%- 'Skonto Terms' | $T8 %] </td>
-      <td> 
+      <td>
       <input type="text" name="payment_term.terms_skonto_as_number" value="[%- HTML.escape(SELF.payment_term.terms_skonto_as_number) %]" size="6">
       </td>
     </tr>
     <tr>
       <td> [%- 'Skonto' | $T8 %] </td>
-      <td> 
+      <td>
       <input type="text" name="payment_term.percent_skonto_as_percent" value="[%- HTML.escape(SELF.payment_term.percent_skonto_as_percent) %]" size="6">
       % </td>
     </tr>
-    [% IF SELF.payment_term.id %] 
+    [% IF SELF.payment_term.id %]
     <tr>
       <td> [% 'Obsolete' | $T8 %] </td>
       <td> [% L.checkbox_tag('payment_term.obsolete', checked = SELF.payment_term.obsolete, for_submit=1) %] </td>
     </tr>
-    [% END %] 
+    [% END %]
   </tbody>
 </table>
 
-   
+
 <table class="tbl-horizontal">
   <caption> [%- 'Long Description' | $T8 %] </caption>
   <tbody>
@@ -56,25 +56,25 @@
       <th> [% LxERP.t8("Texts for invoices") %] </th>
       <td> [% P.input_tag("payment_term.description_long_invoice", SELF.payment_term.description_long_invoice, size="60", "data-validate"="required", "data-title"=LxERP.t8("Long Description for invoices")) %] </td>
     </tr>
-    [%- FOREACH language = SELF.languages %] 
+    [%- FOREACH language = SELF.languages %]
     <tr><th class="caption" colspan="2">[%- HTML.escape(language.description) %] ([%- LxERP.t8('Translation') %])</th></tr>
     <tr>
       <th> [% LxERP.t8("Texts for quotations & orders") %] </th>
-      <td> 
+      <td>
       <input type="text" name="translation_[% language.id %]" value="[%- HTML.escape(SELF.payment_term.translated_attribute('description_long', language, 1)) %]" size="60">
       </td>
       </tr>
       <tr>
       <th> [% LxERP.t8("Texts for invoices") %] </th>
-      <td> 
+      <td>
       <input type="text" name="translation_invoice_[% language.id %]" value="[%- HTML.escape(SELF.payment_term.translated_attribute('description_long_invoice', language, 1)) %]" size="60">
       </td>
     </tr>
-    [%- END %] 
+    [%- END %]
   </tbody>
 </table>
-[% P.hidden_tag("id", SELF.payment_term.id) %] 
-    
+[% P.hidden_tag("id", SELF.payment_term.id) %]
+
 </div>
 
 
@@ -83,7 +83,7 @@
 <div class="instructions">
 <p>[% LxERP.t8("You can use the following strings in the long description and all translations. They will be replaced by their actual values by kivitendo before they're output.") %]</p>
 <p>[% LxERP.t8("As of version 3.7 most of the variables are also availabe as a print variable.") %]</p>
-    
+
 
 <table class="tbl-list-plain">
   <thead>
@@ -164,7 +164,7 @@
   </tbody>
 </table>
 
-    
+
 </div>
 
 </form>

--- a/templates/design40_webpages/payment_term/list.html
+++ b/templates/design40_webpages/payment_term/list.html
@@ -7,20 +7,20 @@
   </p>
 
 [%- ELSE %]
- 
+
 <div class="wrapper">
 <table id="payment_term_list" class="tbl-list wi-moderate">
-  <colgroup> 
-    <col class="wi-smallest"> 
-    <col class="wi-wide"> 
-    <col class="wi-wide"> 
-    <col class="wi-wide"> 
-    <col class="wi-small"> 
-    <col class="wi-small"> 
-    <col class="wi-small"> 
-    <col class="wi-verysmall"> 
-    <col class="wi-verysmall"> 
-  </colgroup> 
+  <colgroup>
+    <col class="wi-smallest">
+    <col class="wi-wide">
+    <col class="wi-wide">
+    <col class="wi-wide">
+    <col class="wi-small">
+    <col class="wi-small">
+    <col class="wi-small">
+    <col class="wi-verysmall">
+    <col class="wi-verysmall">
+  </colgroup>
   <thead>
     <tr>
       <th> <img src="image/updown.png" alt="[%- LxERP.t8('reorder item') %]"> </th>
@@ -35,7 +35,7 @@
     </tr>
   </thead>
   <tbody>
-    [%- FOREACH payment_term = PAYMENT_TERMS %] 
+    [%- FOREACH payment_term = PAYMENT_TERMS %]
     <tr id="payment_term_id_[% payment_term.id %]">
       <td class="dragdrop"> <img src="image/updown.png" alt="[%- LxERP.t8('reorder item') %]"> </td>
       <td> <a href="[% SELF.url_for(action => 'edit', id => payment_term.id) %]"> [%- HTML.escape(payment_term.description) %] </a> </td>
@@ -47,7 +47,7 @@
       <td class="center"> [%- HTML.escape(payment_term.percent_skonto_as_percent) %] % </td>
       <td class="center"> [%- HTML.escape(payment_term.obsolete) %] </td>
     </tr>
-    [%- END %] 
+    [%- END %]
   </tbody>
 </table>
 </div>

--- a/templates/design40_webpages/report_generator/csv_export_options.html
+++ b/templates/design40_webpages/report_generator/csv_export_options.html
@@ -16,7 +16,7 @@
   <tbody>
     <tr>
       <th>[% 'Quote chararacter' | $T8 %]</th>
-      <td> 
+      <td>
         <select name="report_generator_csv_options_quote_char" style="width: 300px">
           <option value="&quot;" selected>&quot;</option>
           <option value="'">'</option>
@@ -25,7 +25,7 @@
     </tr>
     <tr>
       <th>[% 'Escape character' | $T8 %]</th>
-      <td> 
+      <td>
         <select name="report_generator_csv_options_escape_char" style="width: 300px">
           <option value="QUOTE_CHAR" selected>[% 'Same as the quote character' | $T8 %]</option>
           <option value="&quot;">&quot;</option>
@@ -35,7 +35,7 @@
     </tr>
     <tr>
       <th>[% 'Separator chararacter' | $T8 %]</th>
-      <td> 
+      <td>
         <select name="report_generator_csv_options_sep_char" style="width: 300px">
           <option value=";">;</option>
           <option value="," selected>,</option>
@@ -46,7 +46,7 @@
     </tr>
     <tr>
       <th>[% 'Line endings' | $T8 %]</th>
-      <td> 
+      <td>
         <select name="report_generator_csv_options_eol_style" style="width: 300px">
           <option value="DOS">DOS/Windows (CR/LF)</option>
           <option value="Unix" selected>Unix (LF)</option>

--- a/templates/design40_webpages/requirement_spec/_form.html
+++ b/templates/design40_webpages/requirement_spec/_form.html
@@ -1,7 +1,7 @@
 [% USE LxERP %]
 [% USE L %]
 [% USE HTML %]
-[% 
+[%
   DEFAULT id_prefix = 'basic_settings_form'
           submit_as = 'post'
 %]
@@ -29,9 +29,9 @@
       </tr>
       <tr>
         <th>[% LxERP.t8("Customer") %]</th>
-        <td>[% 
+        <td>[%
             L.select_tag("requirement_spec.customer_id",  SELF.customers, default=SELF.requirement_spec.customer_id, title_key="name", id=id_prefix _ '_customer_id',
-              onchange="kivi.requirement_spec.basic_settings_customer_changed('#" _ id_prefix _ "_customer_id', '#" _ id_prefix _ "_hourly_rate_as_number')") 
+              onchange="kivi.requirement_spec.basic_settings_customer_changed('#" _ id_prefix _ "_customer_id', '#" _ id_prefix _ "_hourly_rate_as_number')")
         %]</td>
       </tr>
       <tr>

--- a/templates/design40_webpages/requirement_spec/_new_project_form.html
+++ b/templates/design40_webpages/requirement_spec/_new_project_form.html
@@ -1,7 +1,7 @@
 [% USE LxERP %]
 [% USE L %]
 [% SET id_prefix = "project_link_form" %]
-[% style = "width:300px;" %] 
+[% style = "width:300px;" %]
 
 <form method="post" action="controller.pl" id="[% id_prefix %]"[% UNLESS submit_as == 'post' %] class="edit-project-link-context-menu"[% END %]>
 

--- a/templates/design40_webpages/requirement_spec/show.html
+++ b/templates/design40_webpages/requirement_spec/show.html
@@ -11,16 +11,16 @@
 [% L.hidden_tag('requirement_spec_id', SELF.requirement_spec.id, 'data-is-template'=(SELF.requirement_spec.is_template ? 1 : 0)) %]
 
 <div id="requirement_spec_tabs" class="tabwidget">
- 
+
 <ul>
   <li id="tab-header-function-block"><a href="#function-blocks-tab">[% LxERP.t8("Content") %]</a></li>
   <li id="tab-header-basic-settings"><a href="controller.pl?action=RequirementSpec/ajax_show_basic_settings&id=[% HTML.url(SELF.requirement_spec.id) %]">[% LxERP.t8("Basic settings") %]</a></li>
   <li id="tab-header-time-cost-estimate"><a href="controller.pl?action=RequirementSpec/ajax_show_time_and_cost_estimate&id=[% HTML.url(SELF.requirement_spec.id) %]">[% LxERP.t8("Time and price estimate") %]</a></li>
   <li id="tab-header-additional-parts"><a href="controller.pl?action=RequirementSpecPart/show&requirement_spec_id=[% HTML.url(SELF.requirement_spec.id) %]">[% LxERP.t8("Additional articles") %]</a></li>
-  [% UNLESS SELF.requirement_spec.is_template %] 
+  [% UNLESS SELF.requirement_spec.is_template %]
     <li id="tab-header-versions"><a href="controller.pl?action=RequirementSpecVersion/list&requirement_spec_id=[% HTML.url(SELF.requirement_spec.id) %]">[% LxERP.t8("Versions") %]</a></li>
     <li id="tab-header-quotations-orders"><a href="[% SELF.url_for(controller='RequirementSpecOrder', action='list', requirement_spec_id=SELF.requirement_spec.id) %]">[% LxERP.t8("Quotations and orders") %]</a></li>
-  [% END %] 
+  [% END %]
 </ul>
 
 <div id="function-blocks-tab" class="section-context-menu">

--- a/templates/design40_webpages/shop_order/_transfer_status.html
+++ b/templates/design40_webpages/shop_order/_transfer_status.html
@@ -24,12 +24,12 @@
       <th>[% LxERP.t8("Current status:") %]</th>
       <td>
         [% IF !data.status %]
-          [% LxERP.t8("waiting for job to be started") %] 
-        [% ELSIF data.status == 1 %] 
+          [% LxERP.t8("waiting for job to be started") %]
+        [% ELSIF data.status == 1 %]
           [% LxERP.t8("Converting to deliveryorder") %]
-        [% ELSE %] 
-          [% LxERP.t8("Done.") %] 
-        [% END %] 
+        [% ELSE %]
+          [% LxERP.t8("Done.") %]
+        [% END %]
       </td>
     </tr>
     <tr>

--- a/templates/design40_webpages/shop_order/list.html
+++ b/templates/design40_webpages/shop_order/list.html
@@ -74,10 +74,10 @@
 <form method="post" action="controller.pl" name="shop_orders_list" id="shoporderslist"><!-- PENDENT: FORM nicht erlaubt hier -->
   <tbody>
   [% FOREACH shop_order = SHOPORDERS %]
-    [% IF shop_order.kivi_customer.id && shop_order.kivi_customer.order_lock == 0 && shop_order.open_invoices == 0 %] 
-      [% SET transferable = 1 %] [% SET transferable_class = 'class="shop_transferable"' %] 
-    [% ELSE %] 
-      [% SET transferable = 0 %] 
+    [% IF shop_order.kivi_customer.id && shop_order.kivi_customer.order_lock == 0 && shop_order.open_invoices == 0 %]
+      [% SET transferable = 1 %] [% SET transferable_class = 'class="shop_transferable"' %]
+    [% ELSE %]
+      [% SET transferable = 0 %]
       [% SET transferable_class = '' %]
     [% END %]
   <tr>
@@ -101,9 +101,9 @@
       <br>[% HTML.escape(shop_order.billing_email) %]
       <br>[% IF shop_order.open_invoices > 0 || shop_order.customer.order_lock == 1 %][% SET alertclass = 'class="shop_alert"' %][% ELSE %][% SET alertclass = '' %][% END %]<span [% alertclass %]>&nbsp;&nbsp;[% 'Customernumber' | $T8 %] [% HTML.escape(shop_order.kivi_customer.customernumber) %] -- [% 'Invoices' | $T8 %] [% shop_order.open_invoices %]&nbsp;&nbsp;</span>
     </td>
-    [% IF (shop_order.delivery_lastname != shop_order.billing_lastname || shop_order.delivery_firstname != shop_order.billing_firstname || shop_order.delivery_street != shop_order.billing_street || shop_order.delivery_city != shop_order.billing_city) %] 
+    [% IF (shop_order.delivery_lastname != shop_order.billing_lastname || shop_order.delivery_firstname != shop_order.billing_firstname || shop_order.delivery_street != shop_order.billing_street || shop_order.delivery_city != shop_order.billing_city) %]
       [% SET deliveryclass = 'class="shop_delivery"' %]
-    [% ELSE %] 
+    [% ELSE %]
       [% SET deliveryclass = '' %]
     [% END %]
     <td [% deliveryclass %]>

--- a/templates/design40_webpages/shop_part/_filter.html
+++ b/templates/design40_webpages/shop_part/_filter.html
@@ -21,7 +21,7 @@
     </tr>
   </tbody>
 </table>
- 
+
 <div class="buttons">
   <a href='#' onclick='javascript:$("#filter_table input").val("");$("#filter_table input[type=checkbox]").prop("checked", 0);' class="button neutral">[% 'Reset' | $T8 %]</a>
   [% L.hidden_tag('action', 'ShopPart/dispatch') %]

--- a/templates/design40_webpages/ustva/config_step1.html
+++ b/templates/design40_webpages/ustva/config_step1.html
@@ -16,12 +16,12 @@
     [% method_local %]
   [% END %]
 </fieldset>
-       
+
 <fieldset>
   <legend><b>[% 'Tax Period' | $T8 %]</b></legend>
-  <input name="fa_voranmeld" id="month" type="radio" value="month" [% checked_monthly %]> 
+  <input name="fa_voranmeld" id="month" type="radio" value="month" [% checked_monthly %]>
     <label for="month">[% 'month' | $T8 %]</label> <br>
-  <input name="fa_voranmeld" id="quarter" type="radio" value="quarter" [% checked_quarterly %]> 
+  <input name="fa_voranmeld" id="quarter" type="radio" value="quarter" [% checked_quarterly %]>
     <label for="quarter">[% 'quarter' | $T8 %]</label><br>
   <input name="fa_dauerfrist" id="fa_dauerfrist" type="checkbox" value="1" [% checked_dauerfristverlaengerung %]>
     <label for="">[% 'Extension Of Time' | $T8 %]</label>
@@ -45,7 +45,7 @@
         <td><input type="text" name="fa_steuerberater_name" id="steuerberater" size="25" value="[% HTML.escape(fa_steuerberater_name) %]"></td>
         <td><input type="text" name="fa_steuerberater_street" id="steuerberater" size="25" value="[% HTML.escape(fa_steuerberater_street) %]"></td>
         <td><input type="text" name="fa_steuerberater_city" id="steuerberater" size="25" value="[% HTML.escape(fa_steuerberater_city) %]"></td>
-        <td><input type="text" name="fa_steuerberater_tel" id="steuerberater" size="25" value="[% HTML.escape(fa_steuerberater_tel) %]"> 
+        <td><input type="text" name="fa_steuerberater_tel" id="steuerberater" size="25" value="[% HTML.escape(fa_steuerberater_tel) %]">
       </tr>
     </tbody>
   </table>

--- a/templates/design40_webpages/yearend/_charts.html
+++ b/templates/design40_webpages/yearend/_charts.html
@@ -51,7 +51,7 @@
 <h2>[% 'Profit and loss accounts' | $T8 %]</h2>
 
 <p>
-[% IF profit_loss_sum < 0 %] [% THEN %][% 'Loss' | $T8 %] [% ELSE %] [% 'Profit' | $T8 %] [% END %]:   
+[% IF profit_loss_sum < 0 %] [% THEN %][% 'Loss' | $T8 %] [% ELSE %] [% 'Profit' | $T8 %] [% END %]:
 [% LxERP.format_amount(profit_loss_sum, dec) %]
 </p>
 

--- a/templates/design40_webpages/yearend/form.html
+++ b/templates/design40_webpages/yearend/form.html
@@ -97,14 +97,14 @@ $(function(){
     get_startdate();
     setTimeout(function() {
       refresh_charts();
-    }, 200);    
+    }, 200);
   });
 
   $('#cb_date').change(function(){
     get_startdate();
     setTimeout(function() {
       refresh_charts();
-    }, 200);    
+    }, 200);
   });
 })
 


### PR DESCRIPTION
Leerzeichen am Ende aus einigen Dateien entfernt.
Mein Editor ist so eingestellt, dass er diese autom. entfernt (das sollten eigentlich alle mal machen ;) ) und dann gibt es bei klienen Änderungen große Diffs.

Siehe auch "Stil-Richtlinien" in der Doku/Entwicklerdoku: "Trailing Whitespace, d.h. Leerzeichen am Ende von Zeilen sind unerwünscht. Sie führen zu unnötigen Whitespaceänderungen, die diffs verfälschen."