### PR TITLE
Lager Speichern erlauben, ohne neue Lagerplätze anlegen zu müssen

### DIFF
--- a/SL/AM.pm
+++ b/SL/AM.pm
@@ -1205,8 +1205,6 @@ sub save_warehouse {
 
   my ($self, $myconfig, $form) = @_;
 
-  croak('Need at least one new bin') unless $form->{number_of_new_bins} > 0;
-
   SL::DB->client->with_transaction(sub {
     my $dbh = SL::DB->client->dbh;
 

--- a/bin/mozilla/am.pl
+++ b/bin/mozilla/am.pl
@@ -1343,7 +1343,6 @@ sub save_warehouse {
   $main::auth->assert('config');
 
   $form->isblank("description", $locale->text('Description missing!'));
-  $form->isblank("number_of_new_bins", $locale->text('Number')  . $locale->text(' missing!'));
 
   $form->{number_of_new_bins} = $form->parse_amount(\%myconfig, $form->{number_of_new_bins});
 

--- a/locale/de/all
+++ b/locale/de/all
@@ -13,7 +13,6 @@ $self->{texts} = {
   ' Date missing!'              => ' Datum fehlt!',
   ' bytes, max='                => ' Bytes, Maximum=',
   ' have been set to the state \'paid\'' => ' haben jetzt den Status \'bezahlt\'',
-  ' missing!'                   => ' fehlt!',
   ' would be set to the state \'paid\'' => ' würden den Status \'bezahlt\' haben',
   '"#1" seems to be a faulty list of email addresses. After extracing addresses (#2) too many characters are left.' => '"#1" scheint fehlerhaft zu sein. Es wurden E-Mail Adressen extrahiert (#2), aber es sind noch zu viele Zeichen übrig.',
   '"#1" seems to be a faulty list of email addresses. No addresses could be extracted.' => '"#1" scheint fehlerhaft zu sein. Es konnte keine E-Mail Adresse extrahiert werden',

--- a/locale/en/all
+++ b/locale/en/all
@@ -13,7 +13,6 @@ $self->{texts} = {
   ' Date missing!'              => '',
   ' bytes, max='                => '',
   ' have been set to the state \'paid\'' => '',
-  ' missing!'                   => '',
   ' would be set to the state \'paid\'' => '',
   '"#1" seems to be a faulty list of email addresses. After extracing addresses (#2) too many characters are left.' => '',
   '"#1" seems to be a faulty list of email addresses. No addresses could be extracted.' => '',


### PR DESCRIPTION
Dies ist nötig, um bspw. die Beschreibung eines Lagers ändern zu können.

Die hierin entfernte Prüfung auf Anzahl neuer Lagerplätze > 0 war einfach unsinnig. Der Code zum Anlegen neuer Lagerplätze prüft sogar, ob die Zahl > 0 ist und ist andernfalls nicht aktiv.

Also weg damit!


Getestet habe ich:
- neues Lager anlegen mit 0 Lagerplätzen klappt
- existierendes Lager umbenennen mit 0 zusätzlichen Lagerplätzen klappt
- existierendes Lager mit 2 zusätzlichen Lagerplätzen versehen klappt