### PR TITLE
ZUGFeRD-Import: MIME-Type der Datei im DMS korrekt setzen

### DIFF
--- a/bin/mozilla/ap.pl
+++ b/bin/mozilla/ap.pl
@@ -1022,11 +1022,15 @@ sub post {
           };
         }
         if ($form->{id} && $::instance_conf->get_doc_storage) {
+          my $file_content = do { local $/; my $fh = $file->fh; <$fh> };
+          my $mime_type    = ($file_content =~ m/^%PDF/)   ? 'application/pdf'
+                           : ($file_content =~ m/^<\?xml/) ? 'application/xml'
+                           : undef;
           eval {
             SL::File->save(
               object_id     => $form->{id},
               object_type   => 'purchase_invoice',
-              mime_type     => 'application/pdf',
+              mime_type     => $mime_type,
               source        => 'uploaded',
               file_type     => 'document',
               file_name     => $file_name,


### PR DESCRIPTION
Wichtig, damit bei SEPA-Überweisungen »Download hinterlegte PDFs zum aktuellen SEPA-Lauf« keinen Ghostscript-Fehler wirft, wenn ein XML mit MIME-Type »application/pdf« geladen wird. Dies trat auf, wenn XML-Dateien von Factur-X Rechnungen importiert wurden.

Reichelt Elektronik schickt mit immer ein XML mit Factur-X und ein PDF ohne eingebettetes XML zusammen in einer Mail. Das ist ok. Wenn ich dann das XML in kivi über den Menüpunkt Finanzbuchhaltung → Factur-X/ZUGFeRD-Import anstoße, wird im Hintergrund das XML mit Mime-Type application/pdf ins DMS abgelegt, so dass folgende Ghostscript-Aufrufe mit der Datei fehlschlagen. `GPL Ghostscript 10.05.1: Unrecoverable error, exit code 1`

Was hier nicht geschieht: Korrektur der bisher hochgeladen Dateien in der DB. Ich habe das erledigt mit:
`
update files set mime_type = 'application/xml' where file_name ILIKE '%.xml';
`